### PR TITLE
refactor: separate account storage and code artifact storage

### DIFF
--- a/crates/dora-runtime/src/account.rs
+++ b/crates/dora-runtime/src/account.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 use std::{collections::HashMap, fmt::Debug};
 
-use crate::artifact::Artifact;
 use crate::db::{DbAccount, StorageSlot};
 use bitflags::bitflags;
 use dora_primitives::{Bytecode, B256, U256};
@@ -39,7 +38,7 @@ pub const EMPTY_CODE_HASH_STR: &str =
 /// assert!(!account_info.has_code());
 /// ```
 #[derive(Clone, Default, PartialEq, Eq, Debug)]
-pub struct AccountInfo<A: Artifact> {
+pub struct AccountInfo {
     /// Account balance.
     pub balance: U256,
     /// Account nonce.
@@ -48,13 +47,11 @@ pub struct AccountInfo<A: Artifact> {
     pub code_hash: B256,
     /// The account's bytecode, if any. `None` indicates the code should be fetched when needed.
     pub code: Option<Bytecode>,
-    /// The account's bytecode artifact, if any. `None` indicates the code should be compiled.
-    pub artifact: Option<A>,
 }
 
-impl<A: Artifact> AccountInfo<A> {
+impl AccountInfo {
     /// Construct an empty account info.
-    pub fn empty() -> AccountInfo<A> {
+    pub fn empty() -> AccountInfo {
         DbAccount::empty().into()
     }
 
@@ -99,16 +96,16 @@ impl<A: Artifact> AccountInfo<A> {
 /// - `storage`: A storage cache represented as a `HashMap` that holds the account's storage slots.
 /// - `status`: The current status of the account, which may include flags indicating whether it has been modified.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct Account<A: Artifact> {
+pub struct Account {
     /// The account's core information (balance, nonce, code).
-    pub info: AccountInfo<A>,
+    pub info: AccountInfo,
     /// A cache of the account's storage, mapping storage keys to storage slots.
     pub storage: HashMap<U256, StorageSlot>,
     /// Flags representing the account's current status (e.g., whether it has been modified).
     pub status: AccountStatus,
 }
 
-impl<A: Artifact> Account<A> {
+impl Account {
     /// Checks if the account is marked for self-destruction.
     ///
     /// # Returns:
@@ -177,8 +174,8 @@ impl Default for AccountStatus {
     }
 }
 
-impl<A: Artifact> From<AccountInfo<A>> for Account<A> {
-    fn from(info: AccountInfo<A>) -> Self {
+impl From<AccountInfo> for Account {
+    fn from(info: AccountInfo) -> Self {
         Self {
             info,
             storage: HashMap::new(),

--- a/crates/dora-runtime/src/context.rs
+++ b/crates/dora-runtime/src/context.rs
@@ -113,12 +113,8 @@ impl CallFrame {
     }
 }
 
-pub type RuntimeTransaction<DB> = Arc<
-    dyn Transaction<
-        Context = RuntimeContext<DB>,
-        Result = anyhow::Result<ResultAndState<<DB as Database>::Artifact>>,
-    >,
->;
+pub type RuntimeTransaction<DB> =
+    Arc<dyn Transaction<Context = RuntimeContext<DB>, Result = anyhow::Result<ResultAndState>>>;
 pub type RuntimeHost = Arc<RwLock<dyn Host>>;
 pub type RuntimeDB<DB> = Arc<RwLock<DB>>;
 
@@ -335,7 +331,7 @@ impl<DB: Database> RuntimeContext<DB> {
     /// ```no_check
     /// let result = context.get_result();
     /// ```
-    pub fn get_result(&self) -> anyhow::Result<ResultAndState<DB::Artifact>, EVMError> {
+    pub fn get_result(&self) -> anyhow::Result<ResultAndState, EVMError> {
         let host = self.host.read().unwrap();
         let gas_remaining = self.inner_context.gas_remaining.unwrap_or(0);
         let gas_initial = host.env().tx.gas_limit;
@@ -774,7 +770,7 @@ impl<DB: Database> RuntimeContext<DB> {
         let host = self.host.read().unwrap();
         let addr = host.env().tx.transact_to;
         let account = if addr.is_zero() {
-            AccountInfo::<DB::Artifact>::default()
+            AccountInfo::default()
         } else {
             self.db
                 .read()

--- a/crates/dora-runtime/src/result.rs
+++ b/crates/dora-runtime/src/result.rs
@@ -1,4 +1,4 @@
-use crate::{account::Account, artifact::Artifact, db::DatabaseError};
+use crate::{account::Account, db::DatabaseError};
 use core::fmt;
 use dora_primitives::{Bytes, EVMAddress as Address};
 use ruint::aliases::U256;
@@ -11,11 +11,11 @@ use std::{boxed::Box, fmt::Debug, string::String};
 /// - `result`: The `ExecutionResult` indicating the status of the transaction.
 /// - `state`: A `HashMap` representing the updated account state after execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ResultAndState<A: Artifact> {
+pub struct ResultAndState {
     /// Status of execution, containing details of success, revert, or halt.
     pub result: ExecutionResult,
     /// Updated state of accounts after execution.
-    pub state: FxHashMap<Address, Account<A>>,
+    pub state: FxHashMap<Address, Account>,
 }
 
 /// Represents the result of executing a transaction in the EVM.

--- a/crates/dora-tools/bins/ethertest/main.rs
+++ b/crates/dora-tools/bins/ethertest/main.rs
@@ -253,7 +253,7 @@ fn should_skip(path: &Path) -> bool {
 fn run_with_shared_db<DB: Database + 'static>(
     mut env: Env,
     db: RuntimeDB<DB>,
-) -> Result<ResultAndState<DB::Artifact>> {
+) -> Result<ResultAndState> {
     env.validate_transaction().map_err(|e| anyhow::anyhow!(e))?;
     env.consume_intrinsic_cost()
         .map_err(|e| anyhow::anyhow!(e))?;


### PR DESCRIPTION
refactor: separate account storage and code artifact storage, keeping the account model unchanged

+ Code artifact interfaces (dora format)

```rust
    /// Retrieves the contract bytecode artifact for a given code hash.
    ///
    /// # Parameters:
    /// - `code_hash`: The hash of the contract code to be retrieved.
    ///
    /// # Returns:
    /// - `Result<Bytecode, Self::Error>`: A `Result` containing either the `Bytecode` associated with the hash
    ///   or an error if the query fails.
    fn get_artifact(&self, code_hash: B256) -> Result<Option<Self::Artifact>, Self::Error>;

    /// Sets or updates an account in the database with the specified address and the contract artifact.
    fn set_artifact(&mut self, code_hash: B256, artifact: Self::Artifact);
```

When integrated with different backends or blockchains, `Self::Artifact` is a byte sequence that can be stored on disk or memory, and `Self::Error` is a possible error that may occur when corresponding to the backend API.


+ The evmc host interface maybe

```c
typedef evmc_bytes (*evmc_get_artifact_fn)(struct evmc_host_context* context, const evmc_bytes32* hash);
typedef void (*evmc_set_artifact_fn)(struct evmc_host_context* context, const evmc_bytes32 code_hash, const evmc_bytes artifact);
```

+ One possible memory implementation in dora for the integration test, e.g., `MemoryDB`

```diff
#[derive(Clone, Debug, Default)]
pub struct MemoryDB {
-    accounts: FxHashMap<Address, DbAccount<SymbolArtifact>>,
+    accounts: FxHashMap<Address, DbAccount>,
     contracts: FxHashMap<B256, Bytecode>,
+    artifacts: FxHashMap<B256, SymbolArtifact>,
     block_hashes: FxHashMap<U256, B256>,
}
```
