### PR TITLE
use fxhashmap in runtime for better perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.75",
  "which",
@@ -998,6 +998,7 @@ dependencies = [
  "mlir-sys",
  "num-bigint",
  "ripemd",
+ "rustc-hash 2.0.0",
  "secp256k1",
  "sha2",
  "sha3",
@@ -2302,6 +2303,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc-hex"

--- a/crates/dora-runtime/Cargo.toml
+++ b/crates/dora-runtime/Cargo.toml
@@ -17,3 +17,4 @@ mlir-sys = "0.2.2"
 melior = {version = "0.18.6", features = [
     "ods-dialects",
 ]}
+rustc-hash = { version = "2.0"}

--- a/crates/dora-runtime/src/journal.rs
+++ b/crates/dora-runtime/src/journal.rs
@@ -3,6 +3,7 @@ use dora_primitives::{
     db::{Database, MemoryDb, StorageSlot},
     Bytecode, EVMAddress as Address, B256, U256,
 };
+use rustc_hash::FxHashMap;
 use sha3::{Digest, Keccak256};
 use std::collections::{hash_map::Entry, HashMap};
 use std::str::FromStr;
@@ -64,7 +65,7 @@ impl From<U256> for JournalStorageSlot {
 pub struct JournalAccount {
     pub nonce: u64,
     pub balance: U256,
-    pub storage: HashMap<U256, JournalStorageSlot>,
+    pub storage: FxHashMap<U256, JournalStorageSlot>,
     pub bytecode_hash: B256,
     pub status: AccountStatus,
 }
@@ -107,7 +108,7 @@ impl JournalAccount {
         Self {
             nonce: 0,
             balance,
-            storage: Default::default(),
+            storage: FxHashMap::default(),
             bytecode_hash: B256::from_str(EMPTY_CODE_HASH_STR).unwrap_or_default(),
             status: AccountStatus::Created,
         }
@@ -128,7 +129,7 @@ impl From<AccountInfo> for JournalAccount {
         Self {
             nonce: info.nonce,
             balance: info.balance,
-            storage: Default::default(),
+            storage: FxHashMap::default(),
             bytecode_hash: info.code_hash,
             status: AccountStatus::Cold,
         }


### PR DESCRIPTION
Use FxHashMap instead of standard library’s HashMap as internal storage slots associated with the account. 