### PR TITLE
refactor: evm run api with runtime context

### DIFF
--- a/crates/dora-compiler/src/dora/instructions/contract.rs
+++ b/crates/dora-compiler/src/dora/instructions/contract.rs
@@ -144,6 +144,9 @@ impl<'c> ConversionPass<'c> {
                 location
             ))?,
         };
+
+        // TODO: If the context is static, the transfer value must be zero for CALL and CALLCODE opcodes.
+
         let (args_offset, args_size, ret_offset, ret_size) = (
             op.operand(o_index)?,
             op.operand(o_index + 1)?,

--- a/crates/dora-runtime/src/symbols.rs
+++ b/crates/dora-runtime/src/symbols.rs
@@ -1,5 +1,7 @@
 // Debug functions
 pub const DEBUG_PRINT: &str = "dora_debug_print";
+// Global variables
+pub const CTX_IS_STATIC: &str = "dora_ctx_is_static";
 // System functions
 pub const WRITE_RESULT: &str = "dora_write_result";
 pub const EXTEND_MEMORY: &str = "dora_extend_memory";

--- a/crates/dora-tools/bins/ethertest/main.rs
+++ b/crates/dora-tools/bins/ethertest/main.rs
@@ -218,7 +218,7 @@ fn execute_test(path: &Path) -> Result<(), TestError> {
         kind: e.into(),
     })?;
 
-    for (suite_name, suite) in suite.0 {
+    for (_, suite) in suite.0 {
         // NOTE: currently we only support Cancun spec
         let Some(tests) = suite.post.get(&SpecName::Cancun) else {
             continue;
@@ -240,7 +240,7 @@ fn execute_test(path: &Path) -> Result<(), TestError> {
                 .unwrap()
                 .clone()
                 .0;
-            info!("testing {:?} suite {:?}", name, suite_name);
+            info!("testing {:?} index {:?}", name, test_case.indexes);
             // Mapping access list
             let access_list = suite
                 .transaction

--- a/crates/dora/src/lib.rs
+++ b/crates/dora/src/lib.rs
@@ -24,6 +24,118 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+/// Run the EVM environment with the given state database and return the execution result and final state.
+///
+/// # Arguments
+///
+/// * `env` - The environment configuration for the execution (e.g., gas limit, transaction data, etc.).
+/// * `db` - A mutable reference to the `MemoryDb` that simulates the contract storage and state database.
+///
+/// # Returns
+///
+/// Returns `ResultAndState`, containing the execution result and the final state after execution.
+///
+/// # Errors
+///
+/// Returns an error if the program fails to execute or if the bytecode or address is invalid.
+pub fn run_evm(env: Env, db: MemoryDb) -> Result<ResultAndState> {
+    let mut runtime_context = RuntimeContext::new(
+        Journal::new(db),
+        CallFrame::new(env.tx.caller),
+        Arc::new(EVMTransaction),
+        Arc::new(RwLock::new(DummyHost::new(env))),
+    );
+    run_with_context(&mut runtime_context)
+}
+
+/// Run transaction with the runtime context.
+fn run_with_context(runtime_context: &mut RuntimeContext) -> Result<ResultAndState> {
+    let host = runtime_context.host.read().unwrap();
+    let code_address = host.env().tx.get_address();
+    let mut remaining_gas = host.env().tx.gas_limit;
+    if code_address.is_zero() {
+        let value = host.env().tx.value;
+        let data = host.env().tx.data.clone();
+        drop(host);
+        runtime_context.create_contract(&data, &mut remaining_gas, value, None)?;
+    } else {
+        drop(host);
+        let opcodes = runtime_context.journal.db.code_by_address(code_address)?;
+        let program = Program::from_opcode(&opcodes);
+        let context = Context::new();
+        let compiler = EVMCompiler::new(&context);
+        let mut module = compiler.compile(&program, &())?;
+        // Lowering the EVM dialect to MLIR builtin dialects.
+        evm::pass::run(&context.mlir_context, &mut module.mlir_module)?;
+        dora::pass::run(
+            &context.mlir_context,
+            &mut module.mlir_module,
+            &dora::pass::PassOptions {
+                program_code_size: program.code_size,
+            },
+        )?;
+        pass::run(&context.mlir_context, &mut module.mlir_module)?;
+        debug_assert!(module.mlir_module.as_operation().verify());
+        let executor = Executor::new(module.module(), runtime_context, Default::default());
+        executor.execute(runtime_context, remaining_gas);
+    }
+    runtime_context.get_result().map_err(|e| anyhow::anyhow!(e))
+}
+
+/// A specific implementation of the `Transaction` trait for executing EVM (Ethereum Virtual Machine) transactions.
+///
+/// `EVMTransaction` uses `RuntimeContext` for its execution context and returns a `Result` containing
+/// `ResultAndState` after execution. This struct is designed to handle Ethereum-style transaction processing
+/// by setting the initial gas limit and cloning the database state before running the EVM.
+///
+/// # Example
+/// ```no_check
+/// use dora_primitives::transaction::Transaction;
+/// use dora_runtime::context::RuntimeContext;
+/// use dora::EVMTransaction;
+///
+/// let mut ctx = RuntimeContext::new();
+/// let evm_tx = EVMTransaction::default();
+/// let result = evm_tx.run(&mut ctx, 21_000);
+/// ```
+#[derive(Debug, Default)]
+pub struct EVMTransaction;
+
+impl Transaction for EVMTransaction {
+    type Context = RuntimeContext;
+    type Result = Result<ResultAndState>;
+
+    #[inline]
+    fn run(&self, ctx: &mut Self::Context, _initial_gas: u64) -> Self::Result {
+        run_with_context(ctx)
+    }
+}
+
+/// Run hex-encoded EVM bytecode with custom calldata and return the execution result and final state.
+///
+/// # Arguments
+///
+/// * `program` - A string representing the hex-encoded EVM bytecode.
+/// * `calldata` - A byte slice containing the custom calldata to use for the execution.
+/// * `initial_gas` - The initial amount of gas allocated for the execution.
+///
+/// # Returns
+///
+/// Returns `ResultAndState`, containing the execution result and the final state after execution.
+///
+/// # Errors
+///
+/// Returns an error if the bytecode fails to decode or execute.
+pub fn run_evm_bytecode_with_calldata(
+    program: &str,
+    calldata: &[u8],
+    initial_gas: u64,
+) -> Result<ResultAndState> {
+    let opcodes = hex::decode(program)?;
+    let program = Program::from_opcode(&opcodes);
+    run_evm_program(&program, calldata, initial_gas)
+}
+
 /// Run EVM bytecode from a hex-encoded string and return the execution result and final state.
 ///
 /// # Arguments
@@ -98,124 +210,4 @@ pub fn run_evm_program(
     let executor = Executor::new(module.module(), &context, Default::default());
     black_box(executor.execute(black_box(&mut context), black_box(initial_gas)));
     context.get_result().map_err(|e| anyhow::anyhow!(e))
-}
-
-/// Run the EVM environment with the given state database and return the execution result and final state.
-///
-/// # Arguments
-///
-/// * `env` - The environment configuration for the execution (e.g., gas limit, transaction data, etc.).
-/// * `db` - A mutable reference to the `MemoryDb` that simulates the contract storage and state database.
-///
-/// # Returns
-///
-/// Returns `ResultAndState`, containing the execution result and the final state after execution.
-///
-/// # Errors
-///
-/// Returns an error if the program fails to execute or if the bytecode or address is invalid.
-pub fn run_evm(env: Env, db: MemoryDb) -> Result<ResultAndState> {
-    let code_address = env.tx.get_address();
-    let mut remaining_gas = env.tx.gas_limit;
-    // Create contracts or emit transactions
-    let runtime_context = if code_address.is_zero() {
-        let value = env.tx.value;
-        let data = env.tx.data.clone();
-        let mut runtime_context = RuntimeContext::new(
-            Journal::new(db),
-            CallFrame::new(env.tx.caller),
-            Arc::new(EVMTransaction),
-            Arc::new(RwLock::new(DummyHost::new(env))),
-        );
-        if runtime_context
-            .create_contract(&data, &mut remaining_gas, value, None)
-            .is_none()
-        {
-            return Err(anyhow::anyhow!("create contract error"));
-        }
-        runtime_context
-    } else {
-        let opcodes = db.code_by_address(code_address)?;
-        let program = Program::from_opcode(&opcodes);
-        let context = Context::new();
-        let compiler = EVMCompiler::new(&context);
-        let mut module = compiler.compile(&program, &())?;
-        // Lowering the EVM dialect to MLIR builtin dialects.
-        evm::pass::run(&context.mlir_context, &mut module.mlir_module)?;
-        dora::pass::run(
-            &context.mlir_context,
-            &mut module.mlir_module,
-            &dora::pass::PassOptions {
-                program_code_size: program.code_size,
-            },
-        )?;
-        pass::run(&context.mlir_context, &mut module.mlir_module)?;
-        debug_assert!(module.mlir_module.as_operation().verify());
-        let mut runtime_context = RuntimeContext::new(
-            Journal::new(db),
-            CallFrame::new(env.tx.caller),
-            Arc::new(EVMTransaction),
-            Arc::new(RwLock::new(DummyHost::new(env))),
-        );
-        let executor = Executor::new(module.module(), &runtime_context, Default::default());
-        black_box(executor.execute(black_box(&mut runtime_context), black_box(remaining_gas)));
-        runtime_context
-    };
-    runtime_context.get_result().map_err(|e| anyhow::anyhow!(e))
-}
-
-/// A specific implementation of the `Transaction` trait for executing EVM (Ethereum Virtual Machine) transactions.
-///
-/// `EVMTransaction` uses `RuntimeContext` for its execution context and returns a `Result` containing
-/// `ResultAndState` after execution. This struct is designed to handle Ethereum-style transaction processing
-/// by setting the initial gas limit and cloning the database state before running the EVM.
-///
-/// # Example
-/// ```no_check
-/// use dora_primitives::transaction::Transaction;
-/// use dora_runtime::context::RuntimeContext;
-/// use dora::EVMTransaction;
-///
-/// let mut ctx = RuntimeContext::new();
-/// let evm_tx = EVMTransaction::default();
-/// let result = evm_tx.run(&mut ctx, 21_000);
-/// ```
-#[derive(Debug, Default)]
-pub struct EVMTransaction;
-
-impl Transaction for EVMTransaction {
-    type Context = RuntimeContext;
-    type Result = Result<ResultAndState>;
-
-    fn run(&self, ctx: &mut Self::Context, initial_gas: u64) -> Self::Result {
-        let mut env = ctx.host.read().unwrap().env().clone();
-        env.tx.gas_limit = initial_gas;
-        let db = ctx.journal.cloned_db();
-        run_evm(env, db)
-    }
-}
-
-/// Run hex-encoded EVM bytecode with custom calldata and return the execution result and final state.
-///
-/// # Arguments
-///
-/// * `program` - A string representing the hex-encoded EVM bytecode.
-/// * `calldata` - A byte slice containing the custom calldata to use for the execution.
-/// * `initial_gas` - The initial amount of gas allocated for the execution.
-///
-/// # Returns
-///
-/// Returns `ResultAndState`, containing the execution result and the final state after execution.
-///
-/// # Errors
-///
-/// Returns an error if the bytecode fails to decode or execute.
-pub fn run_evm_bytecode_with_calldata(
-    program: &str,
-    calldata: &[u8],
-    initial_gas: u64,
-) -> Result<ResultAndState> {
-    let opcodes = hex::decode(program)?;
-    let program = Program::from_opcode(&opcodes);
-    run_evm_program(&program, calldata, initial_gas)
 }

--- a/crates/dora/src/tests/operations.rs
+++ b/crates/dora/src/tests/operations.rs
@@ -2663,7 +2663,7 @@ fn create_2() {
         Operation::Return,
     ];
     let (env, db) = default_env_and_db_setup(operations);
-    run_program_assert_halt(env, db);
+    run_program_assert_num_result(env, db, 0_u8.into());
 }
 
 #[test]
@@ -2758,7 +2758,7 @@ fn create2_with_large_salt() {
         Operation::Return,
     ];
     let (env, db) = default_env_and_db_setup(operations);
-    run_program_assert_halt(env, db);
+    run_program_assert_num_result(env, db, 0_u8.into());
 }
 
 #[test]


### PR DESCRIPTION
+ refactor evm run API to prevent runtime context deep clone.
+ add call frame is_static and todo the code generation.