### PR TITLE
refactor: runtime size to u64 to prevent size overflow on the 64-bit machine

### DIFF
--- a/crates/dora-compiler/src/dora/gas.rs
+++ b/crates/dora-compiler/src/dora/gas.rs
@@ -229,7 +229,7 @@ impl<'c> GasPass<'c> {
                                                 let location = rewriter.get_insert_location();
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let dynamic_gas_cost =
@@ -255,13 +255,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(2)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -289,13 +289,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(2)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -339,13 +339,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(1)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(3)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -380,7 +380,7 @@ impl<'c> GasPass<'c> {
                                                 let size = op.operand(3)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let dynamic_gas_cost =
@@ -403,7 +403,7 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = rewriter.make(rewriter.iconst_32(32))?;
@@ -432,7 +432,7 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = rewriter.make(rewriter.iconst_32(32))?;
@@ -461,7 +461,7 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = rewriter.make(rewriter.iconst_32(8))?;
@@ -502,19 +502,19 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let offset = op.operand(1)?;
                                                 let offset = rewriter.make(arith::trunci(
                                                     offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(2)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 // required_size = offset + size
@@ -556,13 +556,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(1)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -597,13 +597,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(1)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -638,13 +638,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(1)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -679,13 +679,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(1)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -720,13 +720,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(0)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(1)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -761,13 +761,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(1)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(2)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -796,13 +796,13 @@ impl<'c> GasPass<'c> {
                                                 let dest_offset = op.operand(1)?;
                                                 let dest_offset = rewriter.make(arith::trunci(
                                                     dest_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let size = op.operand(2)?;
                                                 let size = rewriter.make(arith::trunci(
                                                     size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let required_size = rewriter.make(arith::addi(
@@ -834,26 +834,26 @@ impl<'c> GasPass<'c> {
                                                 let args_offset = op.operand(1)?;
                                                 let args_offset = rewriter.make(arith::trunci(
                                                     args_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let args_size = op.operand(2)?;
                                                 let args_size = rewriter.make(arith::trunci(
                                                     args_size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
 
                                                 let ret_offset = op.operand(3)?;
                                                 let ret_offset = rewriter.make(arith::trunci(
                                                     ret_offset,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let ret_size = op.operand(4)?;
                                                 let ret_size = rewriter.make(arith::trunci(
                                                     ret_size,
-                                                    rewriter.intrinsics.i32_ty,
+                                                    rewriter.intrinsics.i64_ty,
                                                     location,
                                                 ))?;
                                                 let req_arg_mem_size = rewriter.make(

--- a/crates/dora-compiler/src/dora/instructions/contract.rs
+++ b/crates/dora-compiler/src/dora/instructions/contract.rs
@@ -38,10 +38,10 @@ impl<'c> ConversionPass<'c> {
         rewrite_ctx!(context, op, rewriter, location);
 
         let uint8 = rewriter.intrinsics.i8_ty;
-        let uint32 = rewriter.intrinsics.i32_ty;
+        let uint64 = rewriter.intrinsics.i64_ty;
         let uint256 = rewriter.intrinsics.i256_ty;
-        let offset = rewriter.make(arith::trunci(offset, uint32, location))?;
-        let size = rewriter.make(arith::trunci(size, uint32, location))?;
+        let offset = rewriter.make(arith::trunci(offset, uint64, location))?;
+        let size = rewriter.make(arith::trunci(size, uint64, location))?;
 
         // required_size = offset + size
         let required_memory_size = rewriter.make(arith::addi(offset, size, location))?;
@@ -204,22 +204,22 @@ impl<'c> ConversionPass<'c> {
         let gas = rewriter.make(arith::trunci(gas, rewriter.intrinsics.i64_ty, location))?;
         let args_offset = rewriter.make(arith::trunci(
             args_offset,
-            rewriter.intrinsics.i32_ty,
+            rewriter.intrinsics.i64_ty,
             location,
         ))?;
         let args_size = rewriter.make(arith::trunci(
             args_size,
-            rewriter.intrinsics.i32_ty,
+            rewriter.intrinsics.i64_ty,
             location,
         ))?;
         let ret_offset = rewriter.make(arith::trunci(
             ret_offset,
-            rewriter.intrinsics.i32_ty,
+            rewriter.intrinsics.i64_ty,
             location,
         ))?;
         let ret_size = rewriter.make(arith::trunci(
             ret_size,
-            rewriter.intrinsics.i32_ty,
+            rewriter.intrinsics.i64_ty,
             location,
         ))?;
         let req_arg_mem_size = rewriter.make(arith::addi(args_offset, args_size, location))?;
@@ -283,8 +283,8 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let offset = rewriter.make(arith::trunci(offset, rewriter.intrinsics.i32_ty, location))?;
-        let size = rewriter.make(arith::trunci(size, rewriter.intrinsics.i32_ty, location))?;
+        let offset = rewriter.make(arith::trunci(offset, rewriter.intrinsics.i64_ty, location))?;
+        let size = rewriter.make(arith::trunci(size, rewriter.intrinsics.i64_ty, location))?;
         let required_size = rewriter.make(arith::addi(size, offset, location))?;
         let gas_counter = gas::get_gas_counter(&rewriter)?;
         memory::resize_memory(required_size, context, &rewriter, syscall_ctx, location)?;

--- a/crates/dora-compiler/src/dora/instructions/control.rs
+++ b/crates/dora-compiler/src/dora/instructions/control.rs
@@ -25,8 +25,8 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let offset = rewriter.make(arith::trunci(offset, rewriter.intrinsics.i32_ty, location))?;
-        let size = rewriter.make(arith::trunci(size, rewriter.intrinsics.i32_ty, location))?;
+        let offset = rewriter.make(arith::trunci(offset, rewriter.intrinsics.i64_ty, location))?;
+        let size = rewriter.make(arith::trunci(size, rewriter.intrinsics.i64_ty, location))?;
 
         // required_size = offset + size
         let required_memory_size = rewriter.make(arith::addi(offset, size, location))?;

--- a/crates/dora-compiler/src/dora/instructions/host.rs
+++ b/crates/dora-compiler/src/dora/instructions/host.rs
@@ -108,10 +108,10 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let uint32 = rewriter.intrinsics.i32_ty;
-        let offset = rewriter.make(arith::trunci(offset, uint32, location))?;
-        let size = rewriter.make(arith::trunci(size, uint32, location))?;
-        let dest_offset = rewriter.make(arith::trunci(dest_offset, uint32, location))?;
+        let uint64 = rewriter.intrinsics.i64_ty;
+        let offset = rewriter.make(arith::trunci(offset, uint64, location))?;
+        let size = rewriter.make(arith::trunci(size, uint64, location))?;
+        let dest_offset = rewriter.make(arith::trunci(dest_offset, uint64, location))?;
 
         let address_ptr =
             memory::allocate_u256_and_assign_value(context, &rewriter, address, location)?;
@@ -247,9 +247,9 @@ impl<'c> ConversionPass<'c> {
         operands!(op, offset, size);
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
-        let uint32 = rewriter.intrinsics.i32_ty;
-        let offset = rewriter.make(arith::trunci(offset, uint32, location))?;
-        let size = rewriter.make(arith::trunci(size, uint32, location))?;
+        let uint64 = rewriter.intrinsics.i64_ty;
+        let offset = rewriter.make(arith::trunci(offset, uint64, location))?;
+        let size = rewriter.make(arith::trunci(size, uint64, location))?;
 
         // dynamic gas computation
 

--- a/crates/dora-compiler/src/dora/instructions/system.rs
+++ b/crates/dora-compiler/src/dora/instructions/system.rs
@@ -33,9 +33,9 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let uint32 = rewriter.intrinsics.i32_ty;
-        let offset = rewriter.make(arith::trunci(offset, uint32, location))?;
-        let size = rewriter.make(arith::trunci(size, uint32, location))?;
+        let uint64 = rewriter.intrinsics.i64_ty;
+        let offset = rewriter.make(arith::trunci(offset, uint64, location))?;
+        let size = rewriter.make(arith::trunci(size, uint64, location))?;
         let required_memory_size = rewriter.make(arith::addi(offset, size, location))?;
 
         // dynamic_gas_cost = 3 * (size + 31) / 32 gas
@@ -135,16 +135,16 @@ impl<'c> ConversionPass<'c> {
 
         let uint1 = rewriter.intrinsics.i1_ty;
         let uint8 = rewriter.intrinsics.i8_ty;
-        let uint32 = rewriter.intrinsics.i32_ty;
+        let uint64 = rewriter.intrinsics.i64_ty;
         let uint256 = rewriter.intrinsics.i256_ty;
         let ptr_type = rewriter.intrinsics.ptr_ty;
 
         let calldata_ptr =
             load_by_addr!(rewriter, constants::CALLDATA_PTR_GLOBAL, rewriter.ptr_ty());
         // Define the maximum slice width (32 bytes)
-        let max_slice_width = rewriter.make(rewriter.iconst_256(BigUint::from(32_u8))?)?;
-        let calldata_size = load_by_addr!(rewriter, constants::CALLDATA_SIZE_GLOBAL, uint32);
-        // convert calldata_size from u32 to u256
+        let max_slice_width = rewriter.make(rewriter.iconst_256_from_u64(32)?)?;
+        let calldata_size = load_by_addr!(rewriter, constants::CALLDATA_SIZE_GLOBAL, uint64);
+        // convert calldata_size from u64 to u256
         let calldata_size = rewriter.make(arith::extui(calldata_size, uint256, location))?;
         // Compare offset with calldata size
         let offset_cmpi = rewriter.make(arith::cmpi(
@@ -222,13 +222,13 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let uint32 = rewriter.intrinsics.i32_ty;
+        let uint64 = rewriter.intrinsics.i64_ty;
         let uint256 = rewriter.intrinsics.i256_ty;
         let call_data_size = rewriter.make(func::call(
             context,
             FlatSymbolRefAttribute::new(context, symbols::GET_CALLDATA_SIZE),
             &[syscall_ctx.into()],
-            &[uint32],
+            &[uint64],
             location,
         ))?;
         rewriter.make(arith::extui(call_data_size, uint256, location))?;
@@ -240,10 +240,10 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let uint32 = rewriter.intrinsics.i32_ty;
-        let call_data_offset = rewriter.make(arith::trunci(call_data_offset, uint32, location))?;
-        let dest_offset = rewriter.make(arith::trunci(dest_offset, uint32, location))?;
-        let length = rewriter.make(arith::trunci(length, uint32, location))?;
+        let uint64 = rewriter.intrinsics.i64_ty;
+        let call_data_offset = rewriter.make(arith::trunci(call_data_offset, uint64, location))?;
+        let dest_offset = rewriter.make(arith::trunci(dest_offset, uint64, location))?;
+        let length = rewriter.make(arith::trunci(length, uint64, location))?;
 
         // required size = dest_offset + size
         let required_memory_size = rewriter.make(arith::addi(dest_offset, length, location))?;
@@ -283,7 +283,7 @@ impl<'c> ConversionPass<'c> {
             context,
             FlatSymbolRefAttribute::new(context, symbols::GET_CALLDATA_SIZE),
             &[syscall_ctx.into()],
-            &[uint32],
+            &[uint64],
             location,
         ))?;
         let flag = rewriter.make(arith::cmpi(
@@ -360,10 +360,10 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let uint32 = rewriter.intrinsics.i32_ty;
-        let offset = rewriter.make(arith::trunci(offset, uint32, location))?;
-        let dest_offset = rewriter.make(arith::trunci(dest_offset, uint32, location))?;
-        let length = rewriter.make(arith::trunci(length, uint32, location))?;
+        let uint64 = rewriter.intrinsics.i64_ty;
+        let offset = rewriter.make(arith::trunci(offset, uint64, location))?;
+        let dest_offset = rewriter.make(arith::trunci(dest_offset, uint64, location))?;
+        let length = rewriter.make(arith::trunci(length, uint64, location))?;
 
         // required size = dest_offset + size
         let required_memory_size = rewriter.make(arith::addi(dest_offset, length, location))?;
@@ -392,13 +392,13 @@ impl<'c> ConversionPass<'c> {
         syscall_ctx!(op, syscall_ctx);
         rewrite_ctx!(context, op, rewriter, location);
 
-        let uint32 = rewriter.intrinsics.i32_ty;
+        let uint64 = rewriter.intrinsics.i64_ty;
         let uint256 = rewriter.intrinsics.i256_ty;
         let data_size = rewriter.make(func::call(
             context,
             FlatSymbolRefAttribute::new(context, symbols::GET_RETURN_DATA_SIZE),
             &[syscall_ctx.into()],
-            &[uint32],
+            &[uint64],
             location,
         ))?;
         rewriter.create(arith::extui(data_size, uint256, location));
@@ -412,11 +412,11 @@ impl<'c> ConversionPass<'c> {
 
         let dest_offset = rewriter.make(arith::trunci(
             dest_offset,
-            rewriter.intrinsics.i32_ty,
+            rewriter.intrinsics.i64_ty,
             location,
         ))?;
-        let offset = rewriter.make(arith::trunci(offset, rewriter.intrinsics.i32_ty, location))?;
-        let size = rewriter.make(arith::trunci(size, rewriter.intrinsics.i32_ty, location))?;
+        let offset = rewriter.make(arith::trunci(offset, rewriter.intrinsics.i64_ty, location))?;
+        let size = rewriter.make(arith::trunci(size, rewriter.intrinsics.i64_ty, location))?;
         // Extend memory to required size
         let req_mem_size: Value = rewriter.make(arith::addi(dest_offset, size, location))?;
         memory::resize_memory(req_mem_size, context, &rewriter, syscall_ctx, location)?;

--- a/crates/dora-compiler/src/dora/memory.rs
+++ b/crates/dora-compiler/src/dora/memory.rs
@@ -90,7 +90,7 @@ pub(crate) fn resize_memory_with_gas_cost<'c>(
     let context = rewriter.context();
     let location = rewriter.get_insert_location();
     let ptr_type = rewriter.ptr_ty();
-    let uint32 = rewriter.intrinsics.i32_ty;
+    let uint64 = rewriter.intrinsics.i64_ty;
 
     // Load memory size
     let memory_size_ptr =
@@ -98,7 +98,7 @@ pub(crate) fn resize_memory_with_gas_cost<'c>(
     let memory_size = rewriter.make(llvm::load(
         context,
         memory_size_ptr,
-        uint32,
+        uint64,
         location,
         LoadStoreOptions::default(),
     ))?;
@@ -153,7 +153,7 @@ pub(crate) fn resize_memory<'c>(
     location: Location<'c>,
 ) -> Result<()> {
     let ptr_type = rewriter.ptr_ty();
-    let uint32 = rewriter.intrinsics.i32_ty;
+    let uint64 = rewriter.intrinsics.i64_ty;
 
     // Load memory size
     let memory_size_ptr =
@@ -161,7 +161,7 @@ pub(crate) fn resize_memory<'c>(
     let memory_size = rewriter.make(llvm::load(
         context,
         memory_size_ptr,
-        uint32,
+        uint64,
         location,
         LoadStoreOptions::default(),
     ))?;
@@ -233,8 +233,6 @@ pub(crate) fn memory_gas_cost<'c>(
     memory_byte_size: Value<'c, 'c>,
 ) -> Result<Value<'c, 'c>> {
     let location = rewriter.get_insert_location();
-    let uint64 = rewriter.intrinsics.i64_ty;
-
     // Helper function to create constants
     let make_constant =
         |val: i64| -> Result<Value<'c, 'c>> { rewriter.make(rewriter.iconst_64(val)) };
@@ -246,9 +244,8 @@ pub(crate) fn memory_gas_cost<'c>(
     let constant_512 = make_constant(512)?;
 
     // Memory calculations
-    let memory_size_extended = rewriter.make(arith::extui(memory_byte_size, uint64, location))?;
     let memory_byte_size_plus_31 =
-        rewriter.make(arith::addi(memory_size_extended, constant_31, location))?;
+        rewriter.make(arith::addi(memory_byte_size, constant_31, location))?;
     let memory_size_word = rewriter.make(arith::divui(
         memory_byte_size_plus_31,
         constant_32,

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_call_data_copy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_call_data_copy.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb6
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -128,43 +127,41 @@ module {
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
     %32 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %33 = llvm.load %32 : !llvm.ptr -> i64
-    %34 = arith.trunci %23 : i256 to i32
-    %35 = arith.trunci %31 : i256 to i32
-    %36 = arith.addi %34, %35 : i32
+    %34 = arith.trunci %23 : i256 to i64
+    %35 = arith.trunci %31 : i256 to i64
+    %36 = arith.addi %34, %35 : i64
     %37 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %38 = llvm.load %37 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %39 = arith.addi %36, %c31_i32 : i32
-    %40 = arith.divui %39, %c32_i32 : i32
-    %41 = arith.muli %40, %c32_i32 : i32
-    %42 = arith.cmpi ult, %38, %41 : i32
+    %38 = llvm.load %37 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %39 = arith.addi %36, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = arith.cmpi ult, %38, %41 : i64
     %c3_i64 = arith.constant 3 : i64
     %43 = scf.if %42 -> (i64) {
       %c3_i64_4 = arith.constant 3 : i64
-      %c31_i64 = arith.constant 31 : i64
-      %c32_i64 = arith.constant 32 : i64
+      %c31_i64_5 = arith.constant 31 : i64
+      %c32_i64_6 = arith.constant 32 : i64
       %c512_i64 = arith.constant 512 : i64
-      %47 = arith.extui %38 : i32 to i64
-      %48 = arith.addi %47, %c31_i64 : i64
-      %49 = arith.divui %48, %c32_i64 : i64
-      %50 = arith.muli %49, %49 : i64
-      %51 = arith.divui %50, %c512_i64 : i64
-      %52 = arith.muli %49, %c3_i64_4 : i64
-      %53 = arith.addi %51, %52 : i64
-      %c3_i64_5 = arith.constant 3 : i64
-      %c31_i64_6 = arith.constant 31 : i64
-      %c32_i64_7 = arith.constant 32 : i64
-      %c512_i64_8 = arith.constant 512 : i64
-      %54 = arith.extui %41 : i32 to i64
-      %55 = arith.addi %54, %c31_i64_6 : i64
-      %56 = arith.divui %55, %c32_i64_7 : i64
-      %57 = arith.muli %56, %56 : i64
-      %58 = arith.divui %57, %c512_i64_8 : i64
-      %59 = arith.muli %56, %c3_i64_5 : i64
-      %60 = arith.addi %58, %59 : i64
-      %61 = arith.subi %60, %53 : i64
-      scf.yield %61 : i64
+      %47 = arith.addi %38, %c31_i64_5 : i64
+      %48 = arith.divui %47, %c32_i64_6 : i64
+      %49 = arith.muli %48, %48 : i64
+      %50 = arith.divui %49, %c512_i64 : i64
+      %51 = arith.muli %48, %c3_i64_4 : i64
+      %52 = arith.addi %50, %51 : i64
+      %c3_i64_7 = arith.constant 3 : i64
+      %c31_i64_8 = arith.constant 31 : i64
+      %c32_i64_9 = arith.constant 32 : i64
+      %c512_i64_10 = arith.constant 512 : i64
+      %53 = arith.addi %41, %c31_i64_8 : i64
+      %54 = arith.divui %53, %c32_i64_9 : i64
+      %55 = arith.muli %54, %54 : i64
+      %56 = arith.divui %55, %c512_i64_10 : i64
+      %57 = arith.muli %54, %c3_i64_7 : i64
+      %58 = arith.addi %56, %57 : i64
+      %59 = arith.subi %58, %52 : i64
+      scf.yield %59 : i64
     } else {
       %c0_i64_4 = arith.constant 0 : i64
       scf.yield %c0_i64_4 : i64
@@ -178,9 +175,9 @@ module {
     "dora.calldatacopy"(%23, %27, %31) : (i256, i256, i256) -> ()
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_push_push_add.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_push_push_add.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb5
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -129,9 +128,9 @@ module {
     llvm.store %32, %30 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_push_push_add_sub.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_push_push_add_sub.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 4 preds: ^bb2, ^bb5, ^bb8, ^bb11
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -197,9 +196,9 @@ module {
     llvm.store %70, %68 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_push_push_exp.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__gas__gas_push_push_exp.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb5
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -140,9 +139,9 @@ module {
     llvm.store %39, %37 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %17, %15 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address_balance.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address_balance.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -117,9 +116,9 @@ module {
     llvm.store %27, %25 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__basefee.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__basefee.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobbasefee.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobbasefee.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -99,9 +98,9 @@ module {
     llvm.store %16, %14 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobhash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobhash.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -114,9 +113,9 @@ module {
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blockhash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blockhash.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -105,11 +104,16 @@ module {
     llvm.store %17, %18 {alignment = 1 : i64} : i256, !llvm.ptr
     call @dora_get_block_hash(%arg0, %18) : (!llvm.ptr, !llvm.ptr) -> ()
     %19 = llvm.load %18 : !llvm.ptr -> i256
+    %20 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
+    %21 = llvm.load %20 : !llvm.ptr -> !llvm.ptr
+    llvm.store %19, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %20 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__caller.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__caller.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__callvalue.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__callvalue.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__chainid.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__chainid.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -96,9 +95,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__codesize_edge_case_empty.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__codesize_edge_case_empty.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -95,9 +94,9 @@ module {
     llvm.store %13, %11 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__coinbase.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__coinbase.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %17, %15 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb12
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %161 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %161 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %162 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %161, %162 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,27 +163,27 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %c32_i32_4 = arith.constant 32 : i32
-    %52 = arith.addi %51, %c32_i32_4 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c32_i64_4 : i64
     %53 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %55 = arith.addi %52, %c31_i32_5 : i32
-    %56 = arith.divui %55, %c32_i32_6 : i32
-    %57 = arith.muli %56, %c32_i32_6 : i32
-    %58 = arith.cmpi ult, %54, %57 : i32
+    %54 = llvm.load %53 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %55 = arith.addi %52, %c31_i64_5 : i64
+    %56 = arith.divui %55, %c32_i64_6 : i64
+    %57 = arith.muli %56, %c32_i64_6 : i64
+    %58 = arith.cmpi ult, %54, %57 : i64
     scf.if %58 {
-      %161 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %57, %53 : i32, !llvm.ptr
+      %161 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %57, %53 : i64, !llvm.ptr
       %162 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %161, %162 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
-    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %62 = llvm.intr.bswap(%50)  : (i256) -> i256
     llvm.store %62, %61 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb9
@@ -228,20 +227,20 @@ module {
     %82 = llvm.getelementptr %81[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %83 = llvm.load %82 : !llvm.ptr -> i256
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    %84 = arith.trunci %79 : i256 to i32
-    %85 = arith.trunci %83 : i256 to i32
-    %86 = arith.addi %84, %85 : i32
+    %84 = arith.trunci %79 : i256 to i64
+    %85 = arith.trunci %83 : i256 to i64
+    %86 = arith.addi %84, %85 : i64
     %87 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %88 = llvm.load %87 : !llvm.ptr -> i32
-    %c31_i32_9 = arith.constant 31 : i32
-    %c32_i32_10 = arith.constant 32 : i32
-    %89 = arith.addi %86, %c31_i32_9 : i32
-    %90 = arith.divui %89, %c32_i32_10 : i32
-    %91 = arith.muli %90, %c32_i32_10 : i32
-    %92 = arith.cmpi ult, %88, %91 : i32
+    %88 = llvm.load %87 : !llvm.ptr -> i64
+    %c31_i64_9 = arith.constant 31 : i64
+    %c32_i64_10 = arith.constant 32 : i64
+    %89 = arith.addi %86, %c31_i64_9 : i64
+    %90 = arith.divui %89, %c32_i64_10 : i64
+    %91 = arith.muli %90, %c32_i64_10 : i64
+    %92 = arith.cmpi ult, %88, %91 : i64
     scf.if %92 {
-      %161 = func.call @dora_extend_memory(%arg0, %91) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %91, %87 : i32, !llvm.ptr
+      %161 = func.call @dora_extend_memory(%arg0, %91) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %91, %87 : i64, !llvm.ptr
       %162 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %161, %162 : !llvm.ptr, !llvm.ptr
     } else {
@@ -254,7 +253,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %96 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %95, %96 {alignment = 1 : i64} : i64, !llvm.ptr
-    %97 = call @dora_create(%arg0, %85, %84, %93, %96) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %97 = call @dora_create(%arg0, %85, %84, %93, %96) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %98 = arith.cmpi eq, %c0_i8, %97 : i8
     %99 = llvm.load %93 : !llvm.ptr -> i256
@@ -302,27 +301,27 @@ module {
     %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %123 = llvm.load %122 : !llvm.ptr -> i256
     llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
-    %124 = arith.trunci %119 : i256 to i32
-    %c32_i32_13 = arith.constant 32 : i32
-    %125 = arith.addi %124, %c32_i32_13 : i32
+    %124 = arith.trunci %119 : i256 to i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %125 = arith.addi %124, %c32_i64_13 : i64
     %126 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %127 = llvm.load %126 : !llvm.ptr -> i32
-    %c31_i32_14 = arith.constant 31 : i32
-    %c32_i32_15 = arith.constant 32 : i32
-    %128 = arith.addi %125, %c31_i32_14 : i32
-    %129 = arith.divui %128, %c32_i32_15 : i32
-    %130 = arith.muli %129, %c32_i32_15 : i32
-    %131 = arith.cmpi ult, %127, %130 : i32
+    %127 = llvm.load %126 : !llvm.ptr -> i64
+    %c31_i64_14 = arith.constant 31 : i64
+    %c32_i64_15 = arith.constant 32 : i64
+    %128 = arith.addi %125, %c31_i64_14 : i64
+    %129 = arith.divui %128, %c32_i64_15 : i64
+    %130 = arith.muli %129, %c32_i64_15 : i64
+    %131 = arith.cmpi ult, %127, %130 : i64
     scf.if %131 {
-      %161 = func.call @dora_extend_memory(%arg0, %130) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %130, %126 : i32, !llvm.ptr
+      %161 = func.call @dora_extend_memory(%arg0, %130) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %130, %126 : i64, !llvm.ptr
       %162 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %161, %162 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %132 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
-    %134 = llvm.getelementptr %133[%124] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %134 = llvm.getelementptr %133[%124] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %135 = llvm.intr.bswap(%123)  : (i256) -> i256
     llvm.store %135, %134 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb17
@@ -353,35 +352,35 @@ module {
     %148 = llvm.getelementptr %147[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %149 = llvm.load %148 : !llvm.ptr -> i256
     llvm.store %148, %146 : !llvm.ptr, !llvm.ptr
-    %150 = arith.trunci %145 : i256 to i32
-    %151 = arith.trunci %149 : i256 to i32
-    %152 = arith.addi %151, %150 : i32
+    %150 = arith.trunci %145 : i256 to i64
+    %151 = arith.trunci %149 : i256 to i64
+    %152 = arith.addi %151, %150 : i64
     %153 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %154 = llvm.load %153 : !llvm.ptr -> i64
     %155 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %156 = llvm.load %155 : !llvm.ptr -> i32
-    %c31_i32_18 = arith.constant 31 : i32
-    %c32_i32_19 = arith.constant 32 : i32
-    %157 = arith.addi %152, %c31_i32_18 : i32
-    %158 = arith.divui %157, %c32_i32_19 : i32
-    %159 = arith.muli %158, %c32_i32_19 : i32
-    %160 = arith.cmpi ult, %156, %159 : i32
+    %156 = llvm.load %155 : !llvm.ptr -> i64
+    %c31_i64_18 = arith.constant 31 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %157 = arith.addi %152, %c31_i64_18 : i64
+    %158 = arith.divui %157, %c32_i64_19 : i64
+    %159 = arith.muli %158, %c32_i64_19 : i64
+    %160 = arith.cmpi ult, %156, %159 : i64
     scf.if %160 {
-      %161 = func.call @dora_extend_memory(%arg0, %159) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %159, %155 : i32, !llvm.ptr
+      %161 = func.call @dora_extend_memory(%arg0, %159) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %159, %155 : i64, !llvm.ptr
       %162 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %161, %162 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %c0_i8_20 = arith.constant 0 : i8
-    call @dora_write_result(%arg0, %150, %151, %154, %c0_i8_20) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %150, %151, %154, %c0_i8_20) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8_20 : i8
   ^bb20:  // no predecessors
     cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i32_21 = arith.constant 0 : i32
+    %c0_i64_21 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_21, %c0_i32_21, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_21, %c0_i64_21, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -112,9 +111,9 @@ module {
     llvm.store %22, %20 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_nonexistent.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_nonexistent.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -112,9 +111,9 @@ module {
     llvm.store %22, %20 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__gasprice.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__gasprice.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__invalid.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__invalid.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb3
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -91,9 +90,9 @@ module {
   ^bb4:  // no predecessors
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -123,9 +122,9 @@ module {
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -104,9 +103,9 @@ module {
   ^bb5:  // no predecessors
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid_jumpdest.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb5
     cf.switch %10 : i256, [
@@ -112,9 +111,9 @@ module {
   ^bb6:  // no predecessors
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_multiple_destinations.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_multiple_destinations.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -131,9 +130,9 @@ module {
     llvm.store %26, %24 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_to_jumpdest_twice.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_to_jumpdest_twice.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // 2 preds: ^bb4, ^bb9
     cf.switch %10 : i256, [
@@ -143,9 +142,9 @@ module {
   ^bb12:  // 2 preds: ^bb2, ^bb11
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_unconditional.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_unconditional.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb5
     cf.switch %10 : i256, [
@@ -123,9 +122,9 @@ module {
   ^bb8:  // 2 preds: ^bb2, ^bb7
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_jumpdest.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -131,9 +130,9 @@ module {
     llvm.store %26, %24 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_push_pop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_push_pop.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -130,9 +129,9 @@ module {
   ^bb9:  // 2 preds: ^bb2, ^bb8
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,30 +112,30 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %26 = arith.trunci %24 : i256 to i32
-    %27 = arith.addi %25, %26 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %26 = arith.trunci %24 : i256 to i64
+    %27 = arith.addi %25, %26 : i64
     %28 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %29 = llvm.load %28 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %30 = arith.addi %27, %c31_i32 : i32
-    %31 = arith.divui %30, %c32_i32 : i32
-    %32 = arith.muli %31, %c32_i32 : i32
-    %33 = arith.cmpi ult, %29, %32 : i32
+    %29 = llvm.load %28 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %30 = arith.addi %27, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64 : i64
+    %32 = arith.muli %31, %c32_i64 : i64
+    %33 = arith.cmpi ult, %29, %32 : i64
     scf.if %33 {
-      %34 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %32, %28 : i32, !llvm.ptr
+      %34 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %32, %28 : i64, !llvm.ptr
       %35 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %34, %35 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_append_log(%arg0, %25, %26) : (!llvm.ptr, i32, i32) -> ()
+    call @dora_append_log(%arg0, %25, %26) : (!llvm.ptr, i64, i64) -> ()
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,20 +125,20 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %23 : i256 to i32
-    %33 = arith.trunci %27 : i256 to i32
-    %34 = arith.addi %32, %33 : i32
+    %32 = arith.trunci %23 : i256 to i64
+    %33 = arith.trunci %27 : i256 to i64
+    %34 = arith.addi %32, %33 : i64
     %35 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %36 = llvm.load %35 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %37 = arith.addi %34, %c31_i32 : i32
-    %38 = arith.divui %37, %c32_i32 : i32
-    %39 = arith.muli %38, %c32_i32 : i32
-    %40 = arith.cmpi ult, %36, %39 : i32
+    %36 = llvm.load %35 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %37 = arith.addi %34, %c31_i64 : i64
+    %38 = arith.divui %37, %c32_i64 : i64
+    %39 = arith.muli %38, %c32_i64 : i64
+    %40 = arith.cmpi ult, %36, %39 : i64
     scf.if %40 {
-      %42 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %39, %35 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %39, %35 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
@@ -147,12 +146,12 @@ module {
     %c1_i256_2 = arith.constant 1 : i256
     %41 = llvm.alloca %c1_i256_2 x i256 : (i256) -> !llvm.ptr
     llvm.store %31, %41 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_append_log_with_one_topic(%arg0, %32, %33, %41) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+    call @dora_append_log_with_one_topic(%arg0, %32, %33, %41) : (!llvm.ptr, i64, i64, !llvm.ptr) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log2.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,20 +138,20 @@ module {
     %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %38 = llvm.load %37 : !llvm.ptr -> i256
     llvm.store %37, %35 : !llvm.ptr, !llvm.ptr
-    %39 = arith.trunci %26 : i256 to i32
-    %40 = arith.trunci %30 : i256 to i32
-    %41 = arith.addi %39, %40 : i32
+    %39 = arith.trunci %26 : i256 to i64
+    %40 = arith.trunci %30 : i256 to i64
+    %41 = arith.addi %39, %40 : i64
     %42 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %43 = llvm.load %42 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %44 = arith.addi %41, %c31_i32 : i32
-    %45 = arith.divui %44, %c32_i32 : i32
-    %46 = arith.muli %45, %c32_i32 : i32
-    %47 = arith.cmpi ult, %43, %46 : i32
+    %43 = llvm.load %42 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %44 = arith.addi %41, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %46 = arith.muli %45, %c32_i64 : i64
+    %47 = arith.cmpi ult, %43, %46 : i64
     scf.if %47 {
-      %50 = func.call @dora_extend_memory(%arg0, %46) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %46, %42 : i32, !llvm.ptr
+      %50 = func.call @dora_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %46, %42 : i64, !llvm.ptr
       %51 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %50, %51 : !llvm.ptr, !llvm.ptr
     } else {
@@ -163,12 +162,12 @@ module {
     %c1_i256_3 = arith.constant 1 : i256
     %49 = llvm.alloca %c1_i256_3 x i256 : (i256) -> !llvm.ptr
     llvm.store %38, %49 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_append_log_with_two_topics(%arg0, %39, %40, %48, %49) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> ()
+    call @dora_append_log_with_two_topics(%arg0, %39, %40, %48, %49) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_4 = arith.constant 0 : i32
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_4, %c0_i32_4, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log3.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log3.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -152,20 +151,20 @@ module {
     %44 = llvm.getelementptr %43[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %45 = llvm.load %44 : !llvm.ptr -> i256
     llvm.store %44, %42 : !llvm.ptr, !llvm.ptr
-    %46 = arith.trunci %29 : i256 to i32
-    %47 = arith.trunci %33 : i256 to i32
-    %48 = arith.addi %46, %47 : i32
+    %46 = arith.trunci %29 : i256 to i64
+    %47 = arith.trunci %33 : i256 to i64
+    %48 = arith.addi %46, %47 : i64
     %49 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %51 = arith.addi %48, %c31_i32 : i32
-    %52 = arith.divui %51, %c32_i32 : i32
-    %53 = arith.muli %52, %c32_i32 : i32
-    %54 = arith.cmpi ult, %50, %53 : i32
+    %50 = llvm.load %49 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %51 = arith.addi %48, %c31_i64 : i64
+    %52 = arith.divui %51, %c32_i64 : i64
+    %53 = arith.muli %52, %c32_i64 : i64
+    %54 = arith.cmpi ult, %50, %53 : i64
     scf.if %54 {
-      %58 = func.call @dora_extend_memory(%arg0, %53) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %53, %49 : i32, !llvm.ptr
+      %58 = func.call @dora_extend_memory(%arg0, %53) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %53, %49 : i64, !llvm.ptr
       %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %58, %59 : !llvm.ptr, !llvm.ptr
     } else {
@@ -179,12 +178,12 @@ module {
     %c1_i256_4 = arith.constant 1 : i256
     %57 = llvm.alloca %c1_i256_4 x i256 : (i256) -> !llvm.ptr
     llvm.store %45, %57 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_append_log_with_three_topics(%arg0, %46, %47, %55, %56, %57) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    call @dora_append_log_with_three_topics(%arg0, %46, %47, %55, %56, %57) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_5 = arith.constant 0 : i32
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_5, %c0_i32_5, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log4.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log4.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -165,20 +164,20 @@ module {
     %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %52 = llvm.load %51 : !llvm.ptr -> i256
     llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = arith.trunci %32 : i256 to i32
-    %54 = arith.trunci %36 : i256 to i32
-    %55 = arith.addi %53, %54 : i32
+    %53 = arith.trunci %32 : i256 to i64
+    %54 = arith.trunci %36 : i256 to i64
+    %55 = arith.addi %53, %54 : i64
     %56 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %57 = llvm.load %56 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %58 = arith.addi %55, %c31_i32 : i32
-    %59 = arith.divui %58, %c32_i32 : i32
-    %60 = arith.muli %59, %c32_i32 : i32
-    %61 = arith.cmpi ult, %57, %60 : i32
+    %57 = llvm.load %56 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %58 = arith.addi %55, %c31_i64 : i64
+    %59 = arith.divui %58, %c32_i64 : i64
+    %60 = arith.muli %59, %c32_i64 : i64
+    %61 = arith.cmpi ult, %57, %60 : i64
     scf.if %61 {
-      %66 = func.call @dora_extend_memory(%arg0, %60) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %60, %56 : i32, !llvm.ptr
+      %66 = func.call @dora_extend_memory(%arg0, %60) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %60, %56 : i64, !llvm.ptr
       %67 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %66, %67 : !llvm.ptr, !llvm.ptr
     } else {
@@ -195,12 +194,12 @@ module {
     %c1_i256_5 = arith.constant 1 : i256
     %65 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
     llvm.store %52, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_append_log_with_four_topics(%arg0, %53, %54, %62, %63, %64, %65) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    call @dora_append_log_with_four_topics(%arg0, %53, %54, %62, %63, %64, %65) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %60 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %60 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %61 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %60, %61 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -151,27 +150,27 @@ module {
     %42 = llvm.getelementptr %41[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %43 = llvm.load %42 : !llvm.ptr -> i256
     llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
-    %44 = arith.trunci %43 : i256 to i32
-    %c32_i32_4 = arith.constant 32 : i32
-    %45 = arith.addi %44, %c32_i32_4 : i32
+    %44 = arith.trunci %43 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %45 = arith.addi %44, %c32_i64_4 : i64
     %46 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %48 = arith.addi %45, %c31_i32_5 : i32
-    %49 = arith.divui %48, %c32_i32_6 : i32
-    %50 = arith.muli %49, %c32_i32_6 : i32
-    %51 = arith.cmpi ult, %47, %50 : i32
+    %47 = llvm.load %46 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %48 = arith.addi %45, %c31_i64_5 : i64
+    %49 = arith.divui %48, %c32_i64_6 : i64
+    %50 = arith.muli %49, %c32_i64_6 : i64
+    %51 = arith.cmpi ult, %47, %50 : i64
     scf.if %51 {
-      %60 = func.call @dora_extend_memory(%arg0, %50) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %50, %46 : i32, !llvm.ptr
+      %60 = func.call @dora_extend_memory(%arg0, %50) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %50, %46 : i64, !llvm.ptr
       %61 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %60, %61 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %53 = llvm.load %52 : !llvm.ptr -> !llvm.ptr
-    %54 = llvm.getelementptr %53[%44] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %54 = llvm.getelementptr %53[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %55 = llvm.load %54 {alignment = 1 : i64} : !llvm.ptr -> i256
     %56 = llvm.intr.bswap(%55)  : (i256) -> i256
     %57 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -181,9 +180,9 @@ module {
     llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_7 = arith.constant 0 : i32
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_7, %c0_i32_7, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_high_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_high_address.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_3 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_3 : i32
-    %31 = arith.muli %30, %c32_i32_3 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_3 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_3 : i64
+    %31 = arith.muli %30, %c32_i64_3 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %60 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %60 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %61 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %60, %61 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -151,27 +150,27 @@ module {
     %42 = llvm.getelementptr %41[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %43 = llvm.load %42 : !llvm.ptr -> i256
     llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
-    %44 = arith.trunci %43 : i256 to i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %45 = arith.addi %44, %c32_i32_5 : i32
+    %44 = arith.trunci %43 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %45 = arith.addi %44, %c32_i64_5 : i64
     %46 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> i32
-    %c31_i32_6 = arith.constant 31 : i32
-    %c32_i32_7 = arith.constant 32 : i32
-    %48 = arith.addi %45, %c31_i32_6 : i32
-    %49 = arith.divui %48, %c32_i32_7 : i32
-    %50 = arith.muli %49, %c32_i32_7 : i32
-    %51 = arith.cmpi ult, %47, %50 : i32
+    %47 = llvm.load %46 : !llvm.ptr -> i64
+    %c31_i64_6 = arith.constant 31 : i64
+    %c32_i64_7 = arith.constant 32 : i64
+    %48 = arith.addi %45, %c31_i64_6 : i64
+    %49 = arith.divui %48, %c32_i64_7 : i64
+    %50 = arith.muli %49, %c32_i64_7 : i64
+    %51 = arith.cmpi ult, %47, %50 : i64
     scf.if %51 {
-      %60 = func.call @dora_extend_memory(%arg0, %50) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %50, %46 : i32, !llvm.ptr
+      %60 = func.call @dora_extend_memory(%arg0, %50) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %50, %46 : i64, !llvm.ptr
       %61 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %60, %61 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %53 = llvm.load %52 : !llvm.ptr -> !llvm.ptr
-    %54 = llvm.getelementptr %53[%44] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %54 = llvm.getelementptr %53[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %55 = llvm.load %54 {alignment = 1 : i64} : !llvm.ptr -> i256
     %56 = llvm.intr.bswap(%55)  : (i256) -> i256
     %57 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -181,9 +180,9 @@ module {
     llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_8 = arith.constant 0 : i32
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_8, %c0_i32_8, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_8, %c0_i64_8, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_uninitialized.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_uninitialized.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -100,27 +99,27 @@ module {
     %16 = llvm.getelementptr %15[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %17 = llvm.load %16 : !llvm.ptr -> i256
     llvm.store %16, %14 : !llvm.ptr, !llvm.ptr
-    %18 = arith.trunci %17 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %19 = arith.addi %18, %c32_i32 : i32
+    %18 = arith.trunci %17 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %19 = arith.addi %18, %c32_i64 : i64
     %20 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %21 = llvm.load %20 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %22 = arith.addi %19, %c31_i32 : i32
-    %23 = arith.divui %22, %c32_i32_2 : i32
-    %24 = arith.muli %23, %c32_i32_2 : i32
-    %25 = arith.cmpi ult, %21, %24 : i32
+    %21 = llvm.load %20 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %22 = arith.addi %19, %c31_i64 : i64
+    %23 = arith.divui %22, %c32_i64_2 : i64
+    %24 = arith.muli %23, %c32_i64_2 : i64
+    %25 = arith.cmpi ult, %21, %24 : i64
     scf.if %25 {
-      %34 = func.call @dora_extend_memory(%arg0, %24) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %24, %20 : i32, !llvm.ptr
+      %34 = func.call @dora_extend_memory(%arg0, %24) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %24, %20 : i64, !llvm.ptr
       %35 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %34, %35 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %26 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %27 = llvm.load %26 : !llvm.ptr -> !llvm.ptr
-    %28 = llvm.getelementptr %27[%18] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %28 = llvm.getelementptr %27[%18] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %29 = llvm.load %28 {alignment = 1 : i64} : !llvm.ptr -> i256
     %30 = llvm.intr.bswap(%29)  : (i256) -> i256
     %31 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -130,9 +129,9 @@ module {
     llvm.store %33, %31 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,34 +112,34 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %37 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %37 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %38 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %37, %38 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_high_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_high_address.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,34 +112,34 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_3 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_3 : i32
-    %31 = arith.muli %30, %c32_i32_3 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_3 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_3 : i64
+    %31 = arith.muli %30, %c32_i64_3 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %37 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %37 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %38 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %37, %38 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_4 = arith.constant 0 : i32
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_4, %c0_i32_4, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_overwrite.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_overwrite.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %63 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %63 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %64 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %63, %64 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,34 +163,34 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %c32_i32_4 = arith.constant 32 : i32
-    %52 = arith.addi %51, %c32_i32_4 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c32_i64_4 : i64
     %53 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %55 = arith.addi %52, %c31_i32_5 : i32
-    %56 = arith.divui %55, %c32_i32_6 : i32
-    %57 = arith.muli %56, %c32_i32_6 : i32
-    %58 = arith.cmpi ult, %54, %57 : i32
+    %54 = llvm.load %53 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %55 = arith.addi %52, %c31_i64_5 : i64
+    %56 = arith.divui %55, %c32_i64_6 : i64
+    %57 = arith.muli %56, %c32_i64_6 : i64
+    %58 = arith.cmpi ult, %54, %57 : i64
     scf.if %58 {
-      %63 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %57, %53 : i32, !llvm.ptr
+      %63 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %57, %53 : i64, !llvm.ptr
       %64 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %63, %64 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
-    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %62 = llvm.intr.bswap(%50)  : (i256) -> i256
     llvm.store %62, %61 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_7 = arith.constant 0 : i32
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_7, %c0_i32_7, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__number.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__number.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__origin.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__origin.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__pc.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__pc.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -130,9 +129,9 @@ module {
     llvm.store %25, %23 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__prevrandao.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__prevrandao.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb10
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -186,24 +185,24 @@ module {
     cf.cond_br %63, ^bb1, ^bb11
   ^bb11:  // pred: ^bb10
     %64 = arith.trunci %35 : i256 to i64
-    %65 = arith.trunci %47 : i256 to i32
-    %66 = arith.trunci %51 : i256 to i32
-    %67 = arith.trunci %55 : i256 to i32
-    %68 = arith.trunci %59 : i256 to i32
-    %69 = arith.addi %65, %66 : i32
-    %70 = arith.addi %67, %68 : i32
-    %71 = arith.maxui %69, %70 : i32
+    %65 = arith.trunci %47 : i256 to i64
+    %66 = arith.trunci %51 : i256 to i64
+    %67 = arith.trunci %55 : i256 to i64
+    %68 = arith.trunci %59 : i256 to i64
+    %69 = arith.addi %65, %66 : i64
+    %70 = arith.addi %67, %68 : i64
+    %71 = arith.maxui %69, %70 : i64
     %72 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %74 = arith.addi %71, %c31_i32 : i32
-    %75 = arith.divui %74, %c32_i32 : i32
-    %76 = arith.muli %75, %c32_i32 : i32
-    %77 = arith.cmpi ult, %73, %76 : i32
+    %73 = llvm.load %72 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %74 = arith.addi %71, %c31_i64 : i64
+    %75 = arith.divui %74, %c32_i64 : i64
+    %76 = arith.muli %75, %c32_i64 : i64
+    %77 = arith.cmpi ult, %73, %76 : i64
     scf.if %77 {
-      %89 = func.call @dora_extend_memory(%arg0, %76) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %76, %72 : i32, !llvm.ptr
+      %89 = func.call @dora_extend_memory(%arg0, %76) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %76, %72 : i64, !llvm.ptr
       %90 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %89, %90 : !llvm.ptr, !llvm.ptr
     } else {
@@ -219,7 +218,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %82 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     %c0_i8 = arith.constant 0 : i8
-    %83 = call @dora_call(%arg0, %64, %81, %80, %65, %66, %67, %68, %79, %82, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %83 = call @dora_call(%arg0, %64, %81, %80, %65, %66, %67, %68, %79, %82, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %84 = llvm.load %82 : !llvm.ptr -> i64
     %85 = arith.extui %83 : i8 to i256
     %86 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -229,9 +228,9 @@ module {
     llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb10
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -186,24 +185,24 @@ module {
     cf.cond_br %63, ^bb1, ^bb11
   ^bb11:  // pred: ^bb10
     %64 = arith.trunci %35 : i256 to i64
-    %65 = arith.trunci %47 : i256 to i32
-    %66 = arith.trunci %51 : i256 to i32
-    %67 = arith.trunci %55 : i256 to i32
-    %68 = arith.trunci %59 : i256 to i32
-    %69 = arith.addi %65, %66 : i32
-    %70 = arith.addi %67, %68 : i32
-    %71 = arith.maxui %69, %70 : i32
+    %65 = arith.trunci %47 : i256 to i64
+    %66 = arith.trunci %51 : i256 to i64
+    %67 = arith.trunci %55 : i256 to i64
+    %68 = arith.trunci %59 : i256 to i64
+    %69 = arith.addi %65, %66 : i64
+    %70 = arith.addi %67, %68 : i64
+    %71 = arith.maxui %69, %70 : i64
     %72 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %74 = arith.addi %71, %c31_i32 : i32
-    %75 = arith.divui %74, %c32_i32 : i32
-    %76 = arith.muli %75, %c32_i32 : i32
-    %77 = arith.cmpi ult, %73, %76 : i32
+    %73 = llvm.load %72 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %74 = arith.addi %71, %c31_i64 : i64
+    %75 = arith.divui %74, %c32_i64 : i64
+    %76 = arith.muli %75, %c32_i64 : i64
+    %77 = arith.cmpi ult, %73, %76 : i64
     scf.if %77 {
-      %89 = func.call @dora_extend_memory(%arg0, %76) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %76, %72 : i32, !llvm.ptr
+      %89 = func.call @dora_extend_memory(%arg0, %76) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %76, %72 : i64, !llvm.ptr
       %90 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %89, %90 : !llvm.ptr, !llvm.ptr
     } else {
@@ -219,7 +218,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %82 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     %c0_i8 = arith.constant 0 : i8
-    %83 = call @dora_call(%arg0, %64, %81, %80, %65, %66, %67, %68, %79, %82, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %83 = call @dora_call(%arg0, %64, %81, %80, %65, %66, %67, %68, %79, %82, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %84 = llvm.load %82 : !llvm.ptr -> i64
     %85 = arith.extui %83 : i8 to i256
     %86 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -229,9 +228,9 @@ module {
     llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,45 +125,45 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %23 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %33, %34 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %23 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %33, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %47 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %47 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %48 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %47, %48 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %42 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-    %44 = llvm.getelementptr %43[%33] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %44 = llvm.getelementptr %43[%33] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %c0_i8 = arith.constant 0 : i8
-    "llvm.intr.memset"(%44, %c0_i8, %34) <{isVolatile = false}> : (!llvm.ptr, i8, i32) -> ()
-    %45 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
-    %46 = arith.cmpi ugt, %32, %45 : i32
+    "llvm.intr.memset"(%44, %c0_i8, %34) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %45 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %46 = arith.cmpi ugt, %32, %45 : i64
     scf.if %46 {
-      %47 = arith.subi %45, %32 : i32
-      %48 = arith.minui %47, %34 : i32
+      %47 = arith.subi %45, %32 : i64
+      %48 = arith.minui %47, %34 : i64
       %49 = func.call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-      %50 = llvm.getelementptr %49[%32] : (!llvm.ptr, i32) -> !llvm.ptr, i8
-      "llvm.intr.memcpy"(%44, %50, %48) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+      %50 = llvm.getelementptr %49[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      "llvm.intr.memcpy"(%44, %50, %48) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     } else {
     }
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_out_of_bounds.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,45 +125,45 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %23 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %33, %34 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %23 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %33, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %47 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %47 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %48 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %47, %48 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %42 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-    %44 = llvm.getelementptr %43[%33] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %44 = llvm.getelementptr %43[%33] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %c0_i8 = arith.constant 0 : i8
-    "llvm.intr.memset"(%44, %c0_i8, %34) <{isVolatile = false}> : (!llvm.ptr, i8, i32) -> ()
-    %45 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
-    %46 = arith.cmpi ugt, %32, %45 : i32
+    "llvm.intr.memset"(%44, %c0_i8, %34) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %45 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %46 = arith.cmpi ugt, %32, %45 : i64
     scf.if %46 {
-      %47 = arith.subi %45, %32 : i32
-      %48 = arith.minui %47, %34 : i32
+      %47 = arith.subi %45, %32 : i64
+      %48 = arith.minui %47, %34 : i64
       %49 = func.call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-      %50 = llvm.getelementptr %49[%32] : (!llvm.ptr, i32) -> !llvm.ptr, i8
-      "llvm.intr.memcpy"(%44, %50, %48) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+      %50 = llvm.getelementptr %49[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      "llvm.intr.memcpy"(%44, %50, %48) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     } else {
     }
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_partial.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,45 +125,45 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %23 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %33, %34 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %23 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %33, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %47 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %47 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %48 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %47, %48 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %42 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-    %44 = llvm.getelementptr %43[%33] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %44 = llvm.getelementptr %43[%33] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %c0_i8 = arith.constant 0 : i8
-    "llvm.intr.memset"(%44, %c0_i8, %34) <{isVolatile = false}> : (!llvm.ptr, i8, i32) -> ()
-    %45 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
-    %46 = arith.cmpi ugt, %32, %45 : i32
+    "llvm.intr.memset"(%44, %c0_i8, %34) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %45 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %46 = arith.cmpi ugt, %32, %45 : i64
     scf.if %46 {
-      %47 = arith.subi %45, %32 : i32
-      %48 = arith.minui %47, %34 : i32
+      %47 = arith.subi %45, %32 : i64
+      %48 = arith.minui %47, %34 : i64
       %49 = func.call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-      %50 = llvm.getelementptr %49[%32] : (!llvm.ptr, i32) -> !llvm.ptr, i8
-      "llvm.intr.memcpy"(%44, %50, %48) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+      %50 = llvm.getelementptr %49[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      "llvm.intr.memcpy"(%44, %50, %48) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     } else {
     }
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -104,8 +103,8 @@ module {
     %19 = llvm.load %18 : !llvm.ptr -> !llvm.ptr
     %c32_i256 = arith.constant 32 : i256
     %20 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    %21 = llvm.load %20 : !llvm.ptr -> i32
-    %22 = arith.extui %21 : i32 to i256
+    %21 = llvm.load %20 : !llvm.ptr -> i64
+    %22 = arith.extui %21 : i64 to i256
     %23 = arith.cmpi ult, %17, %22 : i256
     %c0_i256_2 = arith.constant 0 : i256
     %24 = scf.if %23 -> (i256) {
@@ -129,9 +128,9 @@ module {
     llvm.store %27, %25 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload_edge_case.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -104,8 +103,8 @@ module {
     %19 = llvm.load %18 : !llvm.ptr -> !llvm.ptr
     %c32_i256 = arith.constant 32 : i256
     %20 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    %21 = llvm.load %20 : !llvm.ptr -> i32
-    %22 = arith.extui %21 : i32 to i256
+    %21 = llvm.load %20 : !llvm.ptr -> i64
+    %22 = arith.extui %21 : i64 to i256
     %23 = arith.cmpi ult, %17, %22 : i256
     %c0_i256 = arith.constant 0 : i256
     %24 = scf.if %23 -> (i256) {
@@ -129,9 +128,9 @@ module {
     llvm.store %27, %25 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatasize.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,36 +59,35 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
       default: ^bb1
     ]
   ^bb3:  // pred: ^bb0
-    %11 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
-    %12 = arith.extui %11 : i32 to i256
+    %11 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %12 = arith.extui %11 : i64 to i256
     %13 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     %14 = llvm.load %13 : !llvm.ptr -> !llvm.ptr
     llvm.store %12, %14 : i256, !llvm.ptr
@@ -96,9 +95,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -156,31 +155,31 @@ module {
     %44 = llvm.getelementptr %43[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %45 = llvm.load %44 : !llvm.ptr -> i256
     llvm.store %44, %42 : !llvm.ptr, !llvm.ptr
-    %46 = arith.trunci %41 : i256 to i32
-    %47 = arith.trunci %37 : i256 to i32
-    %48 = arith.trunci %45 : i256 to i32
-    %49 = arith.addi %47, %48 : i32
+    %46 = arith.trunci %41 : i256 to i64
+    %47 = arith.trunci %37 : i256 to i64
+    %48 = arith.trunci %45 : i256 to i64
+    %49 = arith.addi %47, %48 : i64
     %50 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %52 = arith.addi %49, %c31_i32 : i32
-    %53 = arith.divui %52, %c32_i32 : i32
-    %54 = arith.muli %53, %c32_i32 : i32
-    %55 = arith.cmpi ult, %51, %54 : i32
+    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %52 = arith.addi %49, %c31_i64 : i64
+    %53 = arith.divui %52, %c32_i64 : i64
+    %54 = arith.muli %53, %c32_i64 : i64
+    %55 = arith.cmpi ult, %51, %54 : i64
     scf.if %55 {
-      %56 = func.call @dora_extend_memory(%arg0, %54) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %54, %50 : i32, !llvm.ptr
+      %56 = func.call @dora_extend_memory(%arg0, %54) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %54, %50 : i64, !llvm.ptr
       %57 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %56, %57 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_code_to_memory(%arg0, %46, %48, %47) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_code_to_memory(%arg0, %46, %48, %47) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i32_4 = arith.constant 0 : i32
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_4, %c0_i32_4, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,31 +125,31 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %23 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %33, %34 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %23 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %33, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_code_to_memory(%arg0, %32, %34, %33) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_code_to_memory(%arg0, %32, %34, %33) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_out_of_bounds.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,31 +125,31 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %23 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %33, %34 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %23 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %33, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_code_to_memory(%arg0, %32, %34, %33) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_code_to_memory(%arg0, %32, %34, %33) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_partial.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,31 +125,31 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %23 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %33, %34 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %23 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %33, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_code_to_memory(%arg0, %32, %34, %33) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_code_to_memory(%arg0, %32, %34, %33) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb6
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,20 +125,20 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %31 : i256 to i32
-    %34 = arith.addi %32, %33 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %31 : i256 to i64
+    %34 = arith.addi %32, %33 : i64
     %35 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %36 = llvm.load %35 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %37 = arith.addi %34, %c31_i32 : i32
-    %38 = arith.divui %37, %c32_i32 : i32
-    %39 = arith.muli %38, %c32_i32 : i32
-    %40 = arith.cmpi ult, %36, %39 : i32
+    %36 = llvm.load %35 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %37 = arith.addi %34, %c31_i64 : i64
+    %38 = arith.divui %37, %c32_i64 : i64
+    %39 = arith.muli %38, %c32_i64 : i64
+    %40 = arith.cmpi ult, %36, %39 : i64
     scf.if %40 {
-      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %39, %35 : i32, !llvm.ptr
+      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %39, %35 : i64, !llvm.ptr
       %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %51, %52 : !llvm.ptr, !llvm.ptr
     } else {
@@ -152,7 +151,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %44 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %43, %44 {alignment = 1 : i64} : i64, !llvm.ptr
-    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %46 = arith.cmpi eq, %c0_i8, %45 : i8
     %47 = llvm.load %41 : !llvm.ptr -> i256
@@ -165,9 +164,9 @@ module {
     llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb7
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,20 +138,20 @@ module {
     %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %38 = llvm.load %37 : !llvm.ptr -> i256
     llvm.store %37, %35 : !llvm.ptr, !llvm.ptr
-    %39 = arith.trunci %30 : i256 to i32
-    %40 = arith.trunci %34 : i256 to i32
-    %41 = arith.addi %39, %40 : i32
+    %39 = arith.trunci %30 : i256 to i64
+    %40 = arith.trunci %34 : i256 to i64
+    %41 = arith.addi %39, %40 : i64
     %42 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %43 = llvm.load %42 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %44 = arith.addi %41, %c31_i32 : i32
-    %45 = arith.divui %44, %c32_i32 : i32
-    %46 = arith.muli %45, %c32_i32 : i32
-    %47 = arith.cmpi ult, %43, %46 : i32
+    %43 = llvm.load %42 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %44 = arith.addi %41, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %46 = arith.muli %45, %c32_i64 : i64
+    %47 = arith.cmpi ult, %43, %46 : i64
     scf.if %47 {
-      %59 = func.call @dora_extend_memory(%arg0, %46) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %46, %42 : i32, !llvm.ptr
+      %59 = func.call @dora_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %46, %42 : i64, !llvm.ptr
       %60 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
     } else {
@@ -168,7 +167,7 @@ module {
     %c1_i256_2 = arith.constant 1 : i256
     %52 = llvm.alloca %c1_i256_2 x i256 : (i256) -> !llvm.ptr
     llvm.store %38, %52 {alignment = 1 : i64} : i256, !llvm.ptr
-    %53 = call @dora_create2(%arg0, %40, %39, %48, %51, %52) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+    %53 = call @dora_create2(%arg0, %40, %39, %48, %51, %52) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %54 = arith.cmpi eq, %c0_i8, %53 : i8
     %55 = llvm.load %48 : !llvm.ptr -> i256
@@ -181,9 +180,9 @@ module {
     llvm.store %58, %56 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb7
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,20 +138,20 @@ module {
     %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %38 = llvm.load %37 : !llvm.ptr -> i256
     llvm.store %37, %35 : !llvm.ptr, !llvm.ptr
-    %39 = arith.trunci %30 : i256 to i32
-    %40 = arith.trunci %34 : i256 to i32
-    %41 = arith.addi %39, %40 : i32
+    %39 = arith.trunci %30 : i256 to i64
+    %40 = arith.trunci %34 : i256 to i64
+    %41 = arith.addi %39, %40 : i64
     %42 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %43 = llvm.load %42 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %44 = arith.addi %41, %c31_i32 : i32
-    %45 = arith.divui %44, %c32_i32 : i32
-    %46 = arith.muli %45, %c32_i32 : i32
-    %47 = arith.cmpi ult, %43, %46 : i32
+    %43 = llvm.load %42 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %44 = arith.addi %41, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %46 = arith.muli %45, %c32_i64 : i64
+    %47 = arith.cmpi ult, %43, %46 : i64
     scf.if %47 {
-      %59 = func.call @dora_extend_memory(%arg0, %46) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %46, %42 : i32, !llvm.ptr
+      %59 = func.call @dora_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %46, %42 : i64, !llvm.ptr
       %60 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
     } else {
@@ -168,7 +167,7 @@ module {
     %c1_i256_2 = arith.constant 1 : i256
     %52 = llvm.alloca %c1_i256_2 x i256 : (i256) -> !llvm.ptr
     llvm.store %38, %52 {alignment = 1 : i64} : i256, !llvm.ptr
-    %53 = call @dora_create2(%arg0, %40, %39, %48, %51, %52) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+    %53 = call @dora_create2(%arg0, %40, %39, %48, %51, %52) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %54 = arith.cmpi eq, %c0_i8, %53 : i8
     %55 = llvm.load %48 : !llvm.ptr -> i256
@@ -181,9 +180,9 @@ module {
     llvm.store %58, %56 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb6
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,20 +125,20 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %31 : i256 to i32
-    %34 = arith.addi %32, %33 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %31 : i256 to i64
+    %34 = arith.addi %32, %33 : i64
     %35 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %36 = llvm.load %35 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %37 = arith.addi %34, %c31_i32 : i32
-    %38 = arith.divui %37, %c32_i32 : i32
-    %39 = arith.muli %38, %c32_i32 : i32
-    %40 = arith.cmpi ult, %36, %39 : i32
+    %36 = llvm.load %35 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %37 = arith.addi %34, %c31_i64 : i64
+    %38 = arith.divui %37, %c32_i64 : i64
+    %39 = arith.muli %38, %c32_i64 : i64
+    %40 = arith.cmpi ult, %36, %39 : i64
     scf.if %40 {
-      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %39, %35 : i32, !llvm.ptr
+      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %39, %35 : i64, !llvm.ptr
       %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %51, %52 : !llvm.ptr, !llvm.ptr
     } else {
@@ -152,7 +151,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %44 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %43, %44 {alignment = 1 : i64} : i64, !llvm.ptr
-    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %46 = arith.cmpi eq, %c0_i8, %45 : i8
     %47 = llvm.load %41 : !llvm.ptr -> i256
@@ -165,9 +164,9 @@ module {
     llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_4 = arith.constant 0 : i32
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_4, %c0_i32_4, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb6
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,20 +125,20 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %31 : i256 to i32
-    %34 = arith.addi %32, %33 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %31 : i256 to i64
+    %34 = arith.addi %32, %33 : i64
     %35 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %36 = llvm.load %35 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %37 = arith.addi %34, %c31_i32 : i32
-    %38 = arith.divui %37, %c32_i32 : i32
-    %39 = arith.muli %38, %c32_i32 : i32
-    %40 = arith.cmpi ult, %36, %39 : i32
+    %36 = llvm.load %35 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %37 = arith.addi %34, %c31_i64 : i64
+    %38 = arith.divui %37, %c32_i64 : i64
+    %39 = arith.muli %38, %c32_i64 : i64
+    %40 = arith.cmpi ult, %36, %39 : i64
     scf.if %40 {
-      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %39, %35 : i32, !llvm.ptr
+      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %39, %35 : i64, !llvm.ptr
       %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %51, %52 : !llvm.ptr, !llvm.ptr
     } else {
@@ -152,7 +151,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %44 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %43, %44 {alignment = 1 : i64} : i64, !llvm.ptr
-    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %46 = arith.cmpi eq, %c0_i8, %45 : i8
     %47 = llvm.load %41 : !llvm.ptr -> i256
@@ -165,9 +164,9 @@ module {
     llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb9
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %77 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %77 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %78 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %77, %78 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,20 +176,20 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %53 : i256 to i32
-    %59 = arith.trunci %57 : i256 to i32
-    %60 = arith.addi %58, %59 : i32
+    %58 = arith.trunci %53 : i256 to i64
+    %59 = arith.trunci %57 : i256 to i64
+    %60 = arith.addi %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32_4 : i32
-    %64 = arith.divui %63, %c32_i32_5 : i32
-    %65 = arith.muli %64, %c32_i32_5 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64_4 : i64
+    %64 = arith.divui %63, %c32_i64_5 : i64
+    %65 = arith.muli %64, %c32_i64_5 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %77 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %77 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %78 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %77, %78 : !llvm.ptr, !llvm.ptr
     } else {
@@ -203,7 +202,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %70 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %69, %70 {alignment = 1 : i64} : i64, !llvm.ptr
-    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %72 = arith.cmpi eq, %c0_i8, %71 : i8
     %73 = llvm.load %67 : !llvm.ptr -> i256
@@ -216,9 +215,9 @@ module {
     llvm.store %76, %74 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb6
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,20 +125,20 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %27 : i256 to i32
-    %33 = arith.trunci %31 : i256 to i32
-    %34 = arith.addi %32, %33 : i32
+    %32 = arith.trunci %27 : i256 to i64
+    %33 = arith.trunci %31 : i256 to i64
+    %34 = arith.addi %32, %33 : i64
     %35 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %36 = llvm.load %35 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %37 = arith.addi %34, %c31_i32 : i32
-    %38 = arith.divui %37, %c32_i32 : i32
-    %39 = arith.muli %38, %c32_i32 : i32
-    %40 = arith.cmpi ult, %36, %39 : i32
+    %36 = llvm.load %35 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %37 = arith.addi %34, %c31_i64 : i64
+    %38 = arith.divui %37, %c32_i64 : i64
+    %39 = arith.muli %38, %c32_i64 : i64
+    %40 = arith.cmpi ult, %36, %39 : i64
     scf.if %40 {
-      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %39, %35 : i32, !llvm.ptr
+      %51 = func.call @dora_extend_memory(%arg0, %39) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %39, %35 : i64, !llvm.ptr
       %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %51, %52 : !llvm.ptr, !llvm.ptr
     } else {
@@ -152,7 +151,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %44 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %43, %44 {alignment = 1 : i64} : i64, !llvm.ptr
-    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %45 = call @dora_create(%arg0, %33, %32, %41, %44) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %46 = arith.cmpi eq, %c0_i8, %45 : i8
     %47 = llvm.load %41 : !llvm.ptr -> i256
@@ -165,9 +164,9 @@ module {
     llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -167,24 +166,24 @@ module {
     llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
     %53 = arith.trunci %32 : i256 to i64
-    %54 = arith.trunci %40 : i256 to i32
-    %55 = arith.trunci %44 : i256 to i32
-    %56 = arith.trunci %48 : i256 to i32
-    %57 = arith.trunci %52 : i256 to i32
-    %58 = arith.addi %54, %55 : i32
-    %59 = arith.addi %56, %57 : i32
-    %60 = arith.maxui %58, %59 : i32
+    %54 = arith.trunci %40 : i256 to i64
+    %55 = arith.trunci %44 : i256 to i64
+    %56 = arith.trunci %48 : i256 to i64
+    %57 = arith.trunci %52 : i256 to i64
+    %58 = arith.addi %54, %55 : i64
+    %59 = arith.addi %56, %57 : i64
+    %60 = arith.maxui %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32 : i32
-    %64 = arith.divui %63, %c32_i32 : i32
-    %65 = arith.muli %64, %c32_i32 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64 : i64
+    %64 = arith.divui %63, %c32_i64 : i64
+    %65 = arith.muli %64, %c32_i64 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %78 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %78 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %79 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %78, %79 : !llvm.ptr, !llvm.ptr
     } else {
@@ -200,7 +199,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %71 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     %c0_i8 = arith.constant 0 : i8
-    %72 = call @dora_call(%arg0, %53, %70, %69, %54, %55, %56, %57, %68, %71, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %72 = call @dora_call(%arg0, %53, %70, %69, %54, %55, %56, %57, %68, %71, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %73 = llvm.load %71 : !llvm.ptr -> i64
     %74 = arith.extui %72 : i8 to i256
     %75 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -210,9 +209,9 @@ module {
     llvm.store %77, %75 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_5 = arith.constant 0 : i32
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_5, %c0_i32_5, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -106,9 +105,9 @@ module {
     llvm.store %20, %18 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup2.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -114,9 +113,9 @@ module {
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,34 +138,34 @@ module {
     %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %38 = llvm.load %37 : !llvm.ptr -> i256
     llvm.store %37, %35 : !llvm.ptr, !llvm.ptr
-    %39 = arith.trunci %34 : i256 to i32
-    %40 = arith.trunci %38 : i256 to i32
-    %41 = arith.trunci %30 : i256 to i32
+    %39 = arith.trunci %34 : i256 to i64
+    %40 = arith.trunci %38 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
     %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
     llvm.store %26, %42 {alignment = 1 : i64} : i256, !llvm.ptr
-    %43 = arith.addi %41, %40 : i32
+    %43 = arith.addi %41, %40 : i64
     %44 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %45 = llvm.load %44 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %46 = arith.addi %43, %c31_i32 : i32
-    %47 = arith.divui %46, %c32_i32 : i32
-    %48 = arith.muli %47, %c32_i32 : i32
-    %49 = arith.cmpi ult, %45, %48 : i32
+    %45 = llvm.load %44 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %46 = arith.addi %43, %c31_i64 : i64
+    %47 = arith.divui %46, %c32_i64 : i64
+    %48 = arith.muli %47, %c32_i64 : i64
+    %49 = arith.cmpi ult, %45, %48 : i64
     scf.if %49 {
-      %50 = func.call @dora_extend_memory(%arg0, %48) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %48, %44 : i32, !llvm.ptr
+      %50 = func.call @dora_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %48, %44 : i64, !llvm.ptr
       %51 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %50, %51 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_ext_code_to_memory(%arg0, %42, %39, %40, %41) : (!llvm.ptr, !llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_ext_code_to_memory(%arg0, %42, %39, %40, %41) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_out_of_bounds.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,34 +138,34 @@ module {
     %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %38 = llvm.load %37 : !llvm.ptr -> i256
     llvm.store %37, %35 : !llvm.ptr, !llvm.ptr
-    %39 = arith.trunci %34 : i256 to i32
-    %40 = arith.trunci %38 : i256 to i32
-    %41 = arith.trunci %30 : i256 to i32
+    %39 = arith.trunci %34 : i256 to i64
+    %40 = arith.trunci %38 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
     %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
     llvm.store %26, %42 {alignment = 1 : i64} : i256, !llvm.ptr
-    %43 = arith.addi %41, %40 : i32
+    %43 = arith.addi %41, %40 : i64
     %44 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %45 = llvm.load %44 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %46 = arith.addi %43, %c31_i32 : i32
-    %47 = arith.divui %46, %c32_i32 : i32
-    %48 = arith.muli %47, %c32_i32 : i32
-    %49 = arith.cmpi ult, %45, %48 : i32
+    %45 = llvm.load %44 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %46 = arith.addi %43, %c31_i64 : i64
+    %47 = arith.divui %46, %c32_i64 : i64
+    %48 = arith.muli %47, %c32_i64 : i64
+    %49 = arith.cmpi ult, %45, %48 : i64
     scf.if %49 {
-      %50 = func.call @dora_extend_memory(%arg0, %48) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %48, %44 : i32, !llvm.ptr
+      %50 = func.call @dora_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %48, %44 : i64, !llvm.ptr
       %51 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %50, %51 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_ext_code_to_memory(%arg0, %42, %39, %40, %41) : (!llvm.ptr, !llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_ext_code_to_memory(%arg0, %42, %39, %40, %41) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_partial.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,34 +138,34 @@ module {
     %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %38 = llvm.load %37 : !llvm.ptr -> i256
     llvm.store %37, %35 : !llvm.ptr, !llvm.ptr
-    %39 = arith.trunci %34 : i256 to i32
-    %40 = arith.trunci %38 : i256 to i32
-    %41 = arith.trunci %30 : i256 to i32
+    %39 = arith.trunci %34 : i256 to i64
+    %40 = arith.trunci %38 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
     %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
     llvm.store %26, %42 {alignment = 1 : i64} : i256, !llvm.ptr
-    %43 = arith.addi %41, %40 : i32
+    %43 = arith.addi %41, %40 : i64
     %44 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %45 = llvm.load %44 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %46 = arith.addi %43, %c31_i32 : i32
-    %47 = arith.divui %46, %c32_i32 : i32
-    %48 = arith.muli %47, %c32_i32 : i32
-    %49 = arith.cmpi ult, %45, %48 : i32
+    %45 = llvm.load %44 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %46 = arith.addi %43, %c31_i64 : i64
+    %47 = arith.divui %46, %c32_i64 : i64
+    %48 = arith.muli %47, %c32_i64 : i64
+    %49 = arith.cmpi ult, %45, %48 : i64
     scf.if %49 {
-      %50 = func.call @dora_extend_memory(%arg0, %48) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %48, %44 : i32, !llvm.ptr
+      %50 = func.call @dora_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %48, %44 : i64, !llvm.ptr
       %51 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %50, %51 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_ext_code_to_memory(%arg0, %42, %39, %40, %41) : (!llvm.ptr, !llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_ext_code_to_memory(%arg0, %42, %39, %40, %41) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -112,9 +111,9 @@ module {
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize_nonexistent.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize_nonexistent.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -112,9 +111,9 @@ module {
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -150,9 +149,9 @@ module {
     llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas_gaslimit.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas_gaslimit.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -150,9 +149,9 @@ module {
     llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jump_invalid_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jump_invalid_jumpdest.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb6
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -119,9 +118,9 @@ module {
     llvm.store %20, %18 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jumpi_valid_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jumpi_valid_jumpdest.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb7
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb5
     cf.switch %10 : i256, [
@@ -134,9 +133,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mload_misze.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mload_misze.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -88,8 +87,8 @@ module {
     ]
   ^bb3:  // pred: ^bb0
     %11 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %12 = llvm.load %11 : !llvm.ptr -> i32
-    %13 = arith.extui %12 : i32 to i256
+    %12 = llvm.load %11 : !llvm.ptr -> i64
+    %13 = arith.extui %12 : i64 to i256
     %14 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     %15 = llvm.load %14 : !llvm.ptr -> !llvm.ptr
     llvm.store %13, %15 : i256, !llvm.ptr
@@ -110,27 +109,27 @@ module {
     %22 = llvm.getelementptr %21[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %23 = llvm.load %22 : !llvm.ptr -> i256
     llvm.store %22, %20 : !llvm.ptr, !llvm.ptr
-    %24 = arith.trunci %23 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %25 = arith.addi %24, %c32_i32 : i32
+    %24 = arith.trunci %23 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %25 = arith.addi %24, %c32_i64 : i64
     %26 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %27 = llvm.load %26 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %28 = arith.addi %25, %c31_i32 : i32
-    %29 = arith.divui %28, %c32_i32_2 : i32
-    %30 = arith.muli %29, %c32_i32_2 : i32
-    %31 = arith.cmpi ult, %27, %30 : i32
+    %27 = llvm.load %26 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %28 = arith.addi %25, %c31_i64 : i64
+    %29 = arith.divui %28, %c32_i64_2 : i64
+    %30 = arith.muli %29, %c32_i64_2 : i64
+    %31 = arith.cmpi ult, %27, %30 : i64
     scf.if %31 {
-      %83 = func.call @dora_extend_memory(%arg0, %30) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %30, %26 : i32, !llvm.ptr
+      %83 = func.call @dora_extend_memory(%arg0, %30) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %30, %26 : i64, !llvm.ptr
       %84 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %83, %84 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %32 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %33 = llvm.load %32 : !llvm.ptr -> !llvm.ptr
-    %34 = llvm.getelementptr %33[%24] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %34 = llvm.getelementptr %33[%24] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %35 = llvm.load %34 {alignment = 1 : i64} : !llvm.ptr -> i256
     %36 = llvm.intr.bswap(%35)  : (i256) -> i256
     %37 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -148,8 +147,8 @@ module {
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
     %44 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %45 = llvm.load %44 : !llvm.ptr -> i32
-    %46 = arith.extui %45 : i32 to i256
+    %45 = llvm.load %44 : !llvm.ptr -> i64
+    %46 = arith.extui %45 : i64 to i256
     %47 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     %48 = llvm.load %47 : !llvm.ptr -> !llvm.ptr
     llvm.store %46, %48 : i256, !llvm.ptr
@@ -170,27 +169,27 @@ module {
     %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %56 = llvm.load %55 : !llvm.ptr -> i256
     llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = arith.trunci %56 : i256 to i32
-    %c32_i32_3 = arith.constant 32 : i32
-    %58 = arith.addi %57, %c32_i32_3 : i32
+    %57 = arith.trunci %56 : i256 to i64
+    %c32_i64_3 = arith.constant 32 : i64
+    %58 = arith.addi %57, %c32_i64_3 : i64
     %59 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %60 = llvm.load %59 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %61 = arith.addi %58, %c31_i32_4 : i32
-    %62 = arith.divui %61, %c32_i32_5 : i32
-    %63 = arith.muli %62, %c32_i32_5 : i32
-    %64 = arith.cmpi ult, %60, %63 : i32
+    %60 = llvm.load %59 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %61 = arith.addi %58, %c31_i64_4 : i64
+    %62 = arith.divui %61, %c32_i64_5 : i64
+    %63 = arith.muli %62, %c32_i64_5 : i64
+    %64 = arith.cmpi ult, %60, %63 : i64
     scf.if %64 {
-      %83 = func.call @dora_extend_memory(%arg0, %63) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %63, %59 : i32, !llvm.ptr
+      %83 = func.call @dora_extend_memory(%arg0, %63) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %63, %59 : i64, !llvm.ptr
       %84 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %83, %84 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %65 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %66 = llvm.load %65 : !llvm.ptr -> !llvm.ptr
-    %67 = llvm.getelementptr %66[%57] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %67 = llvm.getelementptr %66[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %68 = llvm.load %67 {alignment = 1 : i64} : !llvm.ptr -> i256
     %69 = llvm.intr.bswap(%68)  : (i256) -> i256
     %70 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -208,8 +207,8 @@ module {
     cf.br ^bb11
   ^bb11:  // pred: ^bb10
     %77 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i32
-    %79 = arith.extui %78 : i32 to i256
+    %78 = llvm.load %77 : !llvm.ptr -> i64
+    %79 = arith.extui %78 : i64 to i256
     %80 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
     llvm.store %79, %81 : i256, !llvm.ptr
@@ -217,9 +216,9 @@ module {
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,34 +112,34 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %37 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %37 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %38 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %37, %38 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore8.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore8.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -114,33 +113,33 @@ module {
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     %25 = arith.trunci %24 : i256 to i8
-    %26 = arith.trunci %20 : i256 to i32
-    %c1_i32 = arith.constant 1 : i32
-    %27 = arith.addi %26, %c1_i32 : i32
+    %26 = arith.trunci %20 : i256 to i64
+    %c1_i64 = arith.constant 1 : i64
+    %27 = arith.addi %26, %c1_i64 : i64
     %28 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %29 = llvm.load %28 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %30 = arith.addi %27, %c31_i32 : i32
-    %31 = arith.divui %30, %c32_i32 : i32
-    %32 = arith.muli %31, %c32_i32 : i32
-    %33 = arith.cmpi ult, %29, %32 : i32
+    %29 = llvm.load %28 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %30 = arith.addi %27, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64 : i64
+    %32 = arith.muli %31, %c32_i64 : i64
+    %33 = arith.cmpi ult, %29, %32 : i64
     scf.if %33 {
-      %37 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %32, %28 : i32, !llvm.ptr
+      %37 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %32, %28 : i64, !llvm.ptr
       %38 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %37, %38 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %34 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
-    %36 = llvm.getelementptr %35[%26] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %36 = llvm.getelementptr %35[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     llvm.store %25, %36 {alignment = 1 : i64} : i8, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 3 preds: ^bb2, ^bb9, ^bb18
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %159 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %159 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %160 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %159, %160 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,20 +176,20 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %53 : i256 to i32
-    %59 = arith.trunci %57 : i256 to i32
-    %60 = arith.addi %58, %59 : i32
+    %58 = arith.trunci %53 : i256 to i64
+    %59 = arith.trunci %57 : i256 to i64
+    %60 = arith.addi %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32_4 : i32
-    %64 = arith.divui %63, %c32_i32_5 : i32
-    %65 = arith.muli %64, %c32_i32_5 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64_4 : i64
+    %64 = arith.divui %63, %c32_i64_5 : i64
+    %65 = arith.muli %64, %c32_i64_5 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %159 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %159 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %160 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %159, %160 : !llvm.ptr, !llvm.ptr
     } else {
@@ -203,7 +202,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %70 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %69, %70 {alignment = 1 : i64} : i64, !llvm.ptr
-    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %72 = arith.cmpi eq, %c0_i8, %71 : i8
     %73 = llvm.load %67 : !llvm.ptr -> i256
@@ -318,24 +317,24 @@ module {
     cf.cond_br %133, ^bb1, ^bb19
   ^bb19:  // pred: ^bb18
     %134 = arith.trunci %105 : i256 to i64
-    %135 = arith.trunci %117 : i256 to i32
-    %136 = arith.trunci %121 : i256 to i32
-    %137 = arith.trunci %125 : i256 to i32
-    %138 = arith.trunci %129 : i256 to i32
-    %139 = arith.addi %135, %136 : i32
-    %140 = arith.addi %137, %138 : i32
-    %141 = arith.maxui %139, %140 : i32
+    %135 = arith.trunci %117 : i256 to i64
+    %136 = arith.trunci %121 : i256 to i64
+    %137 = arith.trunci %125 : i256 to i64
+    %138 = arith.trunci %129 : i256 to i64
+    %139 = arith.addi %135, %136 : i64
+    %140 = arith.addi %137, %138 : i64
+    %141 = arith.maxui %139, %140 : i64
     %142 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %143 = llvm.load %142 : !llvm.ptr -> i32
-    %c31_i32_12 = arith.constant 31 : i32
-    %c32_i32_13 = arith.constant 32 : i32
-    %144 = arith.addi %141, %c31_i32_12 : i32
-    %145 = arith.divui %144, %c32_i32_13 : i32
-    %146 = arith.muli %145, %c32_i32_13 : i32
-    %147 = arith.cmpi ult, %143, %146 : i32
+    %143 = llvm.load %142 : !llvm.ptr -> i64
+    %c31_i64_12 = arith.constant 31 : i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %144 = arith.addi %141, %c31_i64_12 : i64
+    %145 = arith.divui %144, %c32_i64_13 : i64
+    %146 = arith.muli %145, %c32_i64_13 : i64
+    %147 = arith.cmpi ult, %143, %146 : i64
     scf.if %147 {
-      %159 = func.call @dora_extend_memory(%arg0, %146) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %146, %142 : i32, !llvm.ptr
+      %159 = func.call @dora_extend_memory(%arg0, %146) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %146, %142 : i64, !llvm.ptr
       %160 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %159, %160 : !llvm.ptr, !llvm.ptr
     } else {
@@ -351,7 +350,7 @@ module {
     %c1_i64_16 = arith.constant 1 : i64
     %152 = llvm.alloca %c1_i64_16 x i64 : (i64) -> !llvm.ptr
     %c0_i8_17 = arith.constant 0 : i8
-    %153 = call @dora_call(%arg0, %134, %151, %150, %135, %136, %137, %138, %149, %152, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %153 = call @dora_call(%arg0, %134, %151, %150, %135, %136, %137, %138, %149, %152, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %154 = llvm.load %152 : !llvm.ptr -> i64
     %155 = arith.extui %153 : i8 to i256
     %156 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -361,9 +360,9 @@ module {
     llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb20:  // pred: ^bb19
-    %c0_i32_18 = arith.constant 0 : i32
+    %c0_i64_18 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_18, %c0_i32_18, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_18, %c0_i64_18, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 4 preds: ^bb2, ^bb9, ^bb18, ^bb27
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %241 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %241 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %242 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %241, %242 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,20 +176,20 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %53 : i256 to i32
-    %59 = arith.trunci %57 : i256 to i32
-    %60 = arith.addi %58, %59 : i32
+    %58 = arith.trunci %53 : i256 to i64
+    %59 = arith.trunci %57 : i256 to i64
+    %60 = arith.addi %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32_4 : i32
-    %64 = arith.divui %63, %c32_i32_5 : i32
-    %65 = arith.muli %64, %c32_i32_5 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64_4 : i64
+    %64 = arith.divui %63, %c32_i64_5 : i64
+    %65 = arith.muli %64, %c32_i64_5 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %241 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %241 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %242 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %241, %242 : !llvm.ptr, !llvm.ptr
     } else {
@@ -203,7 +202,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %70 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %69, %70 {alignment = 1 : i64} : i64, !llvm.ptr
-    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %72 = arith.cmpi eq, %c0_i8, %71 : i8
     %73 = llvm.load %67 : !llvm.ptr -> i256
@@ -318,24 +317,24 @@ module {
     cf.cond_br %133, ^bb1, ^bb19
   ^bb19:  // pred: ^bb18
     %134 = arith.trunci %105 : i256 to i64
-    %135 = arith.trunci %117 : i256 to i32
-    %136 = arith.trunci %121 : i256 to i32
-    %137 = arith.trunci %125 : i256 to i32
-    %138 = arith.trunci %129 : i256 to i32
-    %139 = arith.addi %135, %136 : i32
-    %140 = arith.addi %137, %138 : i32
-    %141 = arith.maxui %139, %140 : i32
+    %135 = arith.trunci %117 : i256 to i64
+    %136 = arith.trunci %121 : i256 to i64
+    %137 = arith.trunci %125 : i256 to i64
+    %138 = arith.trunci %129 : i256 to i64
+    %139 = arith.addi %135, %136 : i64
+    %140 = arith.addi %137, %138 : i64
+    %141 = arith.maxui %139, %140 : i64
     %142 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %143 = llvm.load %142 : !llvm.ptr -> i32
-    %c31_i32_12 = arith.constant 31 : i32
-    %c32_i32_13 = arith.constant 32 : i32
-    %144 = arith.addi %141, %c31_i32_12 : i32
-    %145 = arith.divui %144, %c32_i32_13 : i32
-    %146 = arith.muli %145, %c32_i32_13 : i32
-    %147 = arith.cmpi ult, %143, %146 : i32
+    %143 = llvm.load %142 : !llvm.ptr -> i64
+    %c31_i64_12 = arith.constant 31 : i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %144 = arith.addi %141, %c31_i64_12 : i64
+    %145 = arith.divui %144, %c32_i64_13 : i64
+    %146 = arith.muli %145, %c32_i64_13 : i64
+    %147 = arith.cmpi ult, %143, %146 : i64
     scf.if %147 {
-      %241 = func.call @dora_extend_memory(%arg0, %146) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %146, %142 : i32, !llvm.ptr
+      %241 = func.call @dora_extend_memory(%arg0, %146) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %146, %142 : i64, !llvm.ptr
       %242 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %241, %242 : !llvm.ptr, !llvm.ptr
     } else {
@@ -351,7 +350,7 @@ module {
     %c1_i64_16 = arith.constant 1 : i64
     %152 = llvm.alloca %c1_i64_16 x i64 : (i64) -> !llvm.ptr
     %c0_i8_17 = arith.constant 0 : i8
-    %153 = call @dora_call(%arg0, %134, %151, %150, %135, %136, %137, %138, %149, %152, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %153 = call @dora_call(%arg0, %134, %151, %150, %135, %136, %137, %138, %149, %152, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %154 = llvm.load %152 : !llvm.ptr -> i64
     %155 = arith.extui %153 : i8 to i256
     %156 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -463,24 +462,24 @@ module {
     cf.cond_br %215, ^bb1, ^bb28
   ^bb28:  // pred: ^bb27
     %216 = arith.trunci %187 : i256 to i64
-    %217 = arith.trunci %199 : i256 to i32
-    %218 = arith.trunci %203 : i256 to i32
-    %219 = arith.trunci %207 : i256 to i32
-    %220 = arith.trunci %211 : i256 to i32
-    %221 = arith.addi %217, %218 : i32
-    %222 = arith.addi %219, %220 : i32
-    %223 = arith.maxui %221, %222 : i32
+    %217 = arith.trunci %199 : i256 to i64
+    %218 = arith.trunci %203 : i256 to i64
+    %219 = arith.trunci %207 : i256 to i64
+    %220 = arith.trunci %211 : i256 to i64
+    %221 = arith.addi %217, %218 : i64
+    %222 = arith.addi %219, %220 : i64
+    %223 = arith.maxui %221, %222 : i64
     %224 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %225 = llvm.load %224 : !llvm.ptr -> i32
-    %c31_i32_24 = arith.constant 31 : i32
-    %c32_i32_25 = arith.constant 32 : i32
-    %226 = arith.addi %223, %c31_i32_24 : i32
-    %227 = arith.divui %226, %c32_i32_25 : i32
-    %228 = arith.muli %227, %c32_i32_25 : i32
-    %229 = arith.cmpi ult, %225, %228 : i32
+    %225 = llvm.load %224 : !llvm.ptr -> i64
+    %c31_i64_24 = arith.constant 31 : i64
+    %c32_i64_25 = arith.constant 32 : i64
+    %226 = arith.addi %223, %c31_i64_24 : i64
+    %227 = arith.divui %226, %c32_i64_25 : i64
+    %228 = arith.muli %227, %c32_i64_25 : i64
+    %229 = arith.cmpi ult, %225, %228 : i64
     scf.if %229 {
-      %241 = func.call @dora_extend_memory(%arg0, %228) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %228, %224 : i32, !llvm.ptr
+      %241 = func.call @dora_extend_memory(%arg0, %228) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %228, %224 : i64, !llvm.ptr
       %242 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %241, %242 : !llvm.ptr, !llvm.ptr
     } else {
@@ -496,7 +495,7 @@ module {
     %c1_i64_28 = arith.constant 1 : i64
     %234 = llvm.alloca %c1_i64_28 x i64 : (i64) -> !llvm.ptr
     %c0_i8_29 = arith.constant 0 : i8
-    %235 = call @dora_call(%arg0, %216, %233, %232, %217, %218, %219, %220, %231, %234, %c0_i8_29) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %235 = call @dora_call(%arg0, %216, %233, %232, %217, %218, %219, %220, %231, %234, %c0_i8_29) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %236 = llvm.load %234 : !llvm.ptr -> i64
     %237 = arith.extui %235 : i8 to i256
     %238 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -506,9 +505,9 @@ module {
     llvm.store %240, %238 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i32_30 = arith.constant 0 : i32
+    %c0_i64_30 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_30, %c0_i32_30, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_30, %c0_i64_30, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 4 preds: ^bb2, ^bb9, ^bb18, ^bb30
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %258 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %258 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %259 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %258, %259 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,20 +176,20 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %53 : i256 to i32
-    %59 = arith.trunci %57 : i256 to i32
-    %60 = arith.addi %58, %59 : i32
+    %58 = arith.trunci %53 : i256 to i64
+    %59 = arith.trunci %57 : i256 to i64
+    %60 = arith.addi %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32_4 : i32
-    %64 = arith.divui %63, %c32_i32_5 : i32
-    %65 = arith.muli %64, %c32_i32_5 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64_4 : i64
+    %64 = arith.divui %63, %c32_i64_5 : i64
+    %65 = arith.muli %64, %c32_i64_5 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %258 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %258 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %259 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %258, %259 : !llvm.ptr, !llvm.ptr
     } else {
@@ -203,7 +202,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %70 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %69, %70 {alignment = 1 : i64} : i64, !llvm.ptr
-    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %72 = arith.cmpi eq, %c0_i8, %71 : i8
     %73 = llvm.load %67 : !llvm.ptr -> i256
@@ -318,24 +317,24 @@ module {
     cf.cond_br %133, ^bb1, ^bb19
   ^bb19:  // pred: ^bb18
     %134 = arith.trunci %105 : i256 to i64
-    %135 = arith.trunci %117 : i256 to i32
-    %136 = arith.trunci %121 : i256 to i32
-    %137 = arith.trunci %125 : i256 to i32
-    %138 = arith.trunci %129 : i256 to i32
-    %139 = arith.addi %135, %136 : i32
-    %140 = arith.addi %137, %138 : i32
-    %141 = arith.maxui %139, %140 : i32
+    %135 = arith.trunci %117 : i256 to i64
+    %136 = arith.trunci %121 : i256 to i64
+    %137 = arith.trunci %125 : i256 to i64
+    %138 = arith.trunci %129 : i256 to i64
+    %139 = arith.addi %135, %136 : i64
+    %140 = arith.addi %137, %138 : i64
+    %141 = arith.maxui %139, %140 : i64
     %142 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %143 = llvm.load %142 : !llvm.ptr -> i32
-    %c31_i32_12 = arith.constant 31 : i32
-    %c32_i32_13 = arith.constant 32 : i32
-    %144 = arith.addi %141, %c31_i32_12 : i32
-    %145 = arith.divui %144, %c32_i32_13 : i32
-    %146 = arith.muli %145, %c32_i32_13 : i32
-    %147 = arith.cmpi ult, %143, %146 : i32
+    %143 = llvm.load %142 : !llvm.ptr -> i64
+    %c31_i64_12 = arith.constant 31 : i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %144 = arith.addi %141, %c31_i64_12 : i64
+    %145 = arith.divui %144, %c32_i64_13 : i64
+    %146 = arith.muli %145, %c32_i64_13 : i64
+    %147 = arith.cmpi ult, %143, %146 : i64
     scf.if %147 {
-      %258 = func.call @dora_extend_memory(%arg0, %146) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %146, %142 : i32, !llvm.ptr
+      %258 = func.call @dora_extend_memory(%arg0, %146) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %146, %142 : i64, !llvm.ptr
       %259 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %258, %259 : !llvm.ptr, !llvm.ptr
     } else {
@@ -351,7 +350,7 @@ module {
     %c1_i64_16 = arith.constant 1 : i64
     %152 = llvm.alloca %c1_i64_16 x i64 : (i64) -> !llvm.ptr
     %c0_i8_17 = arith.constant 0 : i8
-    %153 = call @dora_call(%arg0, %134, %151, %150, %135, %136, %137, %138, %149, %152, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %153 = call @dora_call(%arg0, %134, %151, %150, %135, %136, %137, %138, %149, %152, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %154 = llvm.load %152 : !llvm.ptr -> i64
     %155 = arith.extui %153 : i8 to i256
     %156 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -498,24 +497,24 @@ module {
     cf.cond_br %232, ^bb1, ^bb31
   ^bb31:  // pred: ^bb30
     %233 = arith.trunci %204 : i256 to i64
-    %234 = arith.trunci %216 : i256 to i32
-    %235 = arith.trunci %220 : i256 to i32
-    %236 = arith.trunci %224 : i256 to i32
-    %237 = arith.trunci %228 : i256 to i32
-    %238 = arith.addi %234, %235 : i32
-    %239 = arith.addi %236, %237 : i32
-    %240 = arith.maxui %238, %239 : i32
+    %234 = arith.trunci %216 : i256 to i64
+    %235 = arith.trunci %220 : i256 to i64
+    %236 = arith.trunci %224 : i256 to i64
+    %237 = arith.trunci %228 : i256 to i64
+    %238 = arith.addi %234, %235 : i64
+    %239 = arith.addi %236, %237 : i64
+    %240 = arith.maxui %238, %239 : i64
     %241 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %242 = llvm.load %241 : !llvm.ptr -> i32
-    %c31_i32_28 = arith.constant 31 : i32
-    %c32_i32_29 = arith.constant 32 : i32
-    %243 = arith.addi %240, %c31_i32_28 : i32
-    %244 = arith.divui %243, %c32_i32_29 : i32
-    %245 = arith.muli %244, %c32_i32_29 : i32
-    %246 = arith.cmpi ult, %242, %245 : i32
+    %242 = llvm.load %241 : !llvm.ptr -> i64
+    %c31_i64_28 = arith.constant 31 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %243 = arith.addi %240, %c31_i64_28 : i64
+    %244 = arith.divui %243, %c32_i64_29 : i64
+    %245 = arith.muli %244, %c32_i64_29 : i64
+    %246 = arith.cmpi ult, %242, %245 : i64
     scf.if %246 {
-      %258 = func.call @dora_extend_memory(%arg0, %245) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %245, %241 : i32, !llvm.ptr
+      %258 = func.call @dora_extend_memory(%arg0, %245) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %245, %241 : i64, !llvm.ptr
       %259 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %258, %259 : !llvm.ptr, !llvm.ptr
     } else {
@@ -531,7 +530,7 @@ module {
     %c1_i64_32 = arith.constant 1 : i64
     %251 = llvm.alloca %c1_i64_32 x i64 : (i64) -> !llvm.ptr
     %c0_i8_33 = arith.constant 0 : i8
-    %252 = call @dora_call(%arg0, %233, %250, %249, %234, %235, %236, %237, %248, %251, %c0_i8_33) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %252 = call @dora_call(%arg0, %233, %250, %249, %234, %235, %236, %237, %248, %251, %c0_i8_33) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %253 = llvm.load %251 : !llvm.ptr -> i64
     %254 = arith.extui %252 : i8 to i256
     %255 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -541,9 +540,9 @@ module {
     llvm.store %257, %255 : !llvm.ptr, !llvm.ptr
     cf.br ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i32_34 = arith.constant 0 : i32
+    %c0_i64_34 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_34, %c0_i32_34, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_34, %c0_i64_34, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb9
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %239 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %239 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %240 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %239, %240 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,20 +176,20 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %53 : i256 to i32
-    %59 = arith.trunci %57 : i256 to i32
-    %60 = arith.addi %58, %59 : i32
+    %58 = arith.trunci %53 : i256 to i64
+    %59 = arith.trunci %57 : i256 to i64
+    %60 = arith.addi %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32_4 : i32
-    %64 = arith.divui %63, %c32_i32_5 : i32
-    %65 = arith.muli %64, %c32_i32_5 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64_4 : i64
+    %64 = arith.divui %63, %c32_i64_5 : i64
+    %65 = arith.muli %64, %c32_i64_5 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %239 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %239 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %240 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %239, %240 : !llvm.ptr, !llvm.ptr
     } else {
@@ -203,7 +202,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %70 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %69, %70 {alignment = 1 : i64} : i64, !llvm.ptr
-    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %72 = arith.cmpi eq, %c0_i8, %71 : i8
     %73 = llvm.load %67 : !llvm.ptr -> i256
@@ -307,24 +306,24 @@ module {
     llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
     %c0_i256_11 = arith.constant 0 : i256
     %126 = arith.trunci %105 : i256 to i64
-    %127 = arith.trunci %113 : i256 to i32
-    %128 = arith.trunci %117 : i256 to i32
-    %129 = arith.trunci %121 : i256 to i32
-    %130 = arith.trunci %125 : i256 to i32
-    %131 = arith.addi %127, %128 : i32
-    %132 = arith.addi %129, %130 : i32
-    %133 = arith.maxui %131, %132 : i32
+    %127 = arith.trunci %113 : i256 to i64
+    %128 = arith.trunci %117 : i256 to i64
+    %129 = arith.trunci %121 : i256 to i64
+    %130 = arith.trunci %125 : i256 to i64
+    %131 = arith.addi %127, %128 : i64
+    %132 = arith.addi %129, %130 : i64
+    %133 = arith.maxui %131, %132 : i64
     %134 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %135 = llvm.load %134 : !llvm.ptr -> i32
-    %c31_i32_12 = arith.constant 31 : i32
-    %c32_i32_13 = arith.constant 32 : i32
-    %136 = arith.addi %133, %c31_i32_12 : i32
-    %137 = arith.divui %136, %c32_i32_13 : i32
-    %138 = arith.muli %137, %c32_i32_13 : i32
-    %139 = arith.cmpi ult, %135, %138 : i32
+    %135 = llvm.load %134 : !llvm.ptr -> i64
+    %c31_i64_12 = arith.constant 31 : i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %136 = arith.addi %133, %c31_i64_12 : i64
+    %137 = arith.divui %136, %c32_i64_13 : i64
+    %138 = arith.muli %137, %c32_i64_13 : i64
+    %139 = arith.cmpi ult, %135, %138 : i64
     scf.if %139 {
-      %239 = func.call @dora_extend_memory(%arg0, %138) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %138, %134 : i32, !llvm.ptr
+      %239 = func.call @dora_extend_memory(%arg0, %138) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %138, %134 : i64, !llvm.ptr
       %240 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %239, %240 : !llvm.ptr, !llvm.ptr
     } else {
@@ -340,7 +339,7 @@ module {
     %c1_i64_16 = arith.constant 1 : i64
     %144 = llvm.alloca %c1_i64_16 x i64 : (i64) -> !llvm.ptr
     %c0_i8_17 = arith.constant 0 : i8
-    %145 = call @dora_call(%arg0, %126, %143, %142, %127, %128, %129, %130, %141, %144, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %145 = call @dora_call(%arg0, %126, %143, %142, %127, %128, %129, %130, %141, %144, %c0_i8_17) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %146 = llvm.load %144 : !llvm.ptr -> i64
     %147 = arith.extui %145 : i8 to i256
     %148 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -468,24 +467,24 @@ module {
     llvm.store %212, %210 : !llvm.ptr, !llvm.ptr
     %c0_i256_26 = arith.constant 0 : i256
     %214 = arith.trunci %193 : i256 to i64
-    %215 = arith.trunci %201 : i256 to i32
-    %216 = arith.trunci %205 : i256 to i32
-    %217 = arith.trunci %209 : i256 to i32
-    %218 = arith.trunci %213 : i256 to i32
-    %219 = arith.addi %215, %216 : i32
-    %220 = arith.addi %217, %218 : i32
-    %221 = arith.maxui %219, %220 : i32
+    %215 = arith.trunci %201 : i256 to i64
+    %216 = arith.trunci %205 : i256 to i64
+    %217 = arith.trunci %209 : i256 to i64
+    %218 = arith.trunci %213 : i256 to i64
+    %219 = arith.addi %215, %216 : i64
+    %220 = arith.addi %217, %218 : i64
+    %221 = arith.maxui %219, %220 : i64
     %222 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %223 = llvm.load %222 : !llvm.ptr -> i32
-    %c31_i32_27 = arith.constant 31 : i32
-    %c32_i32_28 = arith.constant 32 : i32
-    %224 = arith.addi %221, %c31_i32_27 : i32
-    %225 = arith.divui %224, %c32_i32_28 : i32
-    %226 = arith.muli %225, %c32_i32_28 : i32
-    %227 = arith.cmpi ult, %223, %226 : i32
+    %223 = llvm.load %222 : !llvm.ptr -> i64
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %224 = arith.addi %221, %c31_i64_27 : i64
+    %225 = arith.divui %224, %c32_i64_28 : i64
+    %226 = arith.muli %225, %c32_i64_28 : i64
+    %227 = arith.cmpi ult, %223, %226 : i64
     scf.if %227 {
-      %239 = func.call @dora_extend_memory(%arg0, %226) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %226, %222 : i32, !llvm.ptr
+      %239 = func.call @dora_extend_memory(%arg0, %226) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %226, %222 : i64, !llvm.ptr
       %240 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %239, %240 : !llvm.ptr, !llvm.ptr
     } else {
@@ -501,7 +500,7 @@ module {
     %c1_i64_31 = arith.constant 1 : i64
     %232 = llvm.alloca %c1_i64_31 x i64 : (i64) -> !llvm.ptr
     %c0_i8_32 = arith.constant 0 : i8
-    %233 = call @dora_call(%arg0, %214, %231, %230, %215, %216, %217, %218, %229, %232, %c0_i8_32) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %233 = call @dora_call(%arg0, %214, %231, %230, %215, %216, %217, %218, %229, %232, %c0_i8_32) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %234 = llvm.load %232 : !llvm.ptr -> i64
     %235 = arith.extui %233 : i8 to i256
     %236 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -511,9 +510,9 @@ module {
     llvm.store %238, %236 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i32_33 = arith.constant 0 : i32
+    %c0_i64_33 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_33, %c0_i32_33, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_33, %c0_i64_33, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb12
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %198 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %198 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %199 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %198, %199 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,27 +163,27 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %c32_i32_4 = arith.constant 32 : i32
-    %52 = arith.addi %51, %c32_i32_4 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c32_i64_4 : i64
     %53 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %55 = arith.addi %52, %c31_i32_5 : i32
-    %56 = arith.divui %55, %c32_i32_6 : i32
-    %57 = arith.muli %56, %c32_i32_6 : i32
-    %58 = arith.cmpi ult, %54, %57 : i32
+    %54 = llvm.load %53 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %55 = arith.addi %52, %c31_i64_5 : i64
+    %56 = arith.divui %55, %c32_i64_6 : i64
+    %57 = arith.muli %56, %c32_i64_6 : i64
+    %58 = arith.cmpi ult, %54, %57 : i64
     scf.if %58 {
-      %198 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %57, %53 : i32, !llvm.ptr
+      %198 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %57, %53 : i64, !llvm.ptr
       %199 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %198, %199 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
-    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %62 = llvm.intr.bswap(%50)  : (i256) -> i256
     llvm.store %62, %61 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb9
@@ -228,20 +227,20 @@ module {
     %82 = llvm.getelementptr %81[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %83 = llvm.load %82 : !llvm.ptr -> i256
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    %84 = arith.trunci %79 : i256 to i32
-    %85 = arith.trunci %83 : i256 to i32
-    %86 = arith.addi %84, %85 : i32
+    %84 = arith.trunci %79 : i256 to i64
+    %85 = arith.trunci %83 : i256 to i64
+    %86 = arith.addi %84, %85 : i64
     %87 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %88 = llvm.load %87 : !llvm.ptr -> i32
-    %c31_i32_9 = arith.constant 31 : i32
-    %c32_i32_10 = arith.constant 32 : i32
-    %89 = arith.addi %86, %c31_i32_9 : i32
-    %90 = arith.divui %89, %c32_i32_10 : i32
-    %91 = arith.muli %90, %c32_i32_10 : i32
-    %92 = arith.cmpi ult, %88, %91 : i32
+    %88 = llvm.load %87 : !llvm.ptr -> i64
+    %c31_i64_9 = arith.constant 31 : i64
+    %c32_i64_10 = arith.constant 32 : i64
+    %89 = arith.addi %86, %c31_i64_9 : i64
+    %90 = arith.divui %89, %c32_i64_10 : i64
+    %91 = arith.muli %90, %c32_i64_10 : i64
+    %92 = arith.cmpi ult, %88, %91 : i64
     scf.if %92 {
-      %198 = func.call @dora_extend_memory(%arg0, %91) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %91, %87 : i32, !llvm.ptr
+      %198 = func.call @dora_extend_memory(%arg0, %91) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %91, %87 : i64, !llvm.ptr
       %199 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %198, %199 : !llvm.ptr, !llvm.ptr
     } else {
@@ -254,7 +253,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %96 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %95, %96 {alignment = 1 : i64} : i64, !llvm.ptr
-    %97 = call @dora_create(%arg0, %85, %84, %93, %96) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %97 = call @dora_create(%arg0, %85, %84, %93, %96) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %98 = arith.cmpi eq, %c0_i8, %97 : i8
     %99 = llvm.load %93 : !llvm.ptr -> i256
@@ -293,27 +292,27 @@ module {
     %115 = llvm.getelementptr %114[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %116 = llvm.load %115 : !llvm.ptr -> i256
     llvm.store %115, %113 : !llvm.ptr, !llvm.ptr
-    %117 = arith.trunci %112 : i256 to i32
-    %c32_i32_13 = arith.constant 32 : i32
-    %118 = arith.addi %117, %c32_i32_13 : i32
+    %117 = arith.trunci %112 : i256 to i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %118 = arith.addi %117, %c32_i64_13 : i64
     %119 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %120 = llvm.load %119 : !llvm.ptr -> i32
-    %c31_i32_14 = arith.constant 31 : i32
-    %c32_i32_15 = arith.constant 32 : i32
-    %121 = arith.addi %118, %c31_i32_14 : i32
-    %122 = arith.divui %121, %c32_i32_15 : i32
-    %123 = arith.muli %122, %c32_i32_15 : i32
-    %124 = arith.cmpi ult, %120, %123 : i32
+    %120 = llvm.load %119 : !llvm.ptr -> i64
+    %c31_i64_14 = arith.constant 31 : i64
+    %c32_i64_15 = arith.constant 32 : i64
+    %121 = arith.addi %118, %c31_i64_14 : i64
+    %122 = arith.divui %121, %c32_i64_15 : i64
+    %123 = arith.muli %122, %c32_i64_15 : i64
+    %124 = arith.cmpi ult, %120, %123 : i64
     scf.if %124 {
-      %198 = func.call @dora_extend_memory(%arg0, %123) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %123, %119 : i32, !llvm.ptr
+      %198 = func.call @dora_extend_memory(%arg0, %123) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %123, %119 : i64, !llvm.ptr
       %199 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %198, %199 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %125 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %126 = llvm.load %125 : !llvm.ptr -> !llvm.ptr
-    %127 = llvm.getelementptr %126[%117] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %127 = llvm.getelementptr %126[%117] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %128 = llvm.intr.bswap(%116)  : (i256) -> i256
     llvm.store %128, %127 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb17
@@ -344,27 +343,27 @@ module {
     %141 = llvm.getelementptr %140[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %142 = llvm.load %141 : !llvm.ptr -> i256
     llvm.store %141, %139 : !llvm.ptr, !llvm.ptr
-    %143 = arith.trunci %138 : i256 to i32
-    %c32_i32_18 = arith.constant 32 : i32
-    %144 = arith.addi %143, %c32_i32_18 : i32
+    %143 = arith.trunci %138 : i256 to i64
+    %c32_i64_18 = arith.constant 32 : i64
+    %144 = arith.addi %143, %c32_i64_18 : i64
     %145 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %146 = llvm.load %145 : !llvm.ptr -> i32
-    %c31_i32_19 = arith.constant 31 : i32
-    %c32_i32_20 = arith.constant 32 : i32
-    %147 = arith.addi %144, %c31_i32_19 : i32
-    %148 = arith.divui %147, %c32_i32_20 : i32
-    %149 = arith.muli %148, %c32_i32_20 : i32
-    %150 = arith.cmpi ult, %146, %149 : i32
+    %146 = llvm.load %145 : !llvm.ptr -> i64
+    %c31_i64_19 = arith.constant 31 : i64
+    %c32_i64_20 = arith.constant 32 : i64
+    %147 = arith.addi %144, %c31_i64_19 : i64
+    %148 = arith.divui %147, %c32_i64_20 : i64
+    %149 = arith.muli %148, %c32_i64_20 : i64
+    %150 = arith.cmpi ult, %146, %149 : i64
     scf.if %150 {
-      %198 = func.call @dora_extend_memory(%arg0, %149) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %149, %145 : i32, !llvm.ptr
+      %198 = func.call @dora_extend_memory(%arg0, %149) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %149, %145 : i64, !llvm.ptr
       %199 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %198, %199 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %151 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %152 = llvm.load %151 : !llvm.ptr -> !llvm.ptr
-    %153 = llvm.getelementptr %152[%143] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %153 = llvm.getelementptr %152[%143] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %154 = llvm.intr.bswap(%142)  : (i256) -> i256
     llvm.store %154, %153 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb20
@@ -424,34 +423,34 @@ module {
     %185 = llvm.getelementptr %184[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %186 = llvm.load %185 : !llvm.ptr -> i256
     llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
-    %187 = arith.trunci %182 : i256 to i32
-    %188 = arith.trunci %186 : i256 to i32
-    %189 = arith.trunci %178 : i256 to i32
+    %187 = arith.trunci %182 : i256 to i64
+    %188 = arith.trunci %186 : i256 to i64
+    %189 = arith.trunci %178 : i256 to i64
     %c1_i256_24 = arith.constant 1 : i256
     %190 = llvm.alloca %c1_i256_24 x i256 : (i256) -> !llvm.ptr
     llvm.store %174, %190 {alignment = 1 : i64} : i256, !llvm.ptr
-    %191 = arith.addi %189, %188 : i32
+    %191 = arith.addi %189, %188 : i64
     %192 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %193 = llvm.load %192 : !llvm.ptr -> i32
-    %c31_i32_25 = arith.constant 31 : i32
-    %c32_i32_26 = arith.constant 32 : i32
-    %194 = arith.addi %191, %c31_i32_25 : i32
-    %195 = arith.divui %194, %c32_i32_26 : i32
-    %196 = arith.muli %195, %c32_i32_26 : i32
-    %197 = arith.cmpi ult, %193, %196 : i32
+    %193 = llvm.load %192 : !llvm.ptr -> i64
+    %c31_i64_25 = arith.constant 31 : i64
+    %c32_i64_26 = arith.constant 32 : i64
+    %194 = arith.addi %191, %c31_i64_25 : i64
+    %195 = arith.divui %194, %c32_i64_26 : i64
+    %196 = arith.muli %195, %c32_i64_26 : i64
+    %197 = arith.cmpi ult, %193, %196 : i64
     scf.if %197 {
-      %198 = func.call @dora_extend_memory(%arg0, %196) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %196, %192 : i32, !llvm.ptr
+      %198 = func.call @dora_extend_memory(%arg0, %196) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %196, %192 : i64, !llvm.ptr
       %199 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %198, %199 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_ext_code_to_memory(%arg0, %190, %187, %188, %189) : (!llvm.ptr, !llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_ext_code_to_memory(%arg0, %190, %187, %188, %189) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %c0_i32_27 = arith.constant 0 : i32
+    %c0_i64_27 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_27, %c0_i32_27, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_27, %c0_i64_27, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb9
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %86 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %86 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %87 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %86, %87 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,20 +176,20 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %53 : i256 to i32
-    %59 = arith.trunci %57 : i256 to i32
-    %60 = arith.addi %58, %59 : i32
+    %58 = arith.trunci %53 : i256 to i64
+    %59 = arith.trunci %57 : i256 to i64
+    %60 = arith.addi %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32_5 : i32
-    %64 = arith.divui %63, %c32_i32_6 : i32
-    %65 = arith.muli %64, %c32_i32_6 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64_5 : i64
+    %64 = arith.divui %63, %c32_i64_6 : i64
+    %65 = arith.muli %64, %c32_i64_6 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %86 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %86 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %87 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %86, %87 : !llvm.ptr, !llvm.ptr
     } else {
@@ -203,7 +202,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %70 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %69, %70 {alignment = 1 : i64} : i64, !llvm.ptr
-    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %71 = call @dora_create(%arg0, %59, %58, %67, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %72 = arith.cmpi eq, %c0_i8, %71 : i8
     %73 = llvm.load %67 : !llvm.ptr -> i256
@@ -233,9 +232,9 @@ module {
     llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i32_8 = arith.constant 0 : i32
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_8, %c0_i32_8, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_8, %c0_i64_8, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb12
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %113 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %113 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %114 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %113, %114 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,27 +163,27 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %c32_i32_4 = arith.constant 32 : i32
-    %52 = arith.addi %51, %c32_i32_4 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c32_i64_4 : i64
     %53 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %55 = arith.addi %52, %c31_i32_5 : i32
-    %56 = arith.divui %55, %c32_i32_6 : i32
-    %57 = arith.muli %56, %c32_i32_6 : i32
-    %58 = arith.cmpi ult, %54, %57 : i32
+    %54 = llvm.load %53 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %55 = arith.addi %52, %c31_i64_5 : i64
+    %56 = arith.divui %55, %c32_i64_6 : i64
+    %57 = arith.muli %56, %c32_i64_6 : i64
+    %58 = arith.cmpi ult, %54, %57 : i64
     scf.if %58 {
-      %113 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %57, %53 : i32, !llvm.ptr
+      %113 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %57, %53 : i64, !llvm.ptr
       %114 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %113, %114 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
-    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %62 = llvm.intr.bswap(%50)  : (i256) -> i256
     llvm.store %62, %61 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb9
@@ -228,20 +227,20 @@ module {
     %82 = llvm.getelementptr %81[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %83 = llvm.load %82 : !llvm.ptr -> i256
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    %84 = arith.trunci %79 : i256 to i32
-    %85 = arith.trunci %83 : i256 to i32
-    %86 = arith.addi %84, %85 : i32
+    %84 = arith.trunci %79 : i256 to i64
+    %85 = arith.trunci %83 : i256 to i64
+    %86 = arith.addi %84, %85 : i64
     %87 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %88 = llvm.load %87 : !llvm.ptr -> i32
-    %c31_i32_9 = arith.constant 31 : i32
-    %c32_i32_10 = arith.constant 32 : i32
-    %89 = arith.addi %86, %c31_i32_9 : i32
-    %90 = arith.divui %89, %c32_i32_10 : i32
-    %91 = arith.muli %90, %c32_i32_10 : i32
-    %92 = arith.cmpi ult, %88, %91 : i32
+    %88 = llvm.load %87 : !llvm.ptr -> i64
+    %c31_i64_9 = arith.constant 31 : i64
+    %c32_i64_10 = arith.constant 32 : i64
+    %89 = arith.addi %86, %c31_i64_9 : i64
+    %90 = arith.divui %89, %c32_i64_10 : i64
+    %91 = arith.muli %90, %c32_i64_10 : i64
+    %92 = arith.cmpi ult, %88, %91 : i64
     scf.if %92 {
-      %113 = func.call @dora_extend_memory(%arg0, %91) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %91, %87 : i32, !llvm.ptr
+      %113 = func.call @dora_extend_memory(%arg0, %91) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %91, %87 : i64, !llvm.ptr
       %114 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %113, %114 : !llvm.ptr, !llvm.ptr
     } else {
@@ -254,7 +253,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %96 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %95, %96 {alignment = 1 : i64} : i64, !llvm.ptr
-    %97 = call @dora_create(%arg0, %85, %84, %93, %96) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %97 = call @dora_create(%arg0, %85, %84, %93, %96) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %98 = arith.cmpi eq, %c0_i8, %97 : i8
     %99 = llvm.load %93 : !llvm.ptr -> i256
@@ -284,9 +283,9 @@ module {
     llvm.store %112, %110 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
-    %c0_i32_12 = arith.constant 0 : i32
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_12, %c0_i32_12, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_12, %c0_i64_12, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb15
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %317 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,27 +163,27 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %c32_i32_3 = arith.constant 32 : i32
-    %52 = arith.addi %51, %c32_i32_3 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %c32_i64_3 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c32_i64_3 : i64
     %53 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %55 = arith.addi %52, %c31_i32_4 : i32
-    %56 = arith.divui %55, %c32_i32_5 : i32
-    %57 = arith.muli %56, %c32_i32_5 : i32
-    %58 = arith.cmpi ult, %54, %57 : i32
+    %54 = llvm.load %53 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %55 = arith.addi %52, %c31_i64_4 : i64
+    %56 = arith.divui %55, %c32_i64_5 : i64
+    %57 = arith.muli %56, %c32_i64_5 : i64
+    %58 = arith.cmpi ult, %54, %57 : i64
     scf.if %58 {
-      %317 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %57, %53 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %57, %53 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
-    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %62 = llvm.intr.bswap(%50)  : (i256) -> i256
     llvm.store %62, %61 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb9
@@ -215,27 +214,27 @@ module {
     %75 = llvm.getelementptr %74[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %76 = llvm.load %75 : !llvm.ptr -> i256
     llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
-    %77 = arith.trunci %72 : i256 to i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %78 = arith.addi %77, %c32_i32_6 : i32
+    %77 = arith.trunci %72 : i256 to i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %78 = arith.addi %77, %c32_i64_6 : i64
     %79 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %80 = llvm.load %79 : !llvm.ptr -> i32
-    %c31_i32_7 = arith.constant 31 : i32
-    %c32_i32_8 = arith.constant 32 : i32
-    %81 = arith.addi %78, %c31_i32_7 : i32
-    %82 = arith.divui %81, %c32_i32_8 : i32
-    %83 = arith.muli %82, %c32_i32_8 : i32
-    %84 = arith.cmpi ult, %80, %83 : i32
+    %80 = llvm.load %79 : !llvm.ptr -> i64
+    %c31_i64_7 = arith.constant 31 : i64
+    %c32_i64_8 = arith.constant 32 : i64
+    %81 = arith.addi %78, %c31_i64_7 : i64
+    %82 = arith.divui %81, %c32_i64_8 : i64
+    %83 = arith.muli %82, %c32_i64_8 : i64
+    %84 = arith.cmpi ult, %80, %83 : i64
     scf.if %84 {
-      %317 = func.call @dora_extend_memory(%arg0, %83) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %83, %79 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %83) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %83, %79 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %85 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
-    %87 = llvm.getelementptr %86[%77] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %87 = llvm.getelementptr %86[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %88 = llvm.intr.bswap(%76)  : (i256) -> i256
     llvm.store %88, %87 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb12
@@ -279,20 +278,20 @@ module {
     %108 = llvm.getelementptr %107[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %109 = llvm.load %108 : !llvm.ptr -> i256
     llvm.store %108, %106 : !llvm.ptr, !llvm.ptr
-    %110 = arith.trunci %105 : i256 to i32
-    %111 = arith.trunci %109 : i256 to i32
-    %112 = arith.addi %110, %111 : i32
+    %110 = arith.trunci %105 : i256 to i64
+    %111 = arith.trunci %109 : i256 to i64
+    %112 = arith.addi %110, %111 : i64
     %113 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %114 = llvm.load %113 : !llvm.ptr -> i32
-    %c31_i32_11 = arith.constant 31 : i32
-    %c32_i32_12 = arith.constant 32 : i32
-    %115 = arith.addi %112, %c31_i32_11 : i32
-    %116 = arith.divui %115, %c32_i32_12 : i32
-    %117 = arith.muli %116, %c32_i32_12 : i32
-    %118 = arith.cmpi ult, %114, %117 : i32
+    %114 = llvm.load %113 : !llvm.ptr -> i64
+    %c31_i64_11 = arith.constant 31 : i64
+    %c32_i64_12 = arith.constant 32 : i64
+    %115 = arith.addi %112, %c31_i64_11 : i64
+    %116 = arith.divui %115, %c32_i64_12 : i64
+    %117 = arith.muli %116, %c32_i64_12 : i64
+    %118 = arith.cmpi ult, %114, %117 : i64
     scf.if %118 {
-      %317 = func.call @dora_extend_memory(%arg0, %117) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %117, %113 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %117) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %117, %113 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
@@ -305,7 +304,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %122 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %121, %122 {alignment = 1 : i64} : i64, !llvm.ptr
-    %123 = call @dora_create(%arg0, %111, %110, %119, %122) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %123 = call @dora_create(%arg0, %111, %110, %119, %122) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %124 = arith.cmpi eq, %c0_i8, %123 : i8
     %125 = llvm.load %119 : !llvm.ptr -> i256
@@ -401,24 +400,24 @@ module {
     llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
     %c0_i256_17 = arith.constant 0 : i256
     %175 = arith.trunci %154 : i256 to i64
-    %176 = arith.trunci %162 : i256 to i32
-    %177 = arith.trunci %166 : i256 to i32
-    %178 = arith.trunci %170 : i256 to i32
-    %179 = arith.trunci %174 : i256 to i32
-    %180 = arith.addi %176, %177 : i32
-    %181 = arith.addi %178, %179 : i32
-    %182 = arith.maxui %180, %181 : i32
+    %176 = arith.trunci %162 : i256 to i64
+    %177 = arith.trunci %166 : i256 to i64
+    %178 = arith.trunci %170 : i256 to i64
+    %179 = arith.trunci %174 : i256 to i64
+    %180 = arith.addi %176, %177 : i64
+    %181 = arith.addi %178, %179 : i64
+    %182 = arith.maxui %180, %181 : i64
     %183 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> i32
-    %c31_i32_18 = arith.constant 31 : i32
-    %c32_i32_19 = arith.constant 32 : i32
-    %185 = arith.addi %182, %c31_i32_18 : i32
-    %186 = arith.divui %185, %c32_i32_19 : i32
-    %187 = arith.muli %186, %c32_i32_19 : i32
-    %188 = arith.cmpi ult, %184, %187 : i32
+    %184 = llvm.load %183 : !llvm.ptr -> i64
+    %c31_i64_18 = arith.constant 31 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %185 = arith.addi %182, %c31_i64_18 : i64
+    %186 = arith.divui %185, %c32_i64_19 : i64
+    %187 = arith.muli %186, %c32_i64_19 : i64
+    %188 = arith.cmpi ult, %184, %187 : i64
     scf.if %188 {
-      %317 = func.call @dora_extend_memory(%arg0, %187) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %187, %183 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %187) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %187, %183 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
@@ -434,7 +433,7 @@ module {
     %c1_i64_22 = arith.constant 1 : i64
     %193 = llvm.alloca %c1_i64_22 x i64 : (i64) -> !llvm.ptr
     %c0_i8_23 = arith.constant 0 : i8
-    %194 = call @dora_call(%arg0, %175, %192, %191, %176, %177, %178, %179, %190, %193, %c0_i8_23) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %194 = call @dora_call(%arg0, %175, %192, %191, %176, %177, %178, %179, %190, %193, %c0_i8_23) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %195 = llvm.load %193 : !llvm.ptr -> i64
     %196 = arith.extui %194 : i8 to i256
     %197 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -484,27 +483,27 @@ module {
     %220 = llvm.getelementptr %219[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %221 = llvm.load %220 : !llvm.ptr -> i256
     llvm.store %220, %218 : !llvm.ptr, !llvm.ptr
-    %222 = arith.trunci %217 : i256 to i32
-    %c32_i32_26 = arith.constant 32 : i32
-    %223 = arith.addi %222, %c32_i32_26 : i32
+    %222 = arith.trunci %217 : i256 to i64
+    %c32_i64_26 = arith.constant 32 : i64
+    %223 = arith.addi %222, %c32_i64_26 : i64
     %224 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %225 = llvm.load %224 : !llvm.ptr -> i32
-    %c31_i32_27 = arith.constant 31 : i32
-    %c32_i32_28 = arith.constant 32 : i32
-    %226 = arith.addi %223, %c31_i32_27 : i32
-    %227 = arith.divui %226, %c32_i32_28 : i32
-    %228 = arith.muli %227, %c32_i32_28 : i32
-    %229 = arith.cmpi ult, %225, %228 : i32
+    %225 = llvm.load %224 : !llvm.ptr -> i64
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %226 = arith.addi %223, %c31_i64_27 : i64
+    %227 = arith.divui %226, %c32_i64_28 : i64
+    %228 = arith.muli %227, %c32_i64_28 : i64
+    %229 = arith.cmpi ult, %225, %228 : i64
     scf.if %229 {
-      %317 = func.call @dora_extend_memory(%arg0, %228) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %228, %224 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %228) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %228, %224 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %230 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %231 = llvm.load %230 : !llvm.ptr -> !llvm.ptr
-    %232 = llvm.getelementptr %231[%222] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %232 = llvm.getelementptr %231[%222] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %233 = llvm.intr.bswap(%221)  : (i256) -> i256
     llvm.store %233, %232 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb29
@@ -535,27 +534,27 @@ module {
     %246 = llvm.getelementptr %245[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %247 = llvm.load %246 : !llvm.ptr -> i256
     llvm.store %246, %244 : !llvm.ptr, !llvm.ptr
-    %248 = arith.trunci %243 : i256 to i32
-    %c32_i32_31 = arith.constant 32 : i32
-    %249 = arith.addi %248, %c32_i32_31 : i32
+    %248 = arith.trunci %243 : i256 to i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %249 = arith.addi %248, %c32_i64_31 : i64
     %250 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %251 = llvm.load %250 : !llvm.ptr -> i32
-    %c31_i32_32 = arith.constant 31 : i32
-    %c32_i32_33 = arith.constant 32 : i32
-    %252 = arith.addi %249, %c31_i32_32 : i32
-    %253 = arith.divui %252, %c32_i32_33 : i32
-    %254 = arith.muli %253, %c32_i32_33 : i32
-    %255 = arith.cmpi ult, %251, %254 : i32
+    %251 = llvm.load %250 : !llvm.ptr -> i64
+    %c31_i64_32 = arith.constant 31 : i64
+    %c32_i64_33 = arith.constant 32 : i64
+    %252 = arith.addi %249, %c31_i64_32 : i64
+    %253 = arith.divui %252, %c32_i64_33 : i64
+    %254 = arith.muli %253, %c32_i64_33 : i64
+    %255 = arith.cmpi ult, %251, %254 : i64
     scf.if %255 {
-      %317 = func.call @dora_extend_memory(%arg0, %254) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %254, %250 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %254) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %254, %250 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %256 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %257 = llvm.load %256 : !llvm.ptr -> !llvm.ptr
-    %258 = llvm.getelementptr %257[%248] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %258 = llvm.getelementptr %257[%248] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %259 = llvm.intr.bswap(%247)  : (i256) -> i256
     llvm.store %259, %258 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb32
@@ -586,27 +585,27 @@ module {
     %272 = llvm.getelementptr %271[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %273 = llvm.load %272 : !llvm.ptr -> i256
     llvm.store %272, %270 : !llvm.ptr, !llvm.ptr
-    %274 = arith.trunci %269 : i256 to i32
-    %c32_i32_36 = arith.constant 32 : i32
-    %275 = arith.addi %274, %c32_i32_36 : i32
+    %274 = arith.trunci %269 : i256 to i64
+    %c32_i64_36 = arith.constant 32 : i64
+    %275 = arith.addi %274, %c32_i64_36 : i64
     %276 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %277 = llvm.load %276 : !llvm.ptr -> i32
-    %c31_i32_37 = arith.constant 31 : i32
-    %c32_i32_38 = arith.constant 32 : i32
-    %278 = arith.addi %275, %c31_i32_37 : i32
-    %279 = arith.divui %278, %c32_i32_38 : i32
-    %280 = arith.muli %279, %c32_i32_38 : i32
-    %281 = arith.cmpi ult, %277, %280 : i32
+    %277 = llvm.load %276 : !llvm.ptr -> i64
+    %c31_i64_37 = arith.constant 31 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %278 = arith.addi %275, %c31_i64_37 : i64
+    %279 = arith.divui %278, %c32_i64_38 : i64
+    %280 = arith.muli %279, %c32_i64_38 : i64
+    %281 = arith.cmpi ult, %277, %280 : i64
     scf.if %281 {
-      %317 = func.call @dora_extend_memory(%arg0, %280) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %280, %276 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %280) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %280, %276 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %282 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %283 = llvm.load %282 : !llvm.ptr -> !llvm.ptr
-    %284 = llvm.getelementptr %283[%274] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %284 = llvm.getelementptr %283[%274] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %285 = llvm.intr.bswap(%273)  : (i256) -> i256
     llvm.store %285, %284 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb35
@@ -650,31 +649,31 @@ module {
     %305 = llvm.getelementptr %304[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %306 = llvm.load %305 : !llvm.ptr -> i256
     llvm.store %305, %303 : !llvm.ptr, !llvm.ptr
-    %307 = arith.trunci %298 : i256 to i32
-    %308 = arith.trunci %302 : i256 to i32
-    %309 = arith.trunci %306 : i256 to i32
-    %310 = arith.addi %307, %309 : i32
+    %307 = arith.trunci %298 : i256 to i64
+    %308 = arith.trunci %302 : i256 to i64
+    %309 = arith.trunci %306 : i256 to i64
+    %310 = arith.addi %307, %309 : i64
     %311 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %312 = llvm.load %311 : !llvm.ptr -> i32
-    %c31_i32_42 = arith.constant 31 : i32
-    %c32_i32_43 = arith.constant 32 : i32
-    %313 = arith.addi %310, %c31_i32_42 : i32
-    %314 = arith.divui %313, %c32_i32_43 : i32
-    %315 = arith.muli %314, %c32_i32_43 : i32
-    %316 = arith.cmpi ult, %312, %315 : i32
+    %312 = llvm.load %311 : !llvm.ptr -> i64
+    %c31_i64_42 = arith.constant 31 : i64
+    %c32_i64_43 = arith.constant 32 : i64
+    %313 = arith.addi %310, %c31_i64_42 : i64
+    %314 = arith.divui %313, %c32_i64_43 : i64
+    %315 = arith.muli %314, %c32_i64_43 : i64
+    %316 = arith.cmpi ult, %312, %315 : i64
     scf.if %316 {
-      %317 = func.call @dora_extend_memory(%arg0, %315) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %315, %311 : i32, !llvm.ptr
+      %317 = func.call @dora_extend_memory(%arg0, %315) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %315, %311 : i64, !llvm.ptr
       %318 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %317, %318 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_return_data_into_memory(%arg0, %307, %308, %309) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_return_data_into_memory(%arg0, %307, %308, %309) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb39
   ^bb39:  // pred: ^bb38
-    %c0_i32_44 = arith.constant 0 : i32
+    %c0_i64_44 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_44, %c0_i32_44, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_44, %c0_i64_44, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // 2 preds: ^bb2, ^bb15
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %205 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %205 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %206 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %205, %206 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,27 +163,27 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %c32_i32_3 = arith.constant 32 : i32
-    %52 = arith.addi %51, %c32_i32_3 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %c32_i64_3 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c32_i64_3 : i64
     %53 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %55 = arith.addi %52, %c31_i32_4 : i32
-    %56 = arith.divui %55, %c32_i32_5 : i32
-    %57 = arith.muli %56, %c32_i32_5 : i32
-    %58 = arith.cmpi ult, %54, %57 : i32
+    %54 = llvm.load %53 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %55 = arith.addi %52, %c31_i64_4 : i64
+    %56 = arith.divui %55, %c32_i64_5 : i64
+    %57 = arith.muli %56, %c32_i64_5 : i64
+    %58 = arith.cmpi ult, %54, %57 : i64
     scf.if %58 {
-      %205 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %57, %53 : i32, !llvm.ptr
+      %205 = func.call @dora_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %57, %53 : i64, !llvm.ptr
       %206 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %205, %206 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %59 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
-    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %61 = llvm.getelementptr %60[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %62 = llvm.intr.bswap(%50)  : (i256) -> i256
     llvm.store %62, %61 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb9
@@ -215,27 +214,27 @@ module {
     %75 = llvm.getelementptr %74[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %76 = llvm.load %75 : !llvm.ptr -> i256
     llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
-    %77 = arith.trunci %72 : i256 to i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %78 = arith.addi %77, %c32_i32_6 : i32
+    %77 = arith.trunci %72 : i256 to i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %78 = arith.addi %77, %c32_i64_6 : i64
     %79 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %80 = llvm.load %79 : !llvm.ptr -> i32
-    %c31_i32_7 = arith.constant 31 : i32
-    %c32_i32_8 = arith.constant 32 : i32
-    %81 = arith.addi %78, %c31_i32_7 : i32
-    %82 = arith.divui %81, %c32_i32_8 : i32
-    %83 = arith.muli %82, %c32_i32_8 : i32
-    %84 = arith.cmpi ult, %80, %83 : i32
+    %80 = llvm.load %79 : !llvm.ptr -> i64
+    %c31_i64_7 = arith.constant 31 : i64
+    %c32_i64_8 = arith.constant 32 : i64
+    %81 = arith.addi %78, %c31_i64_7 : i64
+    %82 = arith.divui %81, %c32_i64_8 : i64
+    %83 = arith.muli %82, %c32_i64_8 : i64
+    %84 = arith.cmpi ult, %80, %83 : i64
     scf.if %84 {
-      %205 = func.call @dora_extend_memory(%arg0, %83) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %83, %79 : i32, !llvm.ptr
+      %205 = func.call @dora_extend_memory(%arg0, %83) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %83, %79 : i64, !llvm.ptr
       %206 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %205, %206 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %85 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
-    %87 = llvm.getelementptr %86[%77] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %87 = llvm.getelementptr %86[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %88 = llvm.intr.bswap(%76)  : (i256) -> i256
     llvm.store %88, %87 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb12
@@ -279,20 +278,20 @@ module {
     %108 = llvm.getelementptr %107[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %109 = llvm.load %108 : !llvm.ptr -> i256
     llvm.store %108, %106 : !llvm.ptr, !llvm.ptr
-    %110 = arith.trunci %105 : i256 to i32
-    %111 = arith.trunci %109 : i256 to i32
-    %112 = arith.addi %110, %111 : i32
+    %110 = arith.trunci %105 : i256 to i64
+    %111 = arith.trunci %109 : i256 to i64
+    %112 = arith.addi %110, %111 : i64
     %113 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %114 = llvm.load %113 : !llvm.ptr -> i32
-    %c31_i32_11 = arith.constant 31 : i32
-    %c32_i32_12 = arith.constant 32 : i32
-    %115 = arith.addi %112, %c31_i32_11 : i32
-    %116 = arith.divui %115, %c32_i32_12 : i32
-    %117 = arith.muli %116, %c32_i32_12 : i32
-    %118 = arith.cmpi ult, %114, %117 : i32
+    %114 = llvm.load %113 : !llvm.ptr -> i64
+    %c31_i64_11 = arith.constant 31 : i64
+    %c32_i64_12 = arith.constant 32 : i64
+    %115 = arith.addi %112, %c31_i64_11 : i64
+    %116 = arith.divui %115, %c32_i64_12 : i64
+    %117 = arith.muli %116, %c32_i64_12 : i64
+    %118 = arith.cmpi ult, %114, %117 : i64
     scf.if %118 {
-      %205 = func.call @dora_extend_memory(%arg0, %117) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %117, %113 : i32, !llvm.ptr
+      %205 = func.call @dora_extend_memory(%arg0, %117) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %117, %113 : i64, !llvm.ptr
       %206 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %205, %206 : !llvm.ptr, !llvm.ptr
     } else {
@@ -305,7 +304,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %122 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     llvm.store %121, %122 {alignment = 1 : i64} : i64, !llvm.ptr
-    %123 = call @dora_create(%arg0, %111, %110, %119, %122) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
+    %123 = call @dora_create(%arg0, %111, %110, %119, %122) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
     %124 = arith.cmpi eq, %c0_i8, %123 : i8
     %125 = llvm.load %119 : !llvm.ptr -> i256
@@ -401,24 +400,24 @@ module {
     llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
     %c0_i256_17 = arith.constant 0 : i256
     %175 = arith.trunci %154 : i256 to i64
-    %176 = arith.trunci %162 : i256 to i32
-    %177 = arith.trunci %166 : i256 to i32
-    %178 = arith.trunci %170 : i256 to i32
-    %179 = arith.trunci %174 : i256 to i32
-    %180 = arith.addi %176, %177 : i32
-    %181 = arith.addi %178, %179 : i32
-    %182 = arith.maxui %180, %181 : i32
+    %176 = arith.trunci %162 : i256 to i64
+    %177 = arith.trunci %166 : i256 to i64
+    %178 = arith.trunci %170 : i256 to i64
+    %179 = arith.trunci %174 : i256 to i64
+    %180 = arith.addi %176, %177 : i64
+    %181 = arith.addi %178, %179 : i64
+    %182 = arith.maxui %180, %181 : i64
     %183 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> i32
-    %c31_i32_18 = arith.constant 31 : i32
-    %c32_i32_19 = arith.constant 32 : i32
-    %185 = arith.addi %182, %c31_i32_18 : i32
-    %186 = arith.divui %185, %c32_i32_19 : i32
-    %187 = arith.muli %186, %c32_i32_19 : i32
-    %188 = arith.cmpi ult, %184, %187 : i32
+    %184 = llvm.load %183 : !llvm.ptr -> i64
+    %c31_i64_18 = arith.constant 31 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %185 = arith.addi %182, %c31_i64_18 : i64
+    %186 = arith.divui %185, %c32_i64_19 : i64
+    %187 = arith.muli %186, %c32_i64_19 : i64
+    %188 = arith.cmpi ult, %184, %187 : i64
     scf.if %188 {
-      %205 = func.call @dora_extend_memory(%arg0, %187) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %187, %183 : i32, !llvm.ptr
+      %205 = func.call @dora_extend_memory(%arg0, %187) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %187, %183 : i64, !llvm.ptr
       %206 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %205, %206 : !llvm.ptr, !llvm.ptr
     } else {
@@ -434,7 +433,7 @@ module {
     %c1_i64_22 = arith.constant 1 : i64
     %193 = llvm.alloca %c1_i64_22 x i64 : (i64) -> !llvm.ptr
     %c0_i8_23 = arith.constant 0 : i8
-    %194 = call @dora_call(%arg0, %175, %192, %191, %176, %177, %178, %179, %190, %193, %c0_i8_23) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %194 = call @dora_call(%arg0, %175, %192, %191, %176, %177, %178, %179, %190, %193, %c0_i8_23) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %195 = llvm.load %193 : !llvm.ptr -> i64
     %196 = arith.extui %194 : i8 to i256
     %197 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -444,8 +443,8 @@ module {
     llvm.store %199, %197 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb24:  // pred: ^bb23
-    %200 = call @dora_get_return_data_size(%arg0) : (!llvm.ptr) -> i32
-    %201 = arith.extui %200 : i32 to i256
+    %200 = call @dora_get_return_data_size(%arg0) : (!llvm.ptr) -> i64
+    %201 = arith.extui %200 : i64 to i256
     %202 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     %203 = llvm.load %202 : !llvm.ptr -> !llvm.ptr
     llvm.store %201, %203 : i256, !llvm.ptr
@@ -453,9 +452,9 @@ module {
     llvm.store %204, %202 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %c0_i32_24 = arith.constant 0 : i32
+    %c0_i64_24 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_24, %c0_i32_24, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_24, %c0_i64_24, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_keccak256.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_keccak256.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %65 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %65 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %66 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %65, %66 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,27 +163,27 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %52 = arith.trunci %50 : i256 to i32
-    %53 = arith.addi %51, %52 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %52 = arith.trunci %50 : i256 to i64
+    %53 = arith.addi %51, %52 : i64
     %54 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %55 = llvm.load %54 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %56 = arith.addi %53, %c31_i32_4 : i32
-    %57 = arith.divui %56, %c32_i32_5 : i32
-    %58 = arith.muli %57, %c32_i32_5 : i32
-    %59 = arith.cmpi ult, %55, %58 : i32
+    %55 = llvm.load %54 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %56 = arith.addi %53, %c31_i64_4 : i64
+    %57 = arith.divui %56, %c32_i64_5 : i64
+    %58 = arith.muli %57, %c32_i64_5 : i64
+    %59 = arith.cmpi ult, %55, %58 : i64
     scf.if %59 {
-      %65 = func.call @dora_extend_memory(%arg0, %58) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %58, %54 : i32, !llvm.ptr
+      %65 = func.call @dora_extend_memory(%arg0, %58) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %58, %54 : i64, !llvm.ptr
       %66 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %65, %66 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %c1_i256 = arith.constant 1 : i256
     %60 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_keccak256_hasher(%arg0, %51, %52, %60) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+    call @dora_keccak256_hasher(%arg0, %51, %52, %60) : (!llvm.ptr, i64, i64, !llvm.ptr) -> ()
     %61 = llvm.load %60 : !llvm.ptr -> i256
     %62 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
@@ -193,9 +192,9 @@ module {
     llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mcopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mcopy.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %74 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %74 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %75 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %74, %75 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -177,37 +176,37 @@ module {
     %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %57 = llvm.load %56 : !llvm.ptr -> i256
     llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
-    %58 = arith.trunci %49 : i256 to i32
-    %59 = arith.trunci %53 : i256 to i32
-    %60 = arith.trunci %57 : i256 to i32
-    %61 = arith.addi %59, %60 : i32
-    %62 = arith.addi %58, %60 : i32
-    %63 = arith.maxui %61, %62 : i32
+    %58 = arith.trunci %49 : i256 to i64
+    %59 = arith.trunci %53 : i256 to i64
+    %60 = arith.trunci %57 : i256 to i64
+    %61 = arith.addi %59, %60 : i64
+    %62 = arith.addi %58, %60 : i64
+    %63 = arith.maxui %61, %62 : i64
     %64 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %66 = arith.addi %63, %c31_i32_5 : i32
-    %67 = arith.divui %66, %c32_i32_6 : i32
-    %68 = arith.muli %67, %c32_i32_6 : i32
-    %69 = arith.cmpi ult, %65, %68 : i32
+    %65 = llvm.load %64 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %66 = arith.addi %63, %c31_i64_5 : i64
+    %67 = arith.divui %66, %c32_i64_6 : i64
+    %68 = arith.muli %67, %c32_i64_6 : i64
+    %69 = arith.cmpi ult, %65, %68 : i64
     scf.if %69 {
-      %74 = func.call @dora_extend_memory(%arg0, %68) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %68, %64 : i32, !llvm.ptr
+      %74 = func.call @dora_extend_memory(%arg0, %68) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %68, %64 : i64, !llvm.ptr
       %75 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %74, %75 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %70 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %71 = llvm.load %70 : !llvm.ptr -> !llvm.ptr
-    %72 = llvm.getelementptr %71[%59] : (!llvm.ptr, i32) -> !llvm.ptr, i8
-    %73 = llvm.getelementptr %71[%58] : (!llvm.ptr, i32) -> !llvm.ptr, i8
-    "llvm.intr.memmove"(%73, %72, %60) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    %72 = llvm.getelementptr %71[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %73 = llvm.getelementptr %71[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    "llvm.intr.memmove"(%73, %72, %60) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_7 = arith.constant 0 : i32
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_7, %c0_i32_7, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mload.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %60 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %60 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %61 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %60, %61 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -151,27 +150,27 @@ module {
     %42 = llvm.getelementptr %41[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %43 = llvm.load %42 : !llvm.ptr -> i256
     llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
-    %44 = arith.trunci %43 : i256 to i32
-    %c32_i32_4 = arith.constant 32 : i32
-    %45 = arith.addi %44, %c32_i32_4 : i32
+    %44 = arith.trunci %43 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %45 = arith.addi %44, %c32_i64_4 : i64
     %46 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> i32
-    %c31_i32_5 = arith.constant 31 : i32
-    %c32_i32_6 = arith.constant 32 : i32
-    %48 = arith.addi %45, %c31_i32_5 : i32
-    %49 = arith.divui %48, %c32_i32_6 : i32
-    %50 = arith.muli %49, %c32_i32_6 : i32
-    %51 = arith.cmpi ult, %47, %50 : i32
+    %47 = llvm.load %46 : !llvm.ptr -> i64
+    %c31_i64_5 = arith.constant 31 : i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %48 = arith.addi %45, %c31_i64_5 : i64
+    %49 = arith.divui %48, %c32_i64_6 : i64
+    %50 = arith.muli %49, %c32_i64_6 : i64
+    %51 = arith.cmpi ult, %47, %50 : i64
     scf.if %51 {
-      %60 = func.call @dora_extend_memory(%arg0, %50) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %50, %46 : i32, !llvm.ptr
+      %60 = func.call @dora_extend_memory(%arg0, %50) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %50, %46 : i64, !llvm.ptr
       %61 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %60, %61 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %52 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %53 = llvm.load %52 : !llvm.ptr -> !llvm.ptr
-    %54 = llvm.getelementptr %53[%44] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %54 = llvm.getelementptr %53[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %55 = llvm.load %54 {alignment = 1 : i64} : !llvm.ptr -> i256
     %56 = llvm.intr.bswap(%55)  : (i256) -> i256
     %57 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -181,9 +180,9 @@ module {
     llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_7 = arith.constant 0 : i32
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_7, %c0_i32_7, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_revert.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_revert.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %62 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %62 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %63 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %62, %63 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,20 +163,20 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %52 = arith.trunci %50 : i256 to i32
-    %53 = arith.addi %51, %52 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %52 = arith.trunci %50 : i256 to i64
+    %53 = arith.addi %51, %52 : i64
     %54 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %55 = llvm.load %54 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %56 = arith.addi %53, %c31_i32_4 : i32
-    %57 = arith.divui %56, %c32_i32_5 : i32
-    %58 = arith.muli %57, %c32_i32_5 : i32
-    %59 = arith.cmpi ult, %55, %58 : i32
+    %55 = llvm.load %54 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %56 = arith.addi %53, %c31_i64_4 : i64
+    %57 = arith.divui %56, %c32_i64_5 : i64
+    %58 = arith.muli %57, %c32_i64_5 : i64
+    %59 = arith.cmpi ult, %55, %58 : i64
     scf.if %59 {
-      %62 = func.call @dora_extend_memory(%arg0, %58) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %58, %54 : i32, !llvm.ptr
+      %62 = func.call @dora_extend_memory(%arg0, %58) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %58, %54 : i64, !llvm.ptr
       %63 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %62, %63 : !llvm.ptr, !llvm.ptr
     } else {
@@ -185,14 +184,14 @@ module {
     %60 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %61 = llvm.load %60 : !llvm.ptr -> i64
     %c2_i8 = arith.constant 2 : i8
-    call @dora_write_result(%arg0, %51, %52, %61, %c2_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %51, %52, %61, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c2_i8 : i8
   ^bb9:  // no predecessors
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_multiple_pop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_multiple_pop.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -132,9 +131,9 @@ module {
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_not.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_not.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -109,9 +108,9 @@ module {
     llvm.store %21, %19 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_overflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_overflow.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -102,9 +101,9 @@ module {
     llvm.store %16, %14 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -102,9 +101,9 @@ module {
     llvm.store %16, %14 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -102,9 +101,9 @@ module {
     llvm.store %16, %14 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_codesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_codesize.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -110,9 +109,9 @@ module {
     llvm.store %20, %18 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_with_jump.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_with_jump.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // pred: ^bb4
     cf.switch %10 : i256, [
@@ -130,9 +129,9 @@ module {
     llvm.store %26, %24 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_edge_case.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_byte.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_byte.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -134,9 +133,9 @@ module {
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_edge_case.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_large_base.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_large_base.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_gt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_gt.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -110,9 +109,9 @@ module {
     llvm.store %22, %20 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -110,9 +109,9 @@ module {
     llvm.store %22, %20 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_lt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_lt.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_zero_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_zero_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_large.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_large.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_overflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_overflow.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_edge_case.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,9 +138,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod_large_mod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod_large_mod.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,9 +138,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,9 +138,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod_zero_mod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod_zero_mod.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -139,9 +138,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sar.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sar.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -123,9 +122,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shl.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shl.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -129,9 +128,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shr.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shr.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -129,9 +128,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_signextend.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_signextend.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -130,9 +129,9 @@ module {
     llvm.store %33, %31 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod_with_negative.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod_with_negative.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     %27 = call @dora_write_storage(%arg0, %25, %26) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore_sload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore_sload.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -149,9 +148,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_edge_case.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,35 +112,35 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %26 = arith.trunci %24 : i256 to i32
-    %27 = arith.addi %26, %25 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %26 = arith.trunci %24 : i256 to i64
+    %27 = arith.addi %26, %25 : i64
     %28 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %29 = llvm.load %28 : !llvm.ptr -> i64
     %30 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %32 = arith.addi %27, %c31_i32 : i32
-    %33 = arith.divui %32, %c32_i32 : i32
-    %34 = arith.muli %33, %c32_i32 : i32
-    %35 = arith.cmpi ult, %31, %34 : i32
+    %31 = llvm.load %30 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %32 = arith.addi %27, %c31_i64 : i64
+    %33 = arith.divui %32, %c32_i64 : i64
+    %34 = arith.muli %33, %c32_i64 : i64
+    %35 = arith.cmpi ult, %31, %34 : i64
     scf.if %35 {
-      %36 = func.call @dora_extend_memory(%arg0, %34) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %34, %30 : i32, !llvm.ptr
+      %36 = func.call @dora_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %34, %30 : i64, !llvm.ptr
       %37 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %36, %37 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %c0_i8 = arith.constant 0 : i8
-    call @dora_write_result(%arg0, %25, %26, %29, %c0_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %25, %26, %29, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8 : i8
   ^bb6:  // no predecessors
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return_large_data.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return_large_data.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,35 +112,35 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %26 = arith.trunci %24 : i256 to i32
-    %27 = arith.addi %26, %25 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %26 = arith.trunci %24 : i256 to i64
+    %27 = arith.addi %26, %25 : i64
     %28 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %29 = llvm.load %28 : !llvm.ptr -> i64
     %30 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %32 = arith.addi %27, %c31_i32 : i32
-    %33 = arith.divui %32, %c32_i32 : i32
-    %34 = arith.muli %33, %c32_i32 : i32
-    %35 = arith.cmpi ult, %31, %34 : i32
+    %31 = llvm.load %30 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %32 = arith.addi %27, %c31_i64 : i64
+    %33 = arith.divui %32, %c32_i64 : i64
+    %34 = arith.muli %33, %c32_i64 : i64
+    %35 = arith.cmpi ult, %31, %34 : i64
     scf.if %35 {
-      %36 = func.call @dora_extend_memory(%arg0, %34) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %34, %30 : i32, !llvm.ptr
+      %36 = func.call @dora_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %34, %30 : i64, !llvm.ptr
       %37 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %36, %37 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %c0_i8 = arith.constant 0 : i8
-    call @dora_write_result(%arg0, %25, %26, %29, %c0_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %25, %26, %29, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8 : i8
   ^bb6:  // no predecessors
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,20 +112,20 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %26 = arith.trunci %24 : i256 to i32
-    %27 = arith.addi %25, %26 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %26 = arith.trunci %24 : i256 to i64
+    %27 = arith.addi %25, %26 : i64
     %28 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %29 = llvm.load %28 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %30 = arith.addi %27, %c31_i32 : i32
-    %31 = arith.divui %30, %c32_i32 : i32
-    %32 = arith.muli %31, %c32_i32 : i32
-    %33 = arith.cmpi ult, %29, %32 : i32
+    %29 = llvm.load %28 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %30 = arith.addi %27, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64 : i64
+    %32 = arith.muli %31, %c32_i64 : i64
+    %33 = arith.cmpi ult, %29, %32 : i64
     scf.if %33 {
-      %36 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %32, %28 : i32, !llvm.ptr
+      %36 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %32, %28 : i64, !llvm.ptr
       %37 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %36, %37 : !llvm.ptr, !llvm.ptr
     } else {
@@ -134,14 +133,14 @@ module {
     %34 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %35 = llvm.load %34 : !llvm.ptr -> i64
     %c2_i8 = arith.constant 2 : i8
-    call @dora_write_result(%arg0, %25, %26, %35, %c2_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %25, %26, %35, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c2_i8 : i8
   ^bb6:  // no predecessors
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert_large_data.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert_large_data.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,20 +112,20 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %26 = arith.trunci %24 : i256 to i32
-    %27 = arith.addi %25, %26 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %26 = arith.trunci %24 : i256 to i64
+    %27 = arith.addi %25, %26 : i64
     %28 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %29 = llvm.load %28 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %30 = arith.addi %27, %c31_i32 : i32
-    %31 = arith.divui %30, %c32_i32 : i32
-    %32 = arith.muli %31, %c32_i32 : i32
-    %33 = arith.cmpi ult, %29, %32 : i32
+    %29 = llvm.load %28 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %30 = arith.addi %27, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64 : i64
+    %32 = arith.muli %31, %c32_i64 : i64
+    %33 = arith.cmpi ult, %29, %32 : i64
     scf.if %33 {
-      %36 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %32, %28 : i32, !llvm.ptr
+      %36 = func.call @dora_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %32, %28 : i64, !llvm.ptr
       %37 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %36, %37 : !llvm.ptr, !llvm.ptr
     } else {
@@ -134,14 +133,14 @@ module {
     %34 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %35 = llvm.load %34 : !llvm.ptr -> i64
     %c2_i8 = arith.constant 2 : i8
-    call @dora_write_result(%arg0, %25, %26, %35, %c2_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %25, %26, %35, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c2_i8 : i8
   ^bb6:  // no predecessors
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -106,9 +105,9 @@ module {
     %19 = call @dora_selfdestruct(%arg0, %18) : (!llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct_zero_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct_zero_address.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -106,9 +105,9 @@ module {
     %19 = call @dora_selfdestruct(%arg0, %18) : (!llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_stack_depth.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_stack_depth.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -133,9 +132,9 @@ module {
     llvm.store %29, %27 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -167,24 +166,24 @@ module {
     llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
     %53 = arith.trunci %32 : i256 to i64
-    %54 = arith.trunci %40 : i256 to i32
-    %55 = arith.trunci %44 : i256 to i32
-    %56 = arith.trunci %48 : i256 to i32
-    %57 = arith.trunci %52 : i256 to i32
-    %58 = arith.addi %54, %55 : i32
-    %59 = arith.addi %56, %57 : i32
-    %60 = arith.maxui %58, %59 : i32
+    %54 = arith.trunci %40 : i256 to i64
+    %55 = arith.trunci %44 : i256 to i64
+    %56 = arith.trunci %48 : i256 to i64
+    %57 = arith.trunci %52 : i256 to i64
+    %58 = arith.addi %54, %55 : i64
+    %59 = arith.addi %56, %57 : i64
+    %60 = arith.maxui %58, %59 : i64
     %61 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %63 = arith.addi %60, %c31_i32 : i32
-    %64 = arith.divui %63, %c32_i32 : i32
-    %65 = arith.muli %64, %c32_i32 : i32
-    %66 = arith.cmpi ult, %62, %65 : i32
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %63 = arith.addi %60, %c31_i64 : i64
+    %64 = arith.divui %63, %c32_i64 : i64
+    %65 = arith.muli %64, %c32_i64 : i64
+    %66 = arith.cmpi ult, %62, %65 : i64
     scf.if %66 {
-      %78 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %65, %61 : i32, !llvm.ptr
+      %78 = func.call @dora_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %65, %61 : i64, !llvm.ptr
       %79 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %78, %79 : !llvm.ptr, !llvm.ptr
     } else {
@@ -200,7 +199,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %71 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
     %c0_i8 = arith.constant 0 : i8
-    %72 = call @dora_call(%arg0, %53, %70, %69, %54, %55, %56, %57, %68, %71, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+    %72 = call @dora_call(%arg0, %53, %70, %69, %54, %55, %56, %57, %68, %71, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
     %73 = llvm.load %71 : !llvm.ptr -> i64
     %74 = arith.extui %72 : i8 to i256
     %75 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
@@ -210,9 +209,9 @@ module {
     llvm.store %77, %75 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_5 = arith.constant 0 : i32
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_5, %c0_i32_5, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_store_return.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_store_return.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,27 +112,27 @@ module {
     %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %24 = llvm.load %23 : !llvm.ptr -> i256
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
-    %25 = arith.trunci %20 : i256 to i32
-    %c32_i32 = arith.constant 32 : i32
-    %26 = arith.addi %25, %c32_i32 : i32
+    %25 = arith.trunci %20 : i256 to i64
+    %c32_i64 = arith.constant 32 : i64
+    %26 = arith.addi %25, %c32_i64 : i64
     %27 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32_2 = arith.constant 32 : i32
-    %29 = arith.addi %26, %c31_i32 : i32
-    %30 = arith.divui %29, %c32_i32_2 : i32
-    %31 = arith.muli %30, %c32_i32_2 : i32
-    %32 = arith.cmpi ult, %28, %31 : i32
+    %28 = llvm.load %27 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64_2 = arith.constant 32 : i64
+    %29 = arith.addi %26, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_2 : i64
+    %31 = arith.muli %30, %c32_i64_2 : i64
+    %32 = arith.cmpi ult, %28, %31 : i64
     scf.if %32 {
-      %62 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %31, %27 : i32, !llvm.ptr
+      %62 = func.call @dora_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %31, %27 : i64, !llvm.ptr
       %63 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %62, %63 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %33 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
     %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
-    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    %35 = llvm.getelementptr %34[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %36 = llvm.intr.bswap(%24)  : (i256) -> i256
     llvm.store %36, %35 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb6
@@ -164,35 +163,35 @@ module {
     %49 = llvm.getelementptr %48[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %50 = llvm.load %49 : !llvm.ptr -> i256
     llvm.store %49, %47 : !llvm.ptr, !llvm.ptr
-    %51 = arith.trunci %46 : i256 to i32
-    %52 = arith.trunci %50 : i256 to i32
-    %53 = arith.addi %52, %51 : i32
+    %51 = arith.trunci %46 : i256 to i64
+    %52 = arith.trunci %50 : i256 to i64
+    %53 = arith.addi %52, %51 : i64
     %54 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     %55 = llvm.load %54 : !llvm.ptr -> i64
     %56 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %57 = llvm.load %56 : !llvm.ptr -> i32
-    %c31_i32_4 = arith.constant 31 : i32
-    %c32_i32_5 = arith.constant 32 : i32
-    %58 = arith.addi %53, %c31_i32_4 : i32
-    %59 = arith.divui %58, %c32_i32_5 : i32
-    %60 = arith.muli %59, %c32_i32_5 : i32
-    %61 = arith.cmpi ult, %57, %60 : i32
+    %57 = llvm.load %56 : !llvm.ptr -> i64
+    %c31_i64_4 = arith.constant 31 : i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %58 = arith.addi %53, %c31_i64_4 : i64
+    %59 = arith.divui %58, %c32_i64_5 : i64
+    %60 = arith.muli %59, %c32_i64_5 : i64
+    %61 = arith.cmpi ult, %57, %60 : i64
     scf.if %61 {
-      %62 = func.call @dora_extend_memory(%arg0, %60) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %60, %56 : i32, !llvm.ptr
+      %62 = func.call @dora_extend_memory(%arg0, %60) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %60, %56 : i64, !llvm.ptr
       %63 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %62, %63 : !llvm.ptr, !llvm.ptr
     } else {
     }
     %c0_i8 = arith.constant 0 : i8
-    call @dora_write_result(%arg0, %51, %52, %55, %c0_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %51, %52, %55, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8 : i8
   ^bb9:  // no predecessors
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -113,9 +112,9 @@ module {
     llvm.store %22, %19 : i256, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap2.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %25, %22 : i256, !llvm.ptr
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_0.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     call @dora_transient_storage_write(%arg0, %25, %26) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_1.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     call @dora_transient_storage_write(%arg0, %25, %26) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_tload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_tload.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -149,9 +148,9 @@ module {
     llvm.store %39, %37 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,31 +125,31 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %23 : i256 to i32
-    %33 = arith.trunci %27 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %32, %34 : i32
+    %32 = arith.trunci %23 : i256 to i64
+    %33 = arith.trunci %27 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %32, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_return_data_into_memory(%arg0, %32, %33, %34) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_return_data_into_memory(%arg0, %32, %33, %34) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_out_of_bounds.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,31 +125,31 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %23 : i256 to i32
-    %33 = arith.trunci %27 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %32, %34 : i32
+    %32 = arith.trunci %23 : i256 to i64
+    %33 = arith.trunci %27 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %32, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_return_data_into_memory(%arg0, %32, %33, %34) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_return_data_into_memory(%arg0, %32, %33, %34) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_partial.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -126,31 +125,31 @@ module {
     %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %31 = llvm.load %30 : !llvm.ptr -> i256
     llvm.store %30, %28 : !llvm.ptr, !llvm.ptr
-    %32 = arith.trunci %23 : i256 to i32
-    %33 = arith.trunci %27 : i256 to i32
-    %34 = arith.trunci %31 : i256 to i32
-    %35 = arith.addi %32, %34 : i32
+    %32 = arith.trunci %23 : i256 to i64
+    %33 = arith.trunci %27 : i256 to i64
+    %34 = arith.trunci %31 : i256 to i64
+    %35 = arith.addi %32, %34 : i64
     %36 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i32
-    %c31_i32 = arith.constant 31 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %38 = arith.addi %35, %c31_i32 : i32
-    %39 = arith.divui %38, %c32_i32 : i32
-    %40 = arith.muli %39, %c32_i32 : i32
-    %41 = arith.cmpi ult, %37, %40 : i32
+    %37 = llvm.load %36 : !llvm.ptr -> i64
+    %c31_i64 = arith.constant 31 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %38 = arith.addi %35, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = arith.cmpi ult, %37, %40 : i64
     scf.if %41 {
-      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i32) -> !llvm.ptr
-      llvm.store %40, %36 : i32, !llvm.ptr
+      %42 = func.call @dora_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+      llvm.store %40, %36 : i64, !llvm.ptr
       %43 = llvm.mlir.addressof @dora_memory_ptr : !llvm.ptr
       llvm.store %42, %43 : !llvm.ptr, !llvm.ptr
     } else {
     }
-    call @dora_copy_return_data_into_memory(%arg0, %32, %33, %34) : (!llvm.ptr, i32, i32, i32) -> ()
+    call @dora_copy_return_data_into_memory(%arg0, %32, %33, %34) : (!llvm.ptr, i64, i64, i64) -> ()
     cf.br ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__selfbalance.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__selfbalance.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -149,9 +148,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_high_slot.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_high_slot.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -149,9 +148,9 @@ module {
     llvm.store %40, %38 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_multiple_slots.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_multiple_slots.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -211,9 +210,9 @@ module {
     llvm.store %70, %68 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i32_12 = arith.constant 0 : i32
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_12, %c0_i32_12, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_12, %c0_i64_12, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_uninitialized.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_uninitialized.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -114,9 +113,9 @@ module {
     llvm.store %23, %21 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_basic.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     %27 = call @dora_write_storage(%arg0, %25, %26) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_high_slot.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_high_slot.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -122,9 +121,9 @@ module {
     %27 = call @dora_write_storage(%arg0, %25, %26) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_multiple_slots.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_multiple_slots.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -157,9 +156,9 @@ module {
     %44 = call @dora_write_storage(%arg0, %42, %43) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_overwrite.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_overwrite.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -157,9 +156,9 @@ module {
     %44 = call @dora_write_storage(%arg0, %42, %43) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i32_6 = arith.constant 0 : i32
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_6, %c0_i32_6, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__stop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__stop.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,44 +59,43 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
       default: ^bb1
     ]
   ^bb3:  // pred: ^bb0
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb4:  // no predecessors
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8_4 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8_4) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8_4) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8_4 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__timestamp.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__timestamp.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -98,9 +97,9 @@ module {
     llvm.store %15, %13 : !llvm.ptr, !llvm.ptr
     cf.br ^bb4
   ^bb4:  // pred: ^bb3
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__storage__storage_pass.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__storage__storage_pass.snap
@@ -130,18 +130,18 @@ module {
     }
     return %alloc : memref<?x3xi256>
   }
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -149,15 +149,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -166,16 +166,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -186,28 +186,27 @@ module {
     %1 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %2 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %1, %2 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %3 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %3 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %4 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %4 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %4 : i64, !llvm.ptr
     %5 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %6 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %5, %6 : !llvm.ptr, !llvm.ptr
-    %7 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %7 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %8 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %7, %8 : i32, !llvm.ptr
+    llvm.store %7, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %9 : i64, !llvm.ptr
     %10 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%11: i256):  // no predecessors
     cf.switch %11 : i256, [
@@ -322,9 +321,9 @@ module {
   ^bb13:  // no predecessors
     cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %c0_i32_5 = arith.constant 0 : i32
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_5, %c0_i32_5, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/utils.rs
+++ b/crates/dora-compiler/src/dora/utils.rs
@@ -2,7 +2,7 @@ use crate::conversion::rewriter::Rewriter;
 use crate::errors::Result;
 use melior::{
     dialect::arith::{self},
-    ir::{attribute::IntegerAttribute, r#type::IntegerType, *},
+    ir::{attribute::IntegerAttribute, Location, Value},
     Context,
 };
 
@@ -12,12 +12,12 @@ pub(crate) fn round_up_32<'c>(
     rewriter: &'c Rewriter,
     location: Location<'c>,
 ) -> Result<Value<'c, 'c>> {
-    let uint32 = IntegerType::new(context, 32).into();
+    let uint64 = rewriter.intrinsics.i64_ty;
 
     let constant_31 = rewriter
         .create(arith::constant(
             context,
-            IntegerAttribute::new(uint32, 31).into(),
+            IntegerAttribute::new(uint64, 31).into(),
             location,
         ))
         .result(0)?
@@ -26,7 +26,7 @@ pub(crate) fn round_up_32<'c>(
     let constant_32 = rewriter
         .create(arith::constant(
             context,
-            IntegerAttribute::new(uint32, 32).into(),
+            IntegerAttribute::new(uint64, 32).into(),
             location,
         ))
         .result(0)?

--- a/crates/dora-compiler/src/evm/instructions/host.rs
+++ b/crates/dora-compiler/src/evm/instructions/host.rs
@@ -74,7 +74,8 @@ impl<'c> EVMCompiler<'c> {
         let start_block = region.append_block(Block::new(&[]));
         let mut builder = Self::make_builder(ctx, start_block);
         let block_number = builder.stack_pop()?;
-        builder.blockhash(block_number)?;
+        let block_hash = builder.blockhash(block_number)?;
+        builder.stack_push(block_hash)?;
         Ok((start_block, start_block))
     }
 

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_iszero_pop.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_iszero_pop.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -115,9 +114,9 @@ module {
     llvm.store %24, %22 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_pop.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_pop.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -102,9 +101,9 @@ module {
     llvm.store %16, %14 : !llvm.ptr, !llvm.ptr
     cf.br ^bb5
   ^bb5:  // pred: ^bb4
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_add.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_add.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_mul_div.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_mul_div.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -147,9 +146,9 @@ module {
     llvm.store %43, %41 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i32_3 = arith.constant 0 : i32
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_3, %c0_i32_3, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_sub.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_sub.snap
@@ -5,18 +5,18 @@ snapshot_kind: text
 ---
 module {
   llvm.mlir.global internal @dora_stack_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_stack_length() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_memory_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_memory_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_calldata_ptr() {addr_space = 0 : i32} : !llvm.ptr
-  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i32
+  llvm.mlir.global internal @dora_calldata_size() {addr_space = 0 : i32} : i64
   llvm.mlir.global internal @dora_gas_counter() {addr_space = 0 : i32} : i64
   llvm.mlir.global external @dora_ctx_is_static() {addr_space = 0 : i32} : !llvm.ptr
   func.func private @dora_debug_print(i32)
-  func.func private @dora_write_result(!llvm.ptr, i32, i32, i64, i8)
-  func.func private @dora_keccak256_hasher(!llvm.ptr, i32, i32, !llvm.ptr)
+  func.func private @dora_write_result(!llvm.ptr, i64, i64, i64, i8)
+  func.func private @dora_keccak256_hasher(!llvm.ptr, i64, i64, !llvm.ptr)
   func.func private @dora_get_calldata_ptr(!llvm.ptr) -> !llvm.ptr
-  func.func private @dora_get_calldata_size(!llvm.ptr) -> i32
+  func.func private @dora_get_calldata_size(!llvm.ptr) -> i64
   func.func private @dora_get_chainid(!llvm.ptr) -> i64
   func.func private @dora_store_in_callvalue_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_caller_ptr(!llvm.ptr, !llvm.ptr)
@@ -24,15 +24,15 @@ module {
   func.func private @dora_store_in_selfbalance_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_blobbasefee_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_gaslimit(!llvm.ptr) -> i64
-  func.func private @dora_extend_memory(!llvm.ptr, i32) -> !llvm.ptr
-  func.func private @dora_copy_code_to_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_extend_memory(!llvm.ptr, i64) -> !llvm.ptr
+  func.func private @dora_copy_code_to_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_read_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_write_storage(!llvm.ptr, !llvm.ptr, !llvm.ptr) -> i64
-  func.func private @dora_append_log(!llvm.ptr, i32, i32)
-  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i32, i32, !llvm.ptr)
-  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log(!llvm.ptr, i64, i64)
+  func.func private @dora_append_log_with_one_topic(!llvm.ptr, i64, i64, !llvm.ptr)
+  func.func private @dora_append_log_with_two_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_three_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+  func.func private @dora_append_log_with_four_topics(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_origin(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_coinbase_ptr(!llvm.ptr) -> !llvm.ptr
   func.func private @dora_get_block_number(!llvm.ptr, !llvm.ptr)
@@ -41,16 +41,16 @@ module {
   func.func private @dora_get_prevrandao(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_timestamp_ptr(!llvm.ptr, !llvm.ptr)
   func.func private @dora_store_in_basefee_ptr(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i32, i32, i32, i32, i64, !llvm.ptr, i8) -> i8
+  func.func private @dora_call(!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> i8
   func.func private @dora_store_in_balance(!llvm.ptr, !llvm.ptr, !llvm.ptr)
-  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i32, i32, i32)
+  func.func private @dora_copy_ext_code_to_memory(!llvm.ptr, !llvm.ptr, i64, i64, i64)
   func.func private @dora_get_blob_hash_at_index(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_get_block_hash(!llvm.ptr, !llvm.ptr)
   func.func private @dora_get_code_hash(!llvm.ptr, !llvm.ptr)
-  func.func private @dora_create(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_create2(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
-  func.func private @dora_get_return_data_size(!llvm.ptr) -> i32
-  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i32, i32, i32)
+  func.func private @dora_create(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_create2(!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i8
+  func.func private @dora_get_return_data_size(!llvm.ptr) -> i64
+  func.func private @dora_copy_return_data_into_memory(!llvm.ptr, i64, i64, i64)
   func.func private @dora_selfdestruct(!llvm.ptr, !llvm.ptr) -> i64
   func.func private @dora_transient_storage_read(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_transient_storage_write(!llvm.ptr, !llvm.ptr, !llvm.ptr)
@@ -59,28 +59,27 @@ module {
     %0 = llvm.alloca %c1024_i256 x i256 : (i256) -> !llvm.ptr
     %1 = llvm.mlir.addressof @dora_stack_ptr : !llvm.ptr
     llvm.store %0, %1 : !llvm.ptr, !llvm.ptr
-    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
     %2 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    llvm.store %c0_i32, %2 : i32, !llvm.ptr
-    %c0_i32_0 = arith.constant 0 : i32
+    llvm.store %c0_i64, %2 : i64, !llvm.ptr
+    %c0_i64_0 = arith.constant 0 : i64
     %3 = llvm.mlir.addressof @dora_memory_size : !llvm.ptr
-    llvm.store %c0_i32_0, %3 : i32, !llvm.ptr
+    llvm.store %c0_i64_0, %3 : i64, !llvm.ptr
     %4 = call @dora_get_calldata_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
     %5 = llvm.mlir.addressof @dora_calldata_ptr : !llvm.ptr
     llvm.store %4, %5 : !llvm.ptr, !llvm.ptr
-    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i32
+    %6 = call @dora_get_calldata_size(%arg0) : (!llvm.ptr) -> i64
     %7 = llvm.mlir.addressof @dora_calldata_size : !llvm.ptr
-    llvm.store %6, %7 : i32, !llvm.ptr
+    llvm.store %6, %7 : i64, !llvm.ptr
     %8 = llvm.mlir.addressof @dora_gas_counter : !llvm.ptr
     llvm.store %arg1, %8 : i64, !llvm.ptr
     %9 = llvm.mlir.addressof @dora_stack_length : !llvm.ptr
-    %c1024_i32 = arith.constant 1024 : i32
+    %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
   ^bb1:  // pred: ^bb2
-    %c0_i32_1 = arith.constant 0 : i32
-    %c0_i64 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c3_i8 = arith.constant 3 : i8
-    call @dora_write_result(%arg0, %c0_i32_1, %c0_i32_1, %c0_i64, %c3_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %c3_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c3_i8 : i8
   ^bb2(%10: i256):  // no predecessors
     cf.switch %10 : i256, [
@@ -121,9 +120,9 @@ module {
     llvm.store %28, %26 : !llvm.ptr, !llvm.ptr
     cf.br ^bb6
   ^bb6:  // pred: ^bb5
-    %c0_i32_2 = arith.constant 0 : i32
+    %c0_i64_2 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    call @dora_write_result(%arg0, %c0_i32_2, %c0_i32_2, %arg1, %c1_i8) : (!llvm.ptr, i32, i32, i64, i8) -> ()
+    call @dora_write_result(%arg0, %c0_i64_2, %c0_i64_2, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/symbols.rs
+++ b/crates/dora-compiler/src/symbols.rs
@@ -31,16 +31,16 @@ pub(crate) fn declare_symbols(context: &MLIRContext, module: &MLIRModule) {
         (symbols::DEBUG_PRINT, &[uint32], &[]),
         (
             symbols::WRITE_RESULT,
-            &[ptr_type, uint32, uint32, uint64, uint8],
+            &[ptr_type, uint64, uint64, uint64, uint8],
             &[],
         ),
         (
             symbols::KECCAK256_HASHER,
-            &[ptr_type, uint32, uint32, ptr_type],
+            &[ptr_type, uint64, uint64, ptr_type],
             &[],
         ),
         (symbols::GET_CALLDATA_PTR, &[ptr_type], &[ptr_type]),
-        (symbols::GET_CALLDATA_SIZE, &[ptr_type], &[uint32]),
+        (symbols::GET_CALLDATA_SIZE, &[ptr_type], &[uint64]),
         (symbols::GET_CHAINID, &[ptr_type], &[uint64]),
         (symbols::STORE_IN_CALLVALUE_PTR, &[ptr_type, ptr_type], &[]),
         (symbols::STORE_IN_CALLER_PTR, &[ptr_type, ptr_type], &[]),
@@ -56,10 +56,10 @@ pub(crate) fn declare_symbols(context: &MLIRContext, module: &MLIRModule) {
             &[],
         ),
         (symbols::GET_GASLIMIT, &[ptr_type], &[uint64]),
-        (symbols::EXTEND_MEMORY, &[ptr_type, uint32], &[ptr_type]),
+        (symbols::EXTEND_MEMORY, &[ptr_type, uint64], &[ptr_type]),
         (
             symbols::COPY_CODE_TO_MEMORY,
-            &[ptr_type, uint32, uint32, uint32],
+            &[ptr_type, uint64, uint64, uint64],
             &[],
         ),
         (symbols::STORAGE_READ, &[ptr_type, ptr_type, ptr_type], &[]),
@@ -68,26 +68,26 @@ pub(crate) fn declare_symbols(context: &MLIRContext, module: &MLIRModule) {
             &[ptr_type, ptr_type, ptr_type],
             &[uint64],
         ),
-        (symbols::APPEND_LOG, &[ptr_type, uint32, uint32], &[]),
+        (symbols::APPEND_LOG, &[ptr_type, uint64, uint64], &[]),
         (
             symbols::APPEND_LOG_ONE_TOPIC,
-            &[ptr_type, uint32, uint32, ptr_type],
+            &[ptr_type, uint64, uint64, ptr_type],
             &[],
         ),
         (
             symbols::APPEND_LOG_TWO_TOPICS,
-            &[ptr_type, uint32, uint32, ptr_type, ptr_type],
+            &[ptr_type, uint64, uint64, ptr_type, ptr_type],
             &[],
         ),
         (
             symbols::APPEND_LOG_THREE_TOPICS,
-            &[ptr_type, uint32, uint32, ptr_type, ptr_type, ptr_type],
+            &[ptr_type, uint64, uint64, ptr_type, ptr_type, ptr_type],
             &[],
         ),
         (
             symbols::APPEND_LOG_FOUR_TOPICS,
             &[
-                ptr_type, uint32, uint32, ptr_type, ptr_type, ptr_type, ptr_type,
+                ptr_type, uint64, uint64, ptr_type, ptr_type, ptr_type, ptr_type,
             ],
             &[],
         ),
@@ -106,7 +106,7 @@ pub(crate) fn declare_symbols(context: &MLIRContext, module: &MLIRModule) {
         (
             symbols::CALL,
             &[
-                ptr_type, uint64, ptr_type, ptr_type, uint32, uint32, uint32, uint32, uint64,
+                ptr_type, uint64, ptr_type, ptr_type, uint64, uint64, uint64, uint64, uint64,
                 ptr_type, uint8,
             ],
             &[uint8],
@@ -118,7 +118,7 @@ pub(crate) fn declare_symbols(context: &MLIRContext, module: &MLIRModule) {
         ),
         (
             symbols::COPY_EXT_CODE_TO_MEMORY,
-            &[ptr_type, ptr_type, uint32, uint32, uint32],
+            &[ptr_type, ptr_type, uint64, uint64, uint64],
             &[],
         ),
         (
@@ -130,18 +130,18 @@ pub(crate) fn declare_symbols(context: &MLIRContext, module: &MLIRModule) {
         (symbols::GET_CODE_HASH, &[ptr_type, ptr_type], &[]),
         (
             symbols::CREATE,
-            &[ptr_type, uint32, uint32, ptr_type, ptr_type],
+            &[ptr_type, uint64, uint64, ptr_type, ptr_type],
             &[uint8],
         ),
         (
             symbols::CREATE2,
-            &[ptr_type, uint32, uint32, ptr_type, ptr_type, ptr_type],
+            &[ptr_type, uint64, uint64, ptr_type, ptr_type, ptr_type],
             &[uint8],
         ),
-        (symbols::GET_RETURN_DATA_SIZE, &[ptr_type], &[uint32]),
+        (symbols::GET_RETURN_DATA_SIZE, &[ptr_type], &[uint64]),
         (
             symbols::COPY_RETURN_DATA_INTO_MEMORY,
-            &[ptr_type, uint32, uint32, uint32],
+            &[ptr_type, uint64, uint64, uint64],
             &[],
         ),
         (symbols::SELFDESTRUCT, &[ptr_type, ptr_type], &[uint64]),

--- a/crates/dora-runtime/src/result.rs
+++ b/crates/dora-runtime/src/result.rs
@@ -360,6 +360,7 @@ pub enum HaltReason {
     CallNotAllowedInsideStatic,
     OutOfFunds,
     CallTooDeep,
+    RuntimeError,
 }
 
 /// Represents out-of-gas errors during EVM execution.

--- a/crates/dora/src/tests/operations.rs
+++ b/crates/dora/src/tests/operations.rs
@@ -281,7 +281,6 @@ fn sdiv_positive() {
         Operation::Push((1_u8, b.clone())),
         Operation::Push((1_u8, a.clone())),
         Operation::Sdiv,
-        Operation::Mod,
         // Return result
         Operation::Push0,
         Operation::Mstore,
@@ -1027,6 +1026,7 @@ fn address() {
 #[test]
 fn balance() {
     let operations = vec![
+        Operation::Push0,
         Operation::Balance,
         // Return result
         Operation::Push0,
@@ -1638,7 +1638,7 @@ fn extcodehash_empty_address() {
 #[test]
 fn blockhash_invalid_block_number() {
     let operations = vec![
-        Operation::Push((32_u8, BigUint::from(599423545_u32))),
+        Operation::Push((32_u8, BigUint::from(59942354_u32))),
         Operation::BlockHash,
         // Return result
         Operation::Push0,
@@ -1651,9 +1651,8 @@ fn blockhash_invalid_block_number() {
     run_program_assert_num_result(env, db, 0_u8.into());
 }
 
-// #[test]
-// TODO: fix it in CI
-fn _blockhash_previous_block() {
+#[test]
+fn blockhash_previous_block() {
     let block_number = 1_u8;
     let block_hash = 209433;
     let current_block_number = 3_u8;
@@ -2715,7 +2714,7 @@ fn create_with_value() {
 #[test]
 fn create2_with_salt() {
     let operations = vec![
-        Operation::Push((1_u8, BigUint::from(0x1234_u16))),
+        Operation::Push((32_u8, BigUint::from(0x1234_u16))),
         Operation::Push((1_u8, BigUint::from(0_u8))),
         Operation::Push((1_u8, BigUint::from(20_u8))),
         Operation::Push((1_u8, BigUint::from(10_u8))),
@@ -2731,7 +2730,7 @@ fn create2_with_salt() {
     run_program_assert_num_result(
         env,
         db,
-        BigUint::from_str("1360874012957008445308945769568407652762850697122").unwrap(),
+        BigUint::from_str("603501459724177619068228368451474163543628990102").unwrap(),
     );
 }
 
@@ -2949,8 +2948,8 @@ fn call_2() {
 #[test]
 fn callcode() {
     let operations = vec![
-        Operation::Push((1_u8, BigUint::from(5000_u32))),
-        Operation::Push((1_u8, BigUint::from(0x2000_u32))),
+        Operation::Push((32_u8, BigUint::from(5000_u32))),
+        Operation::Push((32_u8, BigUint::from(0x2000_u32))),
         Operation::Push((1_u8, BigUint::from(0_u32))),
         Operation::Push((1_u8, BigUint::from(32_u32))),
         Operation::Push((1_u8, BigUint::from(32_u32))),
@@ -3269,7 +3268,7 @@ pub(crate) fn default_env_and_db_setup(operations: Vec<Operation>) -> (Env, Memo
 
 fn run_program_assert_num_result(env: Env, db: MemoryDb, expected_result: BigUint) {
     let result = run_evm(env, db).unwrap().result;
-    assert!(result.is_success());
+    assert!(result.is_success(), "{:?}", result);
     let result_data = BigUint::from_bytes_be(result.output().unwrap_or(&Bytes::new()));
     assert_eq!(result_data, expected_result);
 }


### PR DESCRIPTION
re #40