### PR TITLE
feat: extend memory runtime error check

### DIFF
--- a/crates/dora-compiler/src/dora/instructions/host.rs
+++ b/crates/dora-compiler/src/dora/instructions/host.rs
@@ -1,7 +1,7 @@
 use crate::backend::IntCC;
 use crate::check_u256_to_u64_overflow;
 use crate::{
-    arith_constant, check_resize_memory,
+    arith_constant,
     conversion::builder::OpBuilder,
     conversion::rewriter::{DeferredRewriter, Rewriter},
     create_var,
@@ -137,15 +137,8 @@ impl<'c> ConversionPass<'c> {
         // consume 3 * (size + 31) / 32 gas
         // dynamic gas computation
 
-        check_resize_memory!(op, rewriter, required_memory_size);
+        memory::resize_memory(context, op, &rewriter, syscall_ctx, required_memory_size)?;
         rewrite_ctx!(context, op, rewriter, location);
-        memory::resize_memory(
-            required_memory_size,
-            context,
-            &rewriter,
-            syscall_ctx,
-            location,
-        )?;
         rewriter.create(func::call(
             context,
             FlatSymbolRefAttribute::new(context, symbols::COPY_EXT_CODE_TO_MEMORY),
@@ -285,15 +278,8 @@ impl<'c> ConversionPass<'c> {
 
         // required_size = offset + size
         let required_memory_size = rewriter.make(arith::addi(offset, size, location))?;
-        check_resize_memory!(op, rewriter, required_memory_size);
+        memory::resize_memory(context, op, &rewriter, syscall_ctx, required_memory_size)?;
         rewrite_ctx!(context, op, rewriter, location);
-        memory::resize_memory(
-            required_memory_size,
-            context,
-            &rewriter,
-            syscall_ctx,
-            location,
-        )?;
 
         // Handle topics dynamically
         let mut topic_pointers = vec![];

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 7 preds: ^bb2, ^bb5, ^bb9, ^bb14, ^bb15, ^bb19, ^bb23
+  ^bb1(%10: i8):  // 12 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11, ^bb16, ^bb17, ^bb18, ^bb22, ^bb23, ^bb27, ^bb28
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,307 +120,312 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %174 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %175 = llvm.getelementptr %174[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %177 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %176, %177 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c170141183460469231731687303715884105727_i256_4 = arith.constant 170141183460469231731687303715884105727 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c170141183460469231731687303715884105727_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c32_i256 = arith.constant 32 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c170141183460469231731687303715884105727_i256_4 = arith.constant 170141183460469231731687303715884105727 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c170141183460469231731687303715884105727_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %c32_i64_5 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c32_i64_5 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %56 = arith.cmpi slt, %55, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %56, ^bb1(%c84_i8_7 : i8), ^bb10
+    %c32_i256 = arith.constant 32 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %60 = arith.addi %59, %c32_i64_5 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_7 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %59 = arith.addi %55, %c31_i64_8 : i64
-    %60 = arith.divui %59, %c32_i64_9 : i64
-    %61 = arith.muli %60, %c32_i64_9 : i64
-    %62 = arith.cmpi ult, %58, %61 : i64
-    scf.if %62 {
-      %174 = func.call @dora_fn_extend_memory(%arg0, %61) : (!llvm.ptr, i64) -> !llvm.ptr
-      %175 = llvm.getelementptr %174[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-      llvm.store %61, %57 : i64, !llvm.ptr
-      %177 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %176, %177 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> !llvm.ptr
-    %65 = llvm.getelementptr %64[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %66 = llvm.intr.bswap(%53)  : (i256) -> i256
-    llvm.store %66, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c41_i256 = arith.constant 41 : i256
-    %67 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c41_i256, %68 : i256, !llvm.ptr
-    %69 = llvm.getelementptr %68[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %69, %67 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb12
+    %62 = arith.addi %60, %c31_i64_8 : i64
+    %63 = arith.divui %62, %c32_i64_9 : i64
+    %64 = arith.muli %63, %c32_i64_9 : i64
+    %65 = call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
+    %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_10 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i256_10 = arith.constant 0 : i256
-    %70 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %71 : i256, !llvm.ptr
-    %72 = llvm.getelementptr %71[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %72, %70 : !llvm.ptr, !llvm.ptr
+    %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %67, %71 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %64, %72 : i64, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
+    %75 = llvm.getelementptr %74[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %76 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %76, %75 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_11 = arith.constant 0 : i256
-    %73 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %74 : i256, !llvm.ptr
-    %75 = llvm.getelementptr %74[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
+    %c41_i256 = arith.constant 41 : i256
+    %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c41_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %76 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %77 = llvm.load %76 : !llvm.ptr -> !llvm.ptr
-    %78 = llvm.getelementptr %77[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %79 = llvm.load %78 : !llvm.ptr -> i256
-    llvm.store %78, %76 : !llvm.ptr, !llvm.ptr
+    %c0_i256_11 = arith.constant 0 : i256
     %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    %82 = llvm.getelementptr %81[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %83 = llvm.load %82 : !llvm.ptr -> i256
+    llvm.store %c0_i256_11, %81 : i256, !llvm.ptr
+    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    %84 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> !llvm.ptr
-    %86 = llvm.getelementptr %85[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %87 = llvm.load %86 : !llvm.ptr -> i256
-    llvm.store %86, %84 : !llvm.ptr, !llvm.ptr
-    %88 = arith.trunci %83 : i256 to i64
-    %89 = arith.trunci %87 : i256 to i64
-    %90 = arith.addi %88, %89 : i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %91 = arith.cmpi slt, %90, %c0_i64_12 : i64
-    %c84_i8_13 = arith.constant 84 : i8
-    cf.cond_br %91, ^bb1(%c84_i8_13 : i8), ^bb15
+    cf.br ^bb15
   ^bb15:  // pred: ^bb14
-    %92 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> i64
-    %c31_i64_14 = arith.constant 31 : i64
-    %c32_i64_15 = arith.constant 32 : i64
-    %94 = arith.addi %90, %c31_i64_14 : i64
-    %95 = arith.divui %94, %c32_i64_15 : i64
-    %96 = arith.muli %95, %c32_i64_15 : i64
-    %97 = arith.cmpi ult, %93, %96 : i64
-    scf.if %97 {
-      %174 = func.call @dora_fn_extend_memory(%arg0, %96) : (!llvm.ptr, i64) -> !llvm.ptr
-      %175 = llvm.getelementptr %174[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-      llvm.store %96, %92 : i64, !llvm.ptr
-      %177 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %176, %177 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %98 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %79, %98 {alignment = 1 : i64} : i256, !llvm.ptr
-    %99 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %100 = llvm.load %99 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %101 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %100, %101 {alignment = 1 : i64} : i64, !llvm.ptr
-    %102 = call @dora_fn_create(%arg0, %89, %88, %98, %101) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %c0_i8, %104 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %105, ^bb1(%c94_i8 : i8), ^bb16
+    %c0_i256_12 = arith.constant 0 : i256
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %84 : i256, !llvm.ptr
+    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb16
   ^bb16:  // pred: ^bb15
-    %106 = llvm.load %98 : !llvm.ptr -> i256
-    %107 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %108 = llvm.load %107 : !llvm.ptr -> !llvm.ptr
-    llvm.store %106, %108 : i256, !llvm.ptr
-    %109 = llvm.getelementptr %108[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %109, %107 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb17
+    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
+    %88 = llvm.getelementptr %87[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %89 = llvm.load %88 : !llvm.ptr -> i256
+    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    %92 = llvm.getelementptr %91[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %93 = llvm.load %92 : !llvm.ptr -> i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
+    %94 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %95 = llvm.load %94 : !llvm.ptr -> !llvm.ptr
+    %96 = llvm.getelementptr %95[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %97 = llvm.load %96 : !llvm.ptr -> i256
+    llvm.store %96, %94 : !llvm.ptr, !llvm.ptr
+    %98 = arith.trunci %93 : i256 to i64
+    %99 = arith.trunci %97 : i256 to i64
+    %100 = arith.addi %98, %99 : i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %101 = arith.cmpi slt, %100, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %101, ^bb1(%c84_i8_14 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %110 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> !llvm.ptr
-    %112 = llvm.getelementptr %111[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %113 = llvm.load %112 : !llvm.ptr -> i256
-    llvm.store %112, %110 : !llvm.ptr, !llvm.ptr
-    %c1_i256_16 = arith.constant 1 : i256
-    %114 = llvm.alloca %c1_i256_16 x i256 : (i256) -> !llvm.ptr
-    llvm.store %113, %114 {alignment = 1 : i64} : i256, !llvm.ptr
-    %115 = call @dora_fn_extcodesize(%arg0, %114) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %116 = llvm.getelementptr %115[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %117 = llvm.load %116 : !llvm.ptr -> i64
-    %118 = arith.extui %117 : i64 to i256
-    %119 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %120 = llvm.load %119 : !llvm.ptr -> !llvm.ptr
-    llvm.store %118, %120 : i256, !llvm.ptr
-    %121 = llvm.getelementptr %120[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %121, %119 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb18
+    %c31_i64_15 = arith.constant 31 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %102 = arith.addi %100, %c31_i64_15 : i64
+    %103 = arith.divui %102, %c32_i64_16 : i64
+    %104 = arith.muli %103, %c32_i64_16 : i64
+    %105 = call @dora_fn_extend_memory(%arg0, %104) : (!llvm.ptr, i64) -> !llvm.ptr
+    %106 = llvm.getelementptr %105[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %107 = llvm.load %106 : !llvm.ptr -> !llvm.ptr
+    %108 = llvm.getelementptr %105[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %109 = llvm.load %108 : !llvm.ptr -> i8
+    %c0_i8_17 = arith.constant 0 : i8
+    %110 = arith.cmpi ne, %109, %c0_i8_17 : i8
+    cf.cond_br %110, ^bb1(%109 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i256_17 = arith.constant 0 : i256
+    %111 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %107, %111 : !llvm.ptr, !llvm.ptr
+    %112 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %104, %112 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %113 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %89, %113 {alignment = 1 : i64} : i256, !llvm.ptr
+    %114 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %116 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %115, %116 {alignment = 1 : i64} : i64, !llvm.ptr
+    %117 = call @dora_fn_create(%arg0, %99, %98, %113, %116) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %118 = llvm.getelementptr %117[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %119 = llvm.load %118 : !llvm.ptr -> i8
+    %c0_i8_18 = arith.constant 0 : i8
+    %120 = arith.cmpi ne, %c0_i8_18, %119 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %120, ^bb1(%c94_i8 : i8), ^bb19
+  ^bb19:  // pred: ^bb18
+    %121 = llvm.load %113 : !llvm.ptr -> i256
     %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_17, %123 : i256, !llvm.ptr
+    llvm.store %121, %123 : i256, !llvm.ptr
     %124 = llvm.getelementptr %123[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb19
-  ^bb19:  // pred: ^bb18
+    cf.br ^bb20
+  ^bb20:  // pred: ^bb19
     %125 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %126 = llvm.load %125 : !llvm.ptr -> !llvm.ptr
     %127 = llvm.getelementptr %126[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %128 = llvm.load %127 : !llvm.ptr -> i256
     llvm.store %127, %125 : !llvm.ptr, !llvm.ptr
-    %129 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %130 = llvm.load %129 : !llvm.ptr -> !llvm.ptr
-    %131 = llvm.getelementptr %130[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %132 = llvm.load %131 : !llvm.ptr -> i256
-    llvm.store %131, %129 : !llvm.ptr, !llvm.ptr
-    %133 = arith.trunci %128 : i256 to i64
-    %c32_i64_18 = arith.constant 32 : i64
-    %134 = arith.addi %133, %c32_i64_18 : i64
-    %c0_i64_19 = arith.constant 0 : i64
-    %135 = arith.cmpi slt, %134, %c0_i64_19 : i64
-    %c84_i8_20 = arith.constant 84 : i8
-    cf.cond_br %135, ^bb1(%c84_i8_20 : i8), ^bb20
-  ^bb20:  // pred: ^bb19
-    %136 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %137 = llvm.load %136 : !llvm.ptr -> i64
-    %c31_i64_21 = arith.constant 31 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %138 = arith.addi %134, %c31_i64_21 : i64
-    %139 = arith.divui %138, %c32_i64_22 : i64
-    %140 = arith.muli %139, %c32_i64_22 : i64
-    %141 = arith.cmpi ult, %137, %140 : i64
-    scf.if %141 {
-      %174 = func.call @dora_fn_extend_memory(%arg0, %140) : (!llvm.ptr, i64) -> !llvm.ptr
-      %175 = llvm.getelementptr %174[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-      llvm.store %140, %136 : i64, !llvm.ptr
-      %177 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %176, %177 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %142 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %143 = llvm.load %142 : !llvm.ptr -> !llvm.ptr
-    %144 = llvm.getelementptr %143[%133] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %145 = llvm.intr.bswap(%132)  : (i256) -> i256
-    llvm.store %145, %144 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_19 = arith.constant 1 : i256
+    %129 = llvm.alloca %c1_i256_19 x i256 : (i256) -> !llvm.ptr
+    llvm.store %128, %129 {alignment = 1 : i64} : i256, !llvm.ptr
+    %130 = call @dora_fn_extcodesize(%arg0, %129) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %131 = llvm.getelementptr %130[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %132 = llvm.load %131 : !llvm.ptr -> i64
+    %133 = arith.extui %132 : i64 to i256
+    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
+    llvm.store %133, %135 : i256, !llvm.ptr
+    %136 = llvm.getelementptr %135[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %c32_i256_23 = arith.constant 32 : i256
-    %146 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %147 = llvm.load %146 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_23, %147 : i256, !llvm.ptr
-    %148 = llvm.getelementptr %147[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %148, %146 : !llvm.ptr, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %137 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %138 = llvm.load %137 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %138 : i256, !llvm.ptr
+    %139 = llvm.getelementptr %138[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %139, %137 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_24 = arith.constant 0 : i256
-    %149 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %150 = llvm.load %149 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_24, %150 : i256, !llvm.ptr
-    %151 = llvm.getelementptr %150[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %151, %149 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %140 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %141 = llvm.load %140 : !llvm.ptr -> !llvm.ptr
+    %142 = llvm.getelementptr %141[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %143 = llvm.load %142 : !llvm.ptr -> i256
+    llvm.store %142, %140 : !llvm.ptr, !llvm.ptr
+    %144 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %145 = llvm.load %144 : !llvm.ptr -> !llvm.ptr
+    %146 = llvm.getelementptr %145[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %147 = llvm.load %146 : !llvm.ptr -> i256
+    llvm.store %146, %144 : !llvm.ptr, !llvm.ptr
+    %148 = arith.trunci %143 : i256 to i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %149 = arith.addi %148, %c32_i64_21 : i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %150 = arith.cmpi slt, %149, %c0_i64_22 : i64
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %150, ^bb1(%c84_i8_23 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %152 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %153 = llvm.load %152 : !llvm.ptr -> !llvm.ptr
-    %154 = llvm.getelementptr %153[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %155 = llvm.load %154 : !llvm.ptr -> i256
-    llvm.store %154, %152 : !llvm.ptr, !llvm.ptr
-    %156 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %157 = llvm.load %156 : !llvm.ptr -> !llvm.ptr
-    %158 = llvm.getelementptr %157[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %159 = llvm.load %158 : !llvm.ptr -> i256
-    llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
-    %160 = arith.trunci %155 : i256 to i64
-    %161 = arith.trunci %159 : i256 to i64
-    %162 = arith.addi %161, %160 : i64
-    %163 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %164 = llvm.load %163 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
-    %165 = arith.cmpi slt, %162, %c0_i64_25 : i64
-    %c84_i8_26 = arith.constant 84 : i8
-    cf.cond_br %165, ^bb1(%c84_i8_26 : i8), ^bb24
+    %c31_i64_24 = arith.constant 31 : i64
+    %c32_i64_25 = arith.constant 32 : i64
+    %151 = arith.addi %149, %c31_i64_24 : i64
+    %152 = arith.divui %151, %c32_i64_25 : i64
+    %153 = arith.muli %152, %c32_i64_25 : i64
+    %154 = call @dora_fn_extend_memory(%arg0, %153) : (!llvm.ptr, i64) -> !llvm.ptr
+    %155 = llvm.getelementptr %154[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %156 = llvm.load %155 : !llvm.ptr -> !llvm.ptr
+    %157 = llvm.getelementptr %154[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %158 = llvm.load %157 : !llvm.ptr -> i8
+    %c0_i8_26 = arith.constant 0 : i8
+    %159 = arith.cmpi ne, %158, %c0_i8_26 : i8
+    cf.cond_br %159, ^bb1(%158 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %166 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %167 = llvm.load %166 : !llvm.ptr -> i64
-    %c31_i64_27 = arith.constant 31 : i64
-    %c32_i64_28 = arith.constant 32 : i64
-    %168 = arith.addi %162, %c31_i64_27 : i64
-    %169 = arith.divui %168, %c32_i64_28 : i64
-    %170 = arith.muli %169, %c32_i64_28 : i64
-    %171 = arith.cmpi ult, %167, %170 : i64
-    scf.if %171 {
-      %174 = func.call @dora_fn_extend_memory(%arg0, %170) : (!llvm.ptr, i64) -> !llvm.ptr
-      %175 = llvm.getelementptr %174[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-      llvm.store %170, %166 : i64, !llvm.ptr
-      %177 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %176, %177 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c0_i8_29 = arith.constant 0 : i8
-    %172 = call @dora_fn_write_result(%arg0, %160, %161, %164, %c0_i8_29) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
-    return %c0_i8_29 : i8
-  ^bb25:  // no predecessors
+    %160 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %156, %160 : !llvm.ptr, !llvm.ptr
+    %161 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %153, %161 : i64, !llvm.ptr
+    %162 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %163 = llvm.load %162 : !llvm.ptr -> !llvm.ptr
+    %164 = llvm.getelementptr %163[%148] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %165 = llvm.intr.bswap(%147)  : (i256) -> i256
+    llvm.store %165, %164 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb25
+  ^bb25:  // pred: ^bb24
+    %c32_i256_27 = arith.constant 32 : i256
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_27, %167 : i256, !llvm.ptr
+    %168 = llvm.getelementptr %167[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i64_30 = arith.constant 0 : i64
+    %c0_i256_28 = arith.constant 0 : i256
+    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_28, %170 : i256, !llvm.ptr
+    %171 = llvm.getelementptr %170[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %171, %169 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb27
+  ^bb27:  // pred: ^bb26
+    %172 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %173 = llvm.load %172 : !llvm.ptr -> !llvm.ptr
+    %174 = llvm.getelementptr %173[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %175 = llvm.load %174 : !llvm.ptr -> i256
+    llvm.store %174, %172 : !llvm.ptr, !llvm.ptr
+    %176 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %177 = llvm.load %176 : !llvm.ptr -> !llvm.ptr
+    %178 = llvm.getelementptr %177[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %179 = llvm.load %178 : !llvm.ptr -> i256
+    llvm.store %178, %176 : !llvm.ptr, !llvm.ptr
+    %180 = arith.trunci %175 : i256 to i64
+    %181 = arith.trunci %179 : i256 to i64
+    %182 = arith.addi %181, %180 : i64
+    %183 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %184 = llvm.load %183 : !llvm.ptr -> i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %185 = arith.cmpi slt, %182, %c0_i64_29 : i64
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %185, ^bb1(%c84_i8_30 : i8), ^bb28
+  ^bb28:  // pred: ^bb27
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %186 = arith.addi %182, %c31_i64_31 : i64
+    %187 = arith.divui %186, %c32_i64_32 : i64
+    %188 = arith.muli %187, %c32_i64_32 : i64
+    %189 = call @dora_fn_extend_memory(%arg0, %188) : (!llvm.ptr, i64) -> !llvm.ptr
+    %190 = llvm.getelementptr %189[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
+    %192 = llvm.getelementptr %189[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %193 = llvm.load %192 : !llvm.ptr -> i8
+    %c0_i8_33 = arith.constant 0 : i8
+    %194 = arith.cmpi ne, %193, %c0_i8_33 : i8
+    cf.cond_br %194, ^bb1(%193 : i8), ^bb29
+  ^bb29:  // pred: ^bb28
+    %195 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %191, %195 : !llvm.ptr, !llvm.ptr
+    %196 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %188, %196 : i64, !llvm.ptr
+    %c0_i8_34 = arith.constant 0 : i8
+    %197 = call @dora_fn_write_result(%arg0, %180, %181, %184, %c0_i8_34) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    return %c0_i8_34 : i8
+  ^bb30:  // no predecessors
+    cf.br ^bb31
+  ^bb31:  // pred: ^bb30
+    %c0_i64_35 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %173 = call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %198 = call @dora_fn_write_result(%arg0, %c0_i64_35, %c0_i64_35, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log0.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb5, ^bb6, ^bb7
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -130,29 +130,30 @@ module {
     %c84_i8_5 = arith.constant 84 : i8
     cf.cond_br %32, ^bb1(%c84_i8_5 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %33 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %34 = llvm.load %33 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %35 = arith.addi %31, %c31_i64 : i64
-    %36 = arith.divui %35, %c32_i64 : i64
-    %37 = arith.muli %36, %c32_i64 : i64
-    %38 = arith.cmpi ult, %34, %37 : i64
-    scf.if %38 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %37) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %37, %33 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %39 = call @dora_fn_append_log(%arg0, %29, %30) : (!llvm.ptr, i64, i64) -> !llvm.ptr
-    cf.br ^bb9
+    %33 = arith.addi %31, %c31_i64 : i64
+    %34 = arith.divui %33, %c32_i64 : i64
+    %35 = arith.muli %34, %c32_i64 : i64
+    %36 = call @dora_fn_extend_memory(%arg0, %35) : (!llvm.ptr, i64) -> !llvm.ptr
+    %37 = llvm.getelementptr %36[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %38 = llvm.load %37 : !llvm.ptr -> !llvm.ptr
+    %39 = llvm.getelementptr %36[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %40 = llvm.load %39 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %41 = arith.cmpi ne, %40, %c0_i8 : i8
+    cf.cond_br %41, ^bb1(%40 : i8), ^bb9
   ^bb9:  // pred: ^bb8
+    %42 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %38, %42 : !llvm.ptr, !llvm.ptr
+    %43 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %35, %43 : i64, !llvm.ptr
+    %44 = call @dora_fn_append_log(%arg0, %29, %30) : (!llvm.ptr, i64, i64) -> !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
     %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log1.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb6, ^bb7, ^bb8
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb6, ^bb7, ^bb8, ^bb9
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -143,32 +143,33 @@ module {
     %c84_i8_5 = arith.constant 84 : i8
     cf.cond_br %39, ^bb1(%c84_i8_5 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %42 = arith.addi %38, %c31_i64 : i64
-    %43 = arith.divui %42, %c32_i64 : i64
-    %44 = arith.muli %43, %c32_i64 : i64
-    %45 = arith.cmpi ult, %41, %44 : i64
-    scf.if %45 {
-      %49 = func.call @dora_fn_extend_memory(%arg0, %44) : (!llvm.ptr, i64) -> !llvm.ptr
-      %50 = llvm.getelementptr %49[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-      llvm.store %44, %40 : i64, !llvm.ptr
-      %52 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %51, %52 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256_6 = arith.constant 1 : i256
-    %46 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
-    llvm.store %33, %46 {alignment = 1 : i64} : i256, !llvm.ptr
-    %47 = call @dora_fn_append_log_with_one_topic(%arg0, %36, %37, %46) : (!llvm.ptr, i64, i64, !llvm.ptr) -> !llvm.ptr
-    cf.br ^bb10
+    %40 = arith.addi %38, %c31_i64 : i64
+    %41 = arith.divui %40, %c32_i64 : i64
+    %42 = arith.muli %41, %c32_i64 : i64
+    %43 = call @dora_fn_extend_memory(%arg0, %42) : (!llvm.ptr, i64) -> !llvm.ptr
+    %44 = llvm.getelementptr %43[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %45 = llvm.load %44 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %43[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %47 = llvm.load %46 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %48 = arith.cmpi ne, %47, %c0_i8 : i8
+    cf.cond_br %48, ^bb1(%47 : i8), ^bb10
   ^bb10:  // pred: ^bb9
+    %49 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %45, %49 : !llvm.ptr, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %42, %50 : i64, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %51 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %51 {alignment = 1 : i64} : i256, !llvm.ptr
+    %52 = call @dora_fn_append_log_with_one_topic(%arg0, %36, %37, %51) : (!llvm.ptr, i64, i64, !llvm.ptr) -> !llvm.ptr
+    cf.br ^bb11
+  ^bb11:  // pred: ^bb10
     %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %48 = call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %53 = call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log2.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb7, ^bb8, ^bb9
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb7, ^bb8, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -156,35 +156,36 @@ module {
     %c84_i8_5 = arith.constant 84 : i8
     cf.cond_br %46, ^bb1(%c84_i8_5 : i8), ^bb10
   ^bb10:  // pred: ^bb9
-    %47 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %49 = arith.addi %45, %c31_i64 : i64
-    %50 = arith.divui %49, %c32_i64 : i64
-    %51 = arith.muli %50, %c32_i64 : i64
-    %52 = arith.cmpi ult, %48, %51 : i64
-    scf.if %52 {
-      %57 = func.call @dora_fn_extend_memory(%arg0, %51) : (!llvm.ptr, i64) -> !llvm.ptr
-      %58 = llvm.getelementptr %57[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
-      llvm.store %51, %47 : i64, !llvm.ptr
-      %60 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256_6 = arith.constant 1 : i256
-    %53 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
-    llvm.store %36, %53 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_7 = arith.constant 1 : i256
-    %54 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
-    llvm.store %40, %54 {alignment = 1 : i64} : i256, !llvm.ptr
-    %55 = call @dora_fn_append_log_with_two_topics(%arg0, %43, %44, %53, %54) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    cf.br ^bb11
+    %47 = arith.addi %45, %c31_i64 : i64
+    %48 = arith.divui %47, %c32_i64 : i64
+    %49 = arith.muli %48, %c32_i64 : i64
+    %50 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %50[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %54 = llvm.load %53 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %55 = arith.cmpi ne, %54, %c0_i8 : i8
+    cf.cond_br %55, ^bb1(%54 : i8), ^bb11
   ^bb11:  // pred: ^bb10
+    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %52, %56 : !llvm.ptr, !llvm.ptr
+    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %49, %57 : i64, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %58 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %36, %58 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_7 = arith.constant 1 : i256
+    %59 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
+    llvm.store %40, %59 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = call @dora_fn_append_log_with_two_topics(%arg0, %43, %44, %58, %59) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    cf.br ^bb12
+  ^bb12:  // pred: ^bb11
     %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %56 = call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %61 = call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log3.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log3.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb8, ^bb9, ^bb10
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb8, ^bb9, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -169,38 +169,39 @@ module {
     %c84_i8_5 = arith.constant 84 : i8
     cf.cond_br %53, ^bb1(%c84_i8_5 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %54 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %55 = llvm.load %54 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %56 = arith.addi %52, %c31_i64 : i64
-    %57 = arith.divui %56, %c32_i64 : i64
-    %58 = arith.muli %57, %c32_i64 : i64
-    %59 = arith.cmpi ult, %55, %58 : i64
-    scf.if %59 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %58) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %58, %54 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256_6 = arith.constant 1 : i256
-    %60 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
-    llvm.store %39, %60 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_7 = arith.constant 1 : i256
-    %61 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
-    llvm.store %43, %61 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_8 = arith.constant 1 : i256
-    %62 = llvm.alloca %c1_i256_8 x i256 : (i256) -> !llvm.ptr
-    llvm.store %47, %62 {alignment = 1 : i64} : i256, !llvm.ptr
-    %63 = call @dora_fn_append_log_with_three_topics(%arg0, %50, %51, %60, %61, %62) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    cf.br ^bb12
+    %54 = arith.addi %52, %c31_i64 : i64
+    %55 = arith.divui %54, %c32_i64 : i64
+    %56 = arith.muli %55, %c32_i64 : i64
+    %57 = call @dora_fn_extend_memory(%arg0, %56) : (!llvm.ptr, i64) -> !llvm.ptr
+    %58 = llvm.getelementptr %57[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %57[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %61 = llvm.load %60 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %62 = arith.cmpi ne, %61, %c0_i8 : i8
+    cf.cond_br %62, ^bb1(%61 : i8), ^bb12
   ^bb12:  // pred: ^bb11
+    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %59, %63 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %56, %64 : i64, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %65 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %39, %65 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_7 = arith.constant 1 : i256
+    %66 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
+    llvm.store %43, %66 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_8 = arith.constant 1 : i256
+    %67 = llvm.alloca %c1_i256_8 x i256 : (i256) -> !llvm.ptr
+    llvm.store %47, %67 {alignment = 1 : i64} : i256, !llvm.ptr
+    %68 = call @dora_fn_append_log_with_three_topics(%arg0, %50, %51, %65, %66, %67) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    cf.br ^bb13
+  ^bb13:  // pred: ^bb12
     %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %69 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log4.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log4.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb9, ^bb10, ^bb11
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb9, ^bb10, ^bb11, ^bb12
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -182,41 +182,42 @@ module {
     %c84_i8_5 = arith.constant 84 : i8
     cf.cond_br %60, ^bb1(%c84_i8_5 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %61 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %63 = arith.addi %59, %c31_i64 : i64
-    %64 = arith.divui %63, %c32_i64 : i64
-    %65 = arith.muli %64, %c32_i64 : i64
-    %66 = arith.cmpi ult, %62, %65 : i64
-    scf.if %66 {
-      %73 = func.call @dora_fn_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
-      %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
-      llvm.store %65, %61 : i64, !llvm.ptr
-      %76 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %75, %76 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256_6 = arith.constant 1 : i256
-    %67 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
-    llvm.store %42, %67 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_7 = arith.constant 1 : i256
-    %68 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
-    llvm.store %46, %68 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_8 = arith.constant 1 : i256
-    %69 = llvm.alloca %c1_i256_8 x i256 : (i256) -> !llvm.ptr
-    llvm.store %50, %69 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %70 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %54, %70 {alignment = 1 : i64} : i256, !llvm.ptr
-    %71 = call @dora_fn_append_log_with_four_topics(%arg0, %57, %58, %67, %68, %69, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    cf.br ^bb13
+    %61 = arith.addi %59, %c31_i64 : i64
+    %62 = arith.divui %61, %c32_i64 : i64
+    %63 = arith.muli %62, %c32_i64 : i64
+    %64 = call @dora_fn_extend_memory(%arg0, %63) : (!llvm.ptr, i64) -> !llvm.ptr
+    %65 = llvm.getelementptr %64[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %66 = llvm.load %65 : !llvm.ptr -> !llvm.ptr
+    %67 = llvm.getelementptr %64[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %68 = llvm.load %67 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %69 = arith.cmpi ne, %68, %c0_i8 : i8
+    cf.cond_br %69, ^bb1(%68 : i8), ^bb13
   ^bb13:  // pred: ^bb12
+    %70 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %66, %70 : !llvm.ptr, !llvm.ptr
+    %71 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %63, %71 : i64, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %72 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %42, %72 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_7 = arith.constant 1 : i256
+    %73 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
+    llvm.store %46, %73 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_8 = arith.constant 1 : i256
+    %74 = llvm.alloca %c1_i256_8 x i256 : (i256) -> !llvm.ptr
+    llvm.store %50, %74 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_9 = arith.constant 1 : i256
+    %75 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
+    llvm.store %54, %75 {alignment = 1 : i64} : i256, !llvm.ptr
+    %76 = call @dora_fn_append_log_with_four_topics(%arg0, %57, %58, %72, %73, %74, %75) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    cf.br ^bb14
+  ^bb14:  // pred: ^bb13
     %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %72 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %77 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_basic.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb8
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,83 +120,85 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i256_4 = arith.constant 0 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    %45 = llvm.getelementptr %44[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
-    %47 = arith.trunci %46 : i256 to i64
-    %c32_i64_5 = arith.constant 32 : i64
-    %48 = arith.addi %47, %c32_i64_5 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %49 = arith.cmpi slt, %48, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %49, ^bb1(%c84_i8_7 : i8), ^bb9
+    %c0_i256_4 = arith.constant 0 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %50 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    %50 = llvm.getelementptr %49[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %51 = llvm.load %50 : !llvm.ptr -> i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    %52 = arith.trunci %51 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %53 = arith.addi %52, %c32_i64_5 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %54 = arith.cmpi slt, %53, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %54, ^bb1(%c84_i8_7 : i8), ^bb10
+  ^bb10:  // pred: ^bb9
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %52 = arith.addi %48, %c31_i64_8 : i64
-    %53 = arith.divui %52, %c32_i64_9 : i64
-    %54 = arith.muli %53, %c32_i64_9 : i64
-    %55 = arith.cmpi ult, %51, %54 : i64
-    scf.if %55 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %54) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %54, %50 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-    %58 = llvm.getelementptr %57[%47] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %59 = llvm.load %58 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %60 = llvm.intr.bswap(%59)  : (i256) -> i256
-    %61 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
-    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %63, %61 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb10
-  ^bb10:  // pred: ^bb9
-    %c0_i64_10 = arith.constant 0 : i64
+    %55 = arith.addi %53, %c31_i64_8 : i64
+    %56 = arith.divui %55, %c32_i64_9 : i64
+    %57 = arith.muli %56, %c32_i64_9 : i64
+    %58 = call @dora_fn_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+    %59 = llvm.getelementptr %58[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
+    %61 = llvm.getelementptr %58[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %62 = llvm.load %61 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %63 = arith.cmpi ne, %62, %c0_i8_10 : i8
+    cf.cond_br %63, ^bb1(%62 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
+    %64 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %60, %64 : !llvm.ptr, !llvm.ptr
+    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %57, %65 : i64, !llvm.ptr
+    %66 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %69 = llvm.load %68 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %70 = llvm.intr.bswap(%69)  : (i256) -> i256
+    %71 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %72 = llvm.load %71 : !llvm.ptr -> !llvm.ptr
+    llvm.store %70, %72 : i256, !llvm.ptr
+    %73 = llvm.getelementptr %72[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %73, %71 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
+  ^bb12:  // pred: ^bb11
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %74 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_high_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_high_address.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb8
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,83 +120,85 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_4 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_4 : i64
-    %34 = arith.muli %33, %c32_i64_4 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_4 : i64
+    %32 = arith.muli %31, %c32_i64_4 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c1024_i256_5 = arith.constant 1024 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c1024_i256_5, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    %45 = llvm.getelementptr %44[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
-    %47 = arith.trunci %46 : i256 to i64
-    %c32_i64_6 = arith.constant 32 : i64
-    %48 = arith.addi %47, %c32_i64_6 : i64
-    %c0_i64_7 = arith.constant 0 : i64
-    %49 = arith.cmpi slt, %48, %c0_i64_7 : i64
-    %c84_i8_8 = arith.constant 84 : i8
-    cf.cond_br %49, ^bb1(%c84_i8_8 : i8), ^bb9
+    %c1024_i256_5 = arith.constant 1024 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1024_i256_5, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %50 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    %50 = llvm.getelementptr %49[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %51 = llvm.load %50 : !llvm.ptr -> i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    %52 = arith.trunci %51 : i256 to i64
+    %c32_i64_6 = arith.constant 32 : i64
+    %53 = arith.addi %52, %c32_i64_6 : i64
+    %c0_i64_7 = arith.constant 0 : i64
+    %54 = arith.cmpi slt, %53, %c0_i64_7 : i64
+    %c84_i8_8 = arith.constant 84 : i8
+    cf.cond_br %54, ^bb1(%c84_i8_8 : i8), ^bb10
+  ^bb10:  // pred: ^bb9
     %c31_i64_9 = arith.constant 31 : i64
     %c32_i64_10 = arith.constant 32 : i64
-    %52 = arith.addi %48, %c31_i64_9 : i64
-    %53 = arith.divui %52, %c32_i64_10 : i64
-    %54 = arith.muli %53, %c32_i64_10 : i64
-    %55 = arith.cmpi ult, %51, %54 : i64
-    scf.if %55 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %54) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %54, %50 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-    %58 = llvm.getelementptr %57[%47] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %59 = llvm.load %58 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %60 = llvm.intr.bswap(%59)  : (i256) -> i256
-    %61 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
-    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %63, %61 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb10
-  ^bb10:  // pred: ^bb9
-    %c0_i64_11 = arith.constant 0 : i64
+    %55 = arith.addi %53, %c31_i64_9 : i64
+    %56 = arith.divui %55, %c32_i64_10 : i64
+    %57 = arith.muli %56, %c32_i64_10 : i64
+    %58 = call @dora_fn_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+    %59 = llvm.getelementptr %58[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
+    %61 = llvm.getelementptr %58[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %62 = llvm.load %61 : !llvm.ptr -> i8
+    %c0_i8_11 = arith.constant 0 : i8
+    %63 = arith.cmpi ne, %62, %c0_i8_11 : i8
+    cf.cond_br %63, ^bb1(%62 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
+    %64 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %60, %64 : !llvm.ptr, !llvm.ptr
+    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %57, %65 : i64, !llvm.ptr
+    %66 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %69 = llvm.load %68 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %70 = llvm.intr.bswap(%69)  : (i256) -> i256
+    %71 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %72 = llvm.load %71 : !llvm.ptr -> !llvm.ptr
+    llvm.store %70, %72 : i256, !llvm.ptr
+    %73 = llvm.getelementptr %72[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %73, %71 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
+  ^bb12:  // pred: ^bb11
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %74 = call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_uninitialized.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_uninitialized.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb4
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -107,38 +107,39 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %22, ^bb1(%c84_i8 : i8), ^bb5
   ^bb5:  // pred: ^bb4
-    %23 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %25 = arith.addi %21, %c31_i64 : i64
-    %26 = arith.divui %25, %c32_i64_3 : i64
-    %27 = arith.muli %26, %c32_i64_3 : i64
-    %28 = arith.cmpi ult, %24, %27 : i64
-    scf.if %28 {
-      %38 = func.call @dora_fn_extend_memory(%arg0, %27) : (!llvm.ptr, i64) -> !llvm.ptr
-      %39 = llvm.getelementptr %38[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %40 = llvm.load %39 : !llvm.ptr -> !llvm.ptr
-      llvm.store %27, %23 : i64, !llvm.ptr
-      %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %40, %41 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %29 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %30 = llvm.load %29 : !llvm.ptr -> !llvm.ptr
-    %31 = llvm.getelementptr %30[%20] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %32 = llvm.load %31 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %33 = llvm.intr.bswap(%32)  : (i256) -> i256
-    %34 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
-    llvm.store %33, %35 : i256, !llvm.ptr
-    %36 = llvm.getelementptr %35[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %36, %34 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb6
+    %23 = arith.addi %21, %c31_i64 : i64
+    %24 = arith.divui %23, %c32_i64_3 : i64
+    %25 = arith.muli %24, %c32_i64_3 : i64
+    %26 = call @dora_fn_extend_memory(%arg0, %25) : (!llvm.ptr, i64) -> !llvm.ptr
+    %27 = llvm.getelementptr %26[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %28 = llvm.load %27 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %26[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %30 = llvm.load %29 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %31 = arith.cmpi ne, %30, %c0_i8 : i8
+    cf.cond_br %31, ^bb1(%30 : i8), ^bb6
   ^bb6:  // pred: ^bb5
+    %32 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %28, %32 : !llvm.ptr, !llvm.ptr
+    %33 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %25, %33 : i64, !llvm.ptr
+    %34 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %35[%20] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %37 = llvm.load %36 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %38 = llvm.intr.bswap(%37)  : (i256) -> i256
+    %39 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %40 = llvm.load %39 : !llvm.ptr -> !llvm.ptr
+    llvm.store %38, %40 : i256, !llvm.ptr
+    %41 = llvm.getelementptr %40[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %41, %39 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb7
+  ^bb7:  // pred: ^bb6
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %37 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %42 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_basic.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,33 +120,34 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb8
+  ^bb8:  // pred: ^bb7
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_high_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_high_address.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,33 +120,34 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_4 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_4 : i64
-    %34 = arith.muli %33, %c32_i64_4 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_4 : i64
+    %32 = arith.muli %31, %c32_i64_4 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb8
+  ^bb8:  // pred: ^bb7
     %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_overwrite.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_overwrite.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb9
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,91 +120,93 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %68 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %70, %71 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i256_4 = arith.constant 0 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c99_i256 = arith.constant 99 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c99_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c0_i256_4 = arith.constant 0 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %c32_i64_5 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c32_i64_5 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %56 = arith.cmpi slt, %55, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %56, ^bb1(%c84_i8_7 : i8), ^bb10
+    %c99_i256 = arith.constant 99 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c99_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %60 = arith.addi %59, %c32_i64_5 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_7 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %59 = arith.addi %55, %c31_i64_8 : i64
-    %60 = arith.divui %59, %c32_i64_9 : i64
-    %61 = arith.muli %60, %c32_i64_9 : i64
-    %62 = arith.cmpi ult, %58, %61 : i64
-    scf.if %62 {
-      %68 = func.call @dora_fn_extend_memory(%arg0, %61) : (!llvm.ptr, i64) -> !llvm.ptr
-      %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-      llvm.store %61, %57 : i64, !llvm.ptr
-      %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %70, %71 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> !llvm.ptr
-    %65 = llvm.getelementptr %64[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %66 = llvm.intr.bswap(%53)  : (i256) -> i256
-    llvm.store %66, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c0_i64_10 = arith.constant 0 : i64
+    %62 = arith.addi %60, %c31_i64_8 : i64
+    %63 = arith.divui %62, %c32_i64_9 : i64
+    %64 = arith.muli %63, %c32_i64_9 : i64
+    %65 = call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
+    %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_10 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
+    %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %67, %71 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %64, %72 : i64, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
+    %75 = llvm.getelementptr %74[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %76 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %76, %75 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb13
+  ^bb13:  // pred: ^bb12
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %67 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %77 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb10, ^bb11
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb10, ^bb11, ^bb12
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -198,49 +198,50 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %74, ^bb1(%c84_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %75 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %77 = arith.addi %73, %c31_i64 : i64
-    %78 = arith.divui %77, %c32_i64 : i64
-    %79 = arith.muli %78, %c32_i64 : i64
-    %80 = arith.cmpi ult, %76, %79 : i64
-    scf.if %80 {
-      %95 = func.call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
-      %96 = llvm.getelementptr %95[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
-      llvm.store %79, %75 : i64, !llvm.ptr
-      %98 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %97, %98 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %81 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %82 = llvm.load %81 : !llvm.ptr -> i64
-    %c1_i256_5 = arith.constant 1 : i256
-    %83 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
-    llvm.store %45, %83 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_6 = arith.constant 1 : i256
-    %84 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
-    llvm.store %41, %84 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64 = arith.constant 1 : i64
-    %85 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %75 = arith.addi %73, %c31_i64 : i64
+    %76 = arith.divui %75, %c32_i64 : i64
+    %77 = arith.muli %76, %c32_i64 : i64
+    %78 = call @dora_fn_extend_memory(%arg0, %77) : (!llvm.ptr, i64) -> !llvm.ptr
+    %79 = llvm.getelementptr %78[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %80 = llvm.load %79 : !llvm.ptr -> !llvm.ptr
+    %81 = llvm.getelementptr %78[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %82 = llvm.load %81 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %86 = call @dora_fn_call(%arg0, %66, %84, %83, %67, %68, %69, %70, %82, %85, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %87 = llvm.getelementptr %86[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %88 = llvm.load %87 : !llvm.ptr -> i8
-    %89 = llvm.load %85 : !llvm.ptr -> i64
-    %90 = arith.extui %88 : i8 to i256
-    %91 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %92 = llvm.load %91 : !llvm.ptr -> !llvm.ptr
-    llvm.store %90, %92 : i256, !llvm.ptr
-    %93 = llvm.getelementptr %92[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %93, %91 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %83 = arith.cmpi ne, %82, %c0_i8 : i8
+    cf.cond_br %83, ^bb1(%82 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_7 = arith.constant 0 : i64
+    %84 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %80, %84 : !llvm.ptr, !llvm.ptr
+    %85 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %77, %85 : i64, !llvm.ptr
+    %86 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %87 = llvm.load %86 : !llvm.ptr -> i64
+    %c1_i256_5 = arith.constant 1 : i256
+    %88 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
+    llvm.store %45, %88 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %89 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %41, %89 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64 = arith.constant 1 : i64
+    %90 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_7 = arith.constant 0 : i8
+    %91 = call @dora_fn_call(%arg0, %66, %89, %88, %67, %68, %69, %70, %87, %90, %c0_i8_7) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %92 = llvm.getelementptr %91[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %93 = llvm.load %92 : !llvm.ptr -> i8
+    %94 = llvm.load %90 : !llvm.ptr -> i64
+    %95 = arith.extui %93 : i8 to i256
+    %96 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
+    llvm.store %95, %97 : i256, !llvm.ptr
+    %98 = llvm.getelementptr %97[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %98, %96 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb14
+  ^bb14:  // pred: ^bb13
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %94 = call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %99 = call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb10, ^bb11
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb10, ^bb11, ^bb12
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -198,49 +198,50 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %74, ^bb1(%c84_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %75 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %77 = arith.addi %73, %c31_i64 : i64
-    %78 = arith.divui %77, %c32_i64 : i64
-    %79 = arith.muli %78, %c32_i64 : i64
-    %80 = arith.cmpi ult, %76, %79 : i64
-    scf.if %80 {
-      %95 = func.call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
-      %96 = llvm.getelementptr %95[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
-      llvm.store %79, %75 : i64, !llvm.ptr
-      %98 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %97, %98 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %81 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %82 = llvm.load %81 : !llvm.ptr -> i64
-    %c1_i256 = arith.constant 1 : i256
-    %83 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %45, %83 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_6 = arith.constant 1 : i256
-    %84 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
-    llvm.store %41, %84 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64 = arith.constant 1 : i64
-    %85 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %75 = arith.addi %73, %c31_i64 : i64
+    %76 = arith.divui %75, %c32_i64 : i64
+    %77 = arith.muli %76, %c32_i64 : i64
+    %78 = call @dora_fn_extend_memory(%arg0, %77) : (!llvm.ptr, i64) -> !llvm.ptr
+    %79 = llvm.getelementptr %78[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %80 = llvm.load %79 : !llvm.ptr -> !llvm.ptr
+    %81 = llvm.getelementptr %78[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %82 = llvm.load %81 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %86 = call @dora_fn_call(%arg0, %66, %84, %83, %67, %68, %69, %70, %82, %85, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %87 = llvm.getelementptr %86[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %88 = llvm.load %87 : !llvm.ptr -> i8
-    %89 = llvm.load %85 : !llvm.ptr -> i64
-    %90 = arith.extui %88 : i8 to i256
-    %91 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %92 = llvm.load %91 : !llvm.ptr -> !llvm.ptr
-    llvm.store %90, %92 : i256, !llvm.ptr
-    %93 = llvm.getelementptr %92[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %93, %91 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %83 = arith.cmpi ne, %82, %c0_i8 : i8
+    cf.cond_br %83, ^bb1(%82 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_7 = arith.constant 0 : i64
+    %84 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %80, %84 : !llvm.ptr, !llvm.ptr
+    %85 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %77, %85 : i64, !llvm.ptr
+    %86 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %87 = llvm.load %86 : !llvm.ptr -> i64
+    %c1_i256 = arith.constant 1 : i256
+    %88 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %45, %88 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %89 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %41, %89 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64 = arith.constant 1 : i64
+    %90 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_7 = arith.constant 0 : i8
+    %91 = call @dora_fn_call(%arg0, %66, %89, %88, %67, %68, %69, %70, %87, %90, %c0_i8_7) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %92 = llvm.getelementptr %91[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %93 = llvm.load %92 : !llvm.ptr -> i8
+    %94 = llvm.load %90 : !llvm.ptr -> i64
+    %95 = arith.extui %93 : i8 to i256
+    %96 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
+    llvm.store %95, %97 : i256, !llvm.ptr
+    %98 = llvm.getelementptr %97[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %98, %96 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb14
+  ^bb14:  // pred: ^bb13
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %94 = call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %99 = call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,43 +134,44 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %51 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %52 = llvm.getelementptr %51[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %53 = llvm.load %52 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %54 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %53, %54 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
-    %47 = llvm.getelementptr %46[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    "llvm.intr.memset"(%47, %c0_i8, %36) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
-    %48 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
-    %49 = arith.cmpi ugt, %34, %48 : i64
-    scf.if %49 {
-      %51 = arith.subi %48, %34 : i64
-      %52 = arith.minui %51, %36 : i64
-      %53 = func.call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
-      %54 = llvm.getelementptr %53[%34] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-      "llvm.intr.memcpy"(%47, %54, %52) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
+  ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
+    %52 = llvm.getelementptr %51[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %c0_i8_4 = arith.constant 0 : i8
+    "llvm.intr.memset"(%52, %c0_i8_4, %36) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %53 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %54 = arith.cmpi ugt, %34, %53 : i64
+    scf.if %54 {
+      %56 = arith.subi %53, %34 : i64
+      %57 = arith.minui %56, %36 : i64
+      %58 = func.call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
+      %59 = llvm.getelementptr %58[%34] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      "llvm.intr.memcpy"(%52, %59, %57) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     } else {
     }
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
-    %c0_i64_4 = arith.constant 0 : i64
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %50 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %55 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_out_of_bounds.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,43 +134,44 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %51 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %52 = llvm.getelementptr %51[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %53 = llvm.load %52 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %54 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %53, %54 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
-    %47 = llvm.getelementptr %46[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    "llvm.intr.memset"(%47, %c0_i8, %36) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
-    %48 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
-    %49 = arith.cmpi ugt, %34, %48 : i64
-    scf.if %49 {
-      %51 = arith.subi %48, %34 : i64
-      %52 = arith.minui %51, %36 : i64
-      %53 = func.call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
-      %54 = llvm.getelementptr %53[%34] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-      "llvm.intr.memcpy"(%47, %54, %52) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
+  ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
+    %52 = llvm.getelementptr %51[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %c0_i8_3 = arith.constant 0 : i8
+    "llvm.intr.memset"(%52, %c0_i8_3, %36) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %53 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %54 = arith.cmpi ugt, %34, %53 : i64
+    scf.if %54 {
+      %56 = arith.subi %53, %34 : i64
+      %57 = arith.minui %56, %36 : i64
+      %58 = func.call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
+      %59 = llvm.getelementptr %58[%34] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      "llvm.intr.memcpy"(%52, %59, %57) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     } else {
     }
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
-    %c0_i64_3 = arith.constant 0 : i64
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %50 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %55 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_partial.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,43 +134,44 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %51 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %52 = llvm.getelementptr %51[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %53 = llvm.load %52 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %54 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %53, %54 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
-    %47 = llvm.getelementptr %46[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    "llvm.intr.memset"(%47, %c0_i8, %36) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
-    %48 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
-    %49 = arith.cmpi ugt, %34, %48 : i64
-    scf.if %49 {
-      %51 = arith.subi %48, %34 : i64
-      %52 = arith.minui %51, %36 : i64
-      %53 = func.call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
-      %54 = llvm.getelementptr %53[%34] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-      "llvm.intr.memcpy"(%47, %54, %52) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
+  ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
+    %52 = llvm.getelementptr %51[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %c0_i8_3 = arith.constant 0 : i8
+    "llvm.intr.memset"(%52, %c0_i8_3, %36) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %53 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %54 = arith.cmpi ugt, %34, %53 : i64
+    scf.if %54 {
+      %56 = arith.subi %53, %34 : i64
+      %57 = arith.minui %56, %36 : i64
+      %58 = func.call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
+      %59 = llvm.getelementptr %58[%34] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      "llvm.intr.memcpy"(%52, %59, %57) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     } else {
     }
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
-    %c0_i64_3 = arith.constant 0 : i64
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %50 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %55 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb10
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -164,29 +164,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %52, ^bb1(%c84_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %53 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %51, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %57 = arith.muli %56, %c32_i64 : i64
-    %58 = arith.cmpi ult, %54, %57 : i64
-    scf.if %58 {
-      %61 = func.call @dora_fn_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
-      %62 = llvm.getelementptr %61[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
-      llvm.store %57, %53 : i64, !llvm.ptr
-      %64 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %63, %64 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %59 = call @dora_fn_code_copy(%arg0, %48, %50, %49) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb12
+    %53 = arith.addi %51, %c31_i64 : i64
+    %54 = arith.divui %53, %c32_i64 : i64
+    %55 = arith.muli %54, %c32_i64 : i64
+    %56 = call @dora_fn_extend_memory(%arg0, %55) : (!llvm.ptr, i64) -> !llvm.ptr
+    %57 = llvm.getelementptr %56[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
+    %59 = llvm.getelementptr %56[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %60 = llvm.load %59 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %61 = arith.cmpi ne, %60, %c0_i8 : i8
+    cf.cond_br %61, ^bb1(%60 : i8), ^bb12
   ^bb12:  // pred: ^bb11
+    %62 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %58, %62 : !llvm.ptr, !llvm.ptr
+    %63 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %55, %63 : i64, !llvm.ptr
+    %64 = call @dora_fn_code_copy(%arg0, %48, %50, %49) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb13
+  ^bb13:  // pred: ^bb12
     %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %60 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %65 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_1.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,29 +134,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %47 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %48 = llvm.getelementptr %47[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %49, %50 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = call @dora_fn_code_copy(%arg0, %34, %36, %35) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
   ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = call @dora_fn_code_copy(%arg0, %34, %36, %35) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %51 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_out_of_bounds.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,29 +134,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %47 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %48 = llvm.getelementptr %47[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %49, %50 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = call @dora_fn_code_copy(%arg0, %34, %36, %35) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
   ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = call @dora_fn_code_copy(%arg0, %34, %36, %35) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %51 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_partial.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,29 +134,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %47 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %48 = llvm.getelementptr %47[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %49, %50 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = call @dora_fn_code_copy(%arg0, %34, %36, %35) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
   ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = call @dora_fn_code_copy(%arg0, %34, %36, %35) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %51 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb6, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -133,50 +133,51 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %38 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %39 = llvm.load %38 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %40 = arith.addi %36, %c31_i64 : i64
-    %41 = arith.divui %40, %c32_i64 : i64
-    %42 = arith.muli %41, %c32_i64 : i64
-    %43 = arith.cmpi ult, %39, %42 : i64
-    scf.if %43 {
-      %57 = func.call @dora_fn_extend_memory(%arg0, %42) : (!llvm.ptr, i64) -> !llvm.ptr
-      %58 = llvm.getelementptr %57[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
-      llvm.store %42, %38 : i64, !llvm.ptr
-      %60 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %44 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %25, %44 {alignment = 1 : i64} : i256, !llvm.ptr
-    %45 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %47 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %46, %47 {alignment = 1 : i64} : i64, !llvm.ptr
-    %48 = call @dora_fn_create(%arg0, %35, %34, %44, %47) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %49 = llvm.getelementptr %48[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %38 = arith.addi %36, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = call @dora_fn_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+    %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
+    %44 = llvm.getelementptr %41[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %45 = llvm.load %44 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %51 = arith.cmpi ne, %c0_i8, %50 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %51, ^bb1(%c94_i8 : i8), ^bb8
+    %46 = arith.cmpi ne, %45, %c0_i8 : i8
+    cf.cond_br %46, ^bb1(%45 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %52 = llvm.load %44 : !llvm.ptr -> i256
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    llvm.store %52, %54 : i256, !llvm.ptr
-    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb9
+    %47 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %43, %47 : !llvm.ptr, !llvm.ptr
+    %48 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %40, %48 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %49 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %49 {alignment = 1 : i64} : i256, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %52 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %51, %52 {alignment = 1 : i64} : i64, !llvm.ptr
+    %53 = call @dora_fn_create(%arg0, %35, %34, %49, %52) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %54 = llvm.getelementptr %53[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %c0_i8_3 = arith.constant 0 : i8
+    %56 = arith.cmpi ne, %c0_i8_3, %55 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %56, ^bb1(%c94_i8 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i64_3 = arith.constant 0 : i64
+    %57 = llvm.load %49 : !llvm.ptr -> i256
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    llvm.store %57, %59 : i256, !llvm.ptr
+    %60 = llvm.getelementptr %59[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %56 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %61 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb7, ^bb8
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb7, ^bb8, ^bb9
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -146,53 +146,54 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %45 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %47 = arith.addi %43, %c31_i64 : i64
-    %48 = arith.divui %47, %c32_i64 : i64
-    %49 = arith.muli %48, %c32_i64 : i64
-    %50 = arith.cmpi ult, %46, %49 : i64
-    scf.if %50 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %49, %45 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %51 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %51 {alignment = 1 : i64} : i256, !llvm.ptr
-    %52 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %53 = llvm.load %52 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %54 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %53, %54 {alignment = 1 : i64} : i64, !llvm.ptr
-    %c1_i256_3 = arith.constant 1 : i256
-    %55 = llvm.alloca %c1_i256_3 x i256 : (i256) -> !llvm.ptr
-    llvm.store %40, %55 {alignment = 1 : i64} : i256, !llvm.ptr
-    %56 = call @dora_fn_create2(%arg0, %42, %41, %51, %54, %55) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %57 = llvm.getelementptr %56[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i8
+    %45 = arith.addi %43, %c31_i64 : i64
+    %46 = arith.divui %45, %c32_i64 : i64
+    %47 = arith.muli %46, %c32_i64 : i64
+    %48 = call @dora_fn_extend_memory(%arg0, %47) : (!llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
+    %51 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %52 = llvm.load %51 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %59 = arith.cmpi ne, %c0_i8, %58 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %59, ^bb1(%c94_i8 : i8), ^bb9
+    %53 = arith.cmpi ne, %52, %c0_i8 : i8
+    cf.cond_br %53, ^bb1(%52 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %60 = llvm.load %51 : !llvm.ptr -> i256
-    %61 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
-    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %63, %61 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb10
+    %54 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %50, %54 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %47, %55 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %56 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %28, %56 {alignment = 1 : i64} : i256, !llvm.ptr
+    %57 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %59 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %58, %59 {alignment = 1 : i64} : i64, !llvm.ptr
+    %c1_i256_3 = arith.constant 1 : i256
+    %60 = llvm.alloca %c1_i256_3 x i256 : (i256) -> !llvm.ptr
+    llvm.store %40, %60 {alignment = 1 : i64} : i256, !llvm.ptr
+    %61 = call @dora_fn_create2(%arg0, %42, %41, %56, %59, %60) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %63 = llvm.load %62 : !llvm.ptr -> i8
+    %c0_i8_4 = arith.constant 0 : i8
+    %64 = arith.cmpi ne, %c0_i8_4, %63 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %64, ^bb1(%c94_i8 : i8), ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i64_4 = arith.constant 0 : i64
+    %65 = llvm.load %56 : !llvm.ptr -> i256
+    %66 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    llvm.store %65, %67 : i256, !llvm.ptr
+    %68 = llvm.getelementptr %67[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %68, %66 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
+  ^bb11:  // pred: ^bb10
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %69 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb7, ^bb8
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb7, ^bb8, ^bb9
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -146,53 +146,54 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %45 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %47 = arith.addi %43, %c31_i64 : i64
-    %48 = arith.divui %47, %c32_i64 : i64
-    %49 = arith.muli %48, %c32_i64 : i64
-    %50 = arith.cmpi ult, %46, %49 : i64
-    scf.if %50 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %49, %45 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %51 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %51 {alignment = 1 : i64} : i256, !llvm.ptr
-    %52 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %53 = llvm.load %52 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %54 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %53, %54 {alignment = 1 : i64} : i64, !llvm.ptr
-    %c1_i256_3 = arith.constant 1 : i256
-    %55 = llvm.alloca %c1_i256_3 x i256 : (i256) -> !llvm.ptr
-    llvm.store %40, %55 {alignment = 1 : i64} : i256, !llvm.ptr
-    %56 = call @dora_fn_create2(%arg0, %42, %41, %51, %54, %55) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %57 = llvm.getelementptr %56[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i8
+    %45 = arith.addi %43, %c31_i64 : i64
+    %46 = arith.divui %45, %c32_i64 : i64
+    %47 = arith.muli %46, %c32_i64 : i64
+    %48 = call @dora_fn_extend_memory(%arg0, %47) : (!llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
+    %51 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %52 = llvm.load %51 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %59 = arith.cmpi ne, %c0_i8, %58 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %59, ^bb1(%c94_i8 : i8), ^bb9
+    %53 = arith.cmpi ne, %52, %c0_i8 : i8
+    cf.cond_br %53, ^bb1(%52 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %60 = llvm.load %51 : !llvm.ptr -> i256
-    %61 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
-    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %63, %61 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb10
+    %54 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %50, %54 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %47, %55 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %56 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %28, %56 {alignment = 1 : i64} : i256, !llvm.ptr
+    %57 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %59 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %58, %59 {alignment = 1 : i64} : i64, !llvm.ptr
+    %c1_i256_3 = arith.constant 1 : i256
+    %60 = llvm.alloca %c1_i256_3 x i256 : (i256) -> !llvm.ptr
+    llvm.store %40, %60 {alignment = 1 : i64} : i256, !llvm.ptr
+    %61 = call @dora_fn_create2(%arg0, %42, %41, %56, %59, %60) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %63 = llvm.load %62 : !llvm.ptr -> i8
+    %c0_i8_4 = arith.constant 0 : i8
+    %64 = arith.cmpi ne, %c0_i8_4, %63 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %64, ^bb1(%c94_i8 : i8), ^bb10
   ^bb10:  // pred: ^bb9
-    %c0_i64_4 = arith.constant 0 : i64
+    %65 = llvm.load %56 : !llvm.ptr -> i256
+    %66 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    llvm.store %65, %67 : i256, !llvm.ptr
+    %68 = llvm.getelementptr %67[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %68, %66 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
+  ^bb11:  // pred: ^bb10
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %69 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb6, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -133,50 +133,51 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %38 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %39 = llvm.load %38 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %40 = arith.addi %36, %c31_i64 : i64
-    %41 = arith.divui %40, %c32_i64 : i64
-    %42 = arith.muli %41, %c32_i64 : i64
-    %43 = arith.cmpi ult, %39, %42 : i64
-    scf.if %43 {
-      %57 = func.call @dora_fn_extend_memory(%arg0, %42) : (!llvm.ptr, i64) -> !llvm.ptr
-      %58 = llvm.getelementptr %57[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
-      llvm.store %42, %38 : i64, !llvm.ptr
-      %60 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %44 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %25, %44 {alignment = 1 : i64} : i256, !llvm.ptr
-    %45 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %47 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %46, %47 {alignment = 1 : i64} : i64, !llvm.ptr
-    %48 = call @dora_fn_create(%arg0, %35, %34, %44, %47) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %49 = llvm.getelementptr %48[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %38 = arith.addi %36, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = call @dora_fn_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+    %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
+    %44 = llvm.getelementptr %41[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %45 = llvm.load %44 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %51 = arith.cmpi ne, %c0_i8, %50 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %51, ^bb1(%c94_i8 : i8), ^bb8
+    %46 = arith.cmpi ne, %45, %c0_i8 : i8
+    cf.cond_br %46, ^bb1(%45 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %52 = llvm.load %44 : !llvm.ptr -> i256
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    llvm.store %52, %54 : i256, !llvm.ptr
-    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb9
+    %47 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %43, %47 : !llvm.ptr, !llvm.ptr
+    %48 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %40, %48 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %49 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %49 {alignment = 1 : i64} : i256, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %52 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %51, %52 {alignment = 1 : i64} : i64, !llvm.ptr
+    %53 = call @dora_fn_create(%arg0, %35, %34, %49, %52) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %54 = llvm.getelementptr %53[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %c0_i8_5 = arith.constant 0 : i8
+    %56 = arith.cmpi ne, %c0_i8_5, %55 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %56, ^bb1(%c94_i8 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i64_5 = arith.constant 0 : i64
+    %57 = llvm.load %49 : !llvm.ptr -> i256
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    llvm.store %57, %59 : i256, !llvm.ptr
+    %60 = llvm.getelementptr %59[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %56 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %61 = call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb6, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -133,50 +133,51 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %38 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %39 = llvm.load %38 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %40 = arith.addi %36, %c31_i64 : i64
-    %41 = arith.divui %40, %c32_i64 : i64
-    %42 = arith.muli %41, %c32_i64 : i64
-    %43 = arith.cmpi ult, %39, %42 : i64
-    scf.if %43 {
-      %57 = func.call @dora_fn_extend_memory(%arg0, %42) : (!llvm.ptr, i64) -> !llvm.ptr
-      %58 = llvm.getelementptr %57[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
-      llvm.store %42, %38 : i64, !llvm.ptr
-      %60 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %44 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %25, %44 {alignment = 1 : i64} : i256, !llvm.ptr
-    %45 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %47 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %46, %47 {alignment = 1 : i64} : i64, !llvm.ptr
-    %48 = call @dora_fn_create(%arg0, %35, %34, %44, %47) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %49 = llvm.getelementptr %48[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %38 = arith.addi %36, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = call @dora_fn_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+    %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
+    %44 = llvm.getelementptr %41[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %45 = llvm.load %44 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %51 = arith.cmpi ne, %c0_i8, %50 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %51, ^bb1(%c94_i8 : i8), ^bb8
+    %46 = arith.cmpi ne, %45, %c0_i8 : i8
+    cf.cond_br %46, ^bb1(%45 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %52 = llvm.load %44 : !llvm.ptr -> i256
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    llvm.store %52, %54 : i256, !llvm.ptr
-    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb9
+    %47 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %43, %47 : !llvm.ptr, !llvm.ptr
+    %48 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %40, %48 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %49 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %49 {alignment = 1 : i64} : i256, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %52 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %51, %52 {alignment = 1 : i64} : i64, !llvm.ptr
+    %53 = call @dora_fn_create(%arg0, %35, %34, %49, %52) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %54 = llvm.getelementptr %53[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %c0_i8_4 = arith.constant 0 : i8
+    %56 = arith.cmpi ne, %c0_i8_4, %55 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %56, ^bb1(%c94_i8 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i64_4 = arith.constant 0 : i64
+    %57 = llvm.load %49 : !llvm.ptr -> i256
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    llvm.store %57, %59 : i256, !llvm.ptr
+    %60 = llvm.getelementptr %59[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %56 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %61 = call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb5, ^bb10, ^bb11
+  ^bb1(%10: i8):  // 6 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12, ^bb13
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,121 +120,123 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %84 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %85 = llvm.getelementptr %84[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %87 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %86, %87 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c13_i256 = arith.constant 13 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c13_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c19_i256 = arith.constant 19 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c19_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c13_i256 = arith.constant 13 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c13_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256_4 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c19_i256 = arith.constant 19 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c19_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %56 : i256 to i64
-    %62 = arith.trunci %60 : i256 to i64
-    %63 = arith.addi %61, %62 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_6 : i8), ^bb11
+    %c0_i256_4 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %66 = llvm.load %65 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %61 : i256 to i64
+    %67 = arith.trunci %65 : i256 to i64
+    %68 = arith.addi %66, %67 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_6 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %67 = arith.addi %63, %c31_i64_7 : i64
-    %68 = arith.divui %67, %c32_i64_8 : i64
-    %69 = arith.muli %68, %c32_i64_8 : i64
-    %70 = arith.cmpi ult, %66, %69 : i64
-    scf.if %70 {
-      %84 = func.call @dora_fn_extend_memory(%arg0, %69) : (!llvm.ptr, i64) -> !llvm.ptr
-      %85 = llvm.getelementptr %84[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
-      llvm.store %69, %65 : i64, !llvm.ptr
-      %87 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %86, %87 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %52, %71 {alignment = 1 : i64} : i256, !llvm.ptr
-    %72 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %73, %74 {alignment = 1 : i64} : i64, !llvm.ptr
-    %75 = call @dora_fn_create(%arg0, %62, %61, %71, %74) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = arith.addi %68, %c31_i64_7 : i64
+    %71 = arith.divui %70, %c32_i64_8 : i64
+    %72 = arith.muli %71, %c32_i64_8 : i64
+    %73 = call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
+    %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %73[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %c0_i8, %77 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %78, ^bb1(%c94_i8 : i8), ^bb12
-  ^bb12:  // pred: ^bb11
-    %79 = llvm.load %71 : !llvm.ptr -> i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %c0_i8_9 = arith.constant 0 : i8
+    %78 = arith.cmpi ne, %77, %c0_i8_9 : i8
+    cf.cond_br %78, ^bb1(%77 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_9 = arith.constant 0 : i64
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %75, %79 : !llvm.ptr, !llvm.ptr
+    %80 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %72, %80 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %82 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %83 = llvm.load %82 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %84 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %83, %84 {alignment = 1 : i64} : i64, !llvm.ptr
+    %85 = call @dora_fn_create(%arg0, %67, %66, %81, %84) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %86 = llvm.getelementptr %85[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %87 = llvm.load %86 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %88 = arith.cmpi ne, %c0_i8_10, %87 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %88, ^bb1(%c94_i8 : i8), ^bb14
+  ^bb14:  // pred: ^bb13
+    %89 = llvm.load %81 : !llvm.ptr -> i256
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %91 : i256, !llvm.ptr
+    %92 = llvm.getelementptr %91[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb15
+  ^bb15:  // pred: ^bb14
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %83 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %93 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
+  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb6, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -133,50 +133,51 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %38 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %39 = llvm.load %38 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %40 = arith.addi %36, %c31_i64 : i64
-    %41 = arith.divui %40, %c32_i64 : i64
-    %42 = arith.muli %41, %c32_i64 : i64
-    %43 = arith.cmpi ult, %39, %42 : i64
-    scf.if %43 {
-      %57 = func.call @dora_fn_extend_memory(%arg0, %42) : (!llvm.ptr, i64) -> !llvm.ptr
-      %58 = llvm.getelementptr %57[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
-      llvm.store %42, %38 : i64, !llvm.ptr
-      %60 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %59, %60 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %44 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %25, %44 {alignment = 1 : i64} : i256, !llvm.ptr
-    %45 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %47 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %46, %47 {alignment = 1 : i64} : i64, !llvm.ptr
-    %48 = call @dora_fn_create(%arg0, %35, %34, %44, %47) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %49 = llvm.getelementptr %48[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %38 = arith.addi %36, %c31_i64 : i64
+    %39 = arith.divui %38, %c32_i64 : i64
+    %40 = arith.muli %39, %c32_i64 : i64
+    %41 = call @dora_fn_extend_memory(%arg0, %40) : (!llvm.ptr, i64) -> !llvm.ptr
+    %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
+    %44 = llvm.getelementptr %41[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %45 = llvm.load %44 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %51 = arith.cmpi ne, %c0_i8, %50 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %51, ^bb1(%c94_i8 : i8), ^bb8
+    %46 = arith.cmpi ne, %45, %c0_i8 : i8
+    cf.cond_br %46, ^bb1(%45 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %52 = llvm.load %44 : !llvm.ptr -> i256
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    llvm.store %52, %54 : i256, !llvm.ptr
-    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb9
+    %47 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %43, %47 : !llvm.ptr, !llvm.ptr
+    %48 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %40, %48 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %49 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %49 {alignment = 1 : i64} : i256, !llvm.ptr
+    %50 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %52 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %51, %52 {alignment = 1 : i64} : i64, !llvm.ptr
+    %53 = call @dora_fn_create(%arg0, %35, %34, %49, %52) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %54 = llvm.getelementptr %53[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %c0_i8_3 = arith.constant 0 : i8
+    %56 = arith.cmpi ne, %c0_i8_3, %55 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %56, ^bb1(%c94_i8 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i64_3 = arith.constant 0 : i64
+    %57 = llvm.load %49 : !llvm.ptr -> i256
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    llvm.store %57, %59 : i256, !llvm.ptr
+    %60 = llvm.getelementptr %59[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %56 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %61 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb9
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -178,49 +178,50 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %63, ^bb1(%c84_i8 : i8), ^bb10
   ^bb10:  // pred: ^bb9
-    %64 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %66 = arith.addi %62, %c31_i64 : i64
-    %67 = arith.divui %66, %c32_i64 : i64
-    %68 = arith.muli %67, %c32_i64 : i64
-    %69 = arith.cmpi ult, %65, %68 : i64
-    scf.if %69 {
-      %84 = func.call @dora_fn_extend_memory(%arg0, %68) : (!llvm.ptr, i64) -> !llvm.ptr
-      %85 = llvm.getelementptr %84[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
-      llvm.store %68, %64 : i64, !llvm.ptr
-      %87 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %86, %87 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %70 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> i64
-    %c1_i256 = arith.constant 1 : i256
-    %72 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256, %72 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_5 = arith.constant 1 : i256
-    %73 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
-    llvm.store %38, %73 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %64 = arith.addi %62, %c31_i64 : i64
+    %65 = arith.divui %64, %c32_i64 : i64
+    %66 = arith.muli %65, %c32_i64 : i64
+    %67 = call @dora_fn_extend_memory(%arg0, %66) : (!llvm.ptr, i64) -> !llvm.ptr
+    %68 = llvm.getelementptr %67[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> !llvm.ptr
+    %70 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %71 = llvm.load %70 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %75 = call @dora_fn_call(%arg0, %55, %73, %72, %56, %57, %58, %59, %71, %74, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %77 = llvm.load %76 : !llvm.ptr -> i8
-    %78 = llvm.load %74 : !llvm.ptr -> i64
-    %79 = arith.extui %77 : i8 to i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb11
+    %72 = arith.cmpi ne, %71, %c0_i8 : i8
+    cf.cond_br %72, ^bb1(%71 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i64_6 = arith.constant 0 : i64
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %69, %73 : !llvm.ptr, !llvm.ptr
+    %74 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %66, %74 : i64, !llvm.ptr
+    %75 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %76 = llvm.load %75 : !llvm.ptr -> i64
+    %c1_i256 = arith.constant 1 : i256
+    %77 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256, %77 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_5 = arith.constant 1 : i256
+    %78 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64 = arith.constant 1 : i64
+    %79 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_6 = arith.constant 0 : i8
+    %80 = call @dora_fn_call(%arg0, %55, %78, %77, %56, %57, %58, %59, %76, %79, %c0_i8_6) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %81 = llvm.getelementptr %80[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %82 = llvm.load %81 : !llvm.ptr -> i8
+    %83 = llvm.load %79 : !llvm.ptr -> i64
+    %84 = arith.extui %82 : i8 to i256
+    %85 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
+    llvm.store %84, %86 : i256, !llvm.ptr
+    %87 = llvm.getelementptr %86[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %87, %85 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
+  ^bb12:  // pred: ^bb11
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %83 = call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %88 = call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_basic.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb7
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -150,29 +150,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %46, ^bb1(%c84_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %47 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %49 = arith.addi %45, %c31_i64 : i64
-    %50 = arith.divui %49, %c32_i64 : i64
-    %51 = arith.muli %50, %c32_i64 : i64
-    %52 = arith.cmpi ult, %48, %51 : i64
-    scf.if %52 {
-      %55 = func.call @dora_fn_extend_memory(%arg0, %51) : (!llvm.ptr, i64) -> !llvm.ptr
-      %56 = llvm.getelementptr %55[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-      llvm.store %51, %47 : i64, !llvm.ptr
-      %58 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %57, %58 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %53 = call @dora_fn_copy_ext_code_to_memory(%arg0, %44, %41, %42, %43) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb9
+    %47 = arith.addi %45, %c31_i64 : i64
+    %48 = arith.divui %47, %c32_i64 : i64
+    %49 = arith.muli %48, %c32_i64 : i64
+    %50 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %50[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %54 = llvm.load %53 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %55 = arith.cmpi ne, %54, %c0_i8 : i8
+    cf.cond_br %55, ^bb1(%54 : i8), ^bb9
   ^bb9:  // pred: ^bb8
+    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %52, %56 : !llvm.ptr, !llvm.ptr
+    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %49, %57 : i64, !llvm.ptr
+    %58 = call @dora_fn_copy_ext_code_to_memory(%arg0, %44, %41, %42, %43) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %59 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_out_of_bounds.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb7
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -150,29 +150,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %46, ^bb1(%c84_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %47 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %49 = arith.addi %45, %c31_i64 : i64
-    %50 = arith.divui %49, %c32_i64 : i64
-    %51 = arith.muli %50, %c32_i64 : i64
-    %52 = arith.cmpi ult, %48, %51 : i64
-    scf.if %52 {
-      %55 = func.call @dora_fn_extend_memory(%arg0, %51) : (!llvm.ptr, i64) -> !llvm.ptr
-      %56 = llvm.getelementptr %55[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-      llvm.store %51, %47 : i64, !llvm.ptr
-      %58 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %57, %58 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %53 = call @dora_fn_copy_ext_code_to_memory(%arg0, %44, %41, %42, %43) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb9
+    %47 = arith.addi %45, %c31_i64 : i64
+    %48 = arith.divui %47, %c32_i64 : i64
+    %49 = arith.muli %48, %c32_i64 : i64
+    %50 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %50[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %54 = llvm.load %53 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %55 = arith.cmpi ne, %54, %c0_i8 : i8
+    cf.cond_br %55, ^bb1(%54 : i8), ^bb9
   ^bb9:  // pred: ^bb8
+    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %52, %56 : !llvm.ptr, !llvm.ptr
+    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %49, %57 : i64, !llvm.ptr
+    %58 = call @dora_fn_copy_ext_code_to_memory(%arg0, %44, %41, %42, %43) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %59 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_partial.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb7
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb7, ^bb8
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -150,29 +150,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %46, ^bb1(%c84_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %47 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %49 = arith.addi %45, %c31_i64 : i64
-    %50 = arith.divui %49, %c32_i64 : i64
-    %51 = arith.muli %50, %c32_i64 : i64
-    %52 = arith.cmpi ult, %48, %51 : i64
-    scf.if %52 {
-      %55 = func.call @dora_fn_extend_memory(%arg0, %51) : (!llvm.ptr, i64) -> !llvm.ptr
-      %56 = llvm.getelementptr %55[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-      llvm.store %51, %47 : i64, !llvm.ptr
-      %58 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %57, %58 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %53 = call @dora_fn_copy_ext_code_to_memory(%arg0, %44, %41, %42, %43) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb9
+    %47 = arith.addi %45, %c31_i64 : i64
+    %48 = arith.divui %47, %c32_i64 : i64
+    %49 = arith.muli %48, %c32_i64 : i64
+    %50 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %50[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %54 = llvm.load %53 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %55 = arith.cmpi ne, %54, %c0_i8 : i8
+    cf.cond_br %55, ^bb1(%54 : i8), ^bb9
   ^bb9:  // pred: ^bb8
+    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %52, %56 : !llvm.ptr, !llvm.ptr
+    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %49, %57 : i64, !llvm.ptr
+    %58 = call @dora_fn_copy_ext_code_to_memory(%arg0, %44, %41, %42, %43) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb10
+  ^bb10:  // pred: ^bb9
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %59 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mload_misze.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mload_misze.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb10
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -117,112 +117,97 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %28, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %29 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %30 = llvm.load %29 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %31 = arith.addi %27, %c31_i64 : i64
-    %32 = arith.divui %31, %c32_i64_3 : i64
-    %33 = arith.muli %32, %c32_i64_3 : i64
-    %34 = arith.cmpi ult, %30, %33 : i64
-    scf.if %34 {
-      %88 = func.call @dora_fn_extend_memory(%arg0, %33) : (!llvm.ptr, i64) -> !llvm.ptr
-      %89 = llvm.getelementptr %88[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %90 = llvm.load %89 : !llvm.ptr -> !llvm.ptr
-      llvm.store %33, %29 : i64, !llvm.ptr
-      %91 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %90, %91 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %35 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %36 = llvm.load %35 : !llvm.ptr -> !llvm.ptr
-    %37 = llvm.getelementptr %36[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %38 = llvm.load %37 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %39 = llvm.intr.bswap(%38)  : (i256) -> i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %39, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb7
+    %29 = arith.addi %27, %c31_i64 : i64
+    %30 = arith.divui %29, %c32_i64_3 : i64
+    %31 = arith.muli %30, %c32_i64_3 : i64
+    %32 = call @dora_fn_extend_memory(%arg0, %31) : (!llvm.ptr, i64) -> !llvm.ptr
+    %33 = llvm.getelementptr %32[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %36 = llvm.load %35 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %37 = arith.cmpi ne, %36, %c0_i8 : i8
+    cf.cond_br %37, ^bb1(%36 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    %45 = llvm.getelementptr %44[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %38 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %34, %38 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %31, %39 : i64, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
+    %42 = llvm.getelementptr %41[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %43 = llvm.load %42 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %44 = llvm.intr.bswap(%43)  : (i256) -> i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %44, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %47 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i64
-    %49 = arith.extui %48 : i64 to i256
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    llvm.store %49, %51 : i256, !llvm.ptr
-    %52 = llvm.getelementptr %51[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    %50 = llvm.getelementptr %49[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %51 = llvm.load %50 : !llvm.ptr -> i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c39_i256 = arith.constant 39 : i256
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c39_i256, %54 : i256, !llvm.ptr
-    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
+    %52 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    %53 = llvm.load %52 : !llvm.ptr -> i64
+    %54 = arith.extui %53 : i64 to i256
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    llvm.store %54, %56 : i256, !llvm.ptr
+    %57 = llvm.getelementptr %56[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %56 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-    %58 = llvm.getelementptr %57[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %59 = llvm.load %58 : !llvm.ptr -> i256
-    llvm.store %58, %56 : !llvm.ptr, !llvm.ptr
-    %60 = arith.trunci %59 : i256 to i64
-    %c32_i64_4 = arith.constant 32 : i64
-    %61 = arith.addi %60, %c32_i64_4 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_6 : i8), ^bb11
+    %c39_i256 = arith.constant 39 : i256
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c39_i256, %59 : i256, !llvm.ptr
+    %60 = llvm.getelementptr %59[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %63 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> i64
+    %61 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %62 = llvm.load %61 : !llvm.ptr -> !llvm.ptr
+    %63 = llvm.getelementptr %62[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %64 = llvm.load %63 : !llvm.ptr -> i256
+    llvm.store %63, %61 : !llvm.ptr, !llvm.ptr
+    %65 = arith.trunci %64 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %66 = arith.addi %65, %c32_i64_4 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %67 = arith.cmpi slt, %66, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %67, ^bb1(%c84_i8_6 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %65 = arith.addi %61, %c31_i64_7 : i64
-    %66 = arith.divui %65, %c32_i64_8 : i64
-    %67 = arith.muli %66, %c32_i64_8 : i64
-    %68 = arith.cmpi ult, %64, %67 : i64
-    scf.if %68 {
-      %88 = func.call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-      %89 = llvm.getelementptr %88[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %90 = llvm.load %89 : !llvm.ptr -> !llvm.ptr
-      llvm.store %67, %63 : i64, !llvm.ptr
-      %91 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %90, %91 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %69 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-    %71 = llvm.getelementptr %70[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %72 = llvm.load %71 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %73 = llvm.intr.bswap(%72)  : (i256) -> i256
-    %74 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
-    llvm.store %73, %75 : i256, !llvm.ptr
-    %76 = llvm.getelementptr %75[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %76, %74 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb12
-  ^bb12:  // pred: ^bb11
-    %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
-    %79 = llvm.getelementptr %78[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %80 = llvm.load %79 : !llvm.ptr -> i256
-    llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %68 = arith.addi %66, %c31_i64_7 : i64
+    %69 = arith.divui %68, %c32_i64_8 : i64
+    %70 = arith.muli %69, %c32_i64_8 : i64
+    %71 = call @dora_fn_extend_memory(%arg0, %70) : (!llvm.ptr, i64) -> !llvm.ptr
+    %72 = llvm.getelementptr %71[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
+    %74 = llvm.getelementptr %71[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> i8
+    %c0_i8_9 = arith.constant 0 : i8
+    %76 = arith.cmpi ne, %75, %c0_i8_9 : i8
+    cf.cond_br %76, ^bb1(%75 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %81 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %82 = llvm.load %81 : !llvm.ptr -> i64
-    %83 = arith.extui %82 : i64 to i256
+    %77 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %73, %77 : !llvm.ptr, !llvm.ptr
+    %78 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %70, %78 : i64, !llvm.ptr
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %80 = llvm.load %79 : !llvm.ptr -> !llvm.ptr
+    %81 = llvm.getelementptr %80[%65] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %82 = llvm.load %81 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %83 = llvm.intr.bswap(%82)  : (i256) -> i256
     %84 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %85 = llvm.load %84 : !llvm.ptr -> !llvm.ptr
     llvm.store %83, %85 : i256, !llvm.ptr
@@ -230,9 +215,26 @@ module {
     llvm.store %86, %84 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %c0_i64_9 = arith.constant 0 : i64
+    %87 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %88 = llvm.load %87 : !llvm.ptr -> !llvm.ptr
+    %89 = llvm.getelementptr %88[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %90 = llvm.load %89 : !llvm.ptr -> i256
+    llvm.store %89, %87 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb15
+  ^bb15:  // pred: ^bb14
+    %91 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    %92 = llvm.load %91 : !llvm.ptr -> i64
+    %93 = arith.extui %92 : i64 to i256
+    %94 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %95 = llvm.load %94 : !llvm.ptr -> !llvm.ptr
+    llvm.store %93, %95 : i256, !llvm.ptr
+    %96 = llvm.getelementptr %95[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %96, %94 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb16
+  ^bb16:  // pred: ^bb15
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %87 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %97 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,33 +120,34 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb8
+  ^bb8:  // pred: ^bb7
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore8.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore8.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -121,32 +121,33 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %30, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %31 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %32 = llvm.load %31 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %33 = arith.addi %29, %c31_i64 : i64
-    %34 = arith.divui %33, %c32_i64 : i64
-    %35 = arith.muli %34, %c32_i64 : i64
-    %36 = arith.cmpi ult, %32, %35 : i64
-    scf.if %36 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %35) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %35, %31 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %37 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %38 = llvm.load %37 : !llvm.ptr -> !llvm.ptr
-    %39 = llvm.getelementptr %38[%28] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    llvm.store %27, %39 {alignment = 1 : i64} : i8, !llvm.ptr
-    cf.br ^bb7
+    %31 = arith.addi %29, %c31_i64 : i64
+    %32 = arith.divui %31, %c32_i64 : i64
+    %33 = arith.muli %32, %c32_i64 : i64
+    %34 = call @dora_fn_extend_memory(%arg0, %33) : (!llvm.ptr, i64) -> !llvm.ptr
+    %35 = llvm.getelementptr %34[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %36 = llvm.load %35 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %34[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %38 = llvm.load %37 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %39 = arith.cmpi ne, %38, %c0_i8 : i8
+    cf.cond_br %39, ^bb1(%38 : i8), ^bb7
   ^bb7:  // pred: ^bb6
+    %40 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %36, %40 : !llvm.ptr, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %33, %41 : i64, !llvm.ptr
+    %42 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
+    %44 = llvm.getelementptr %43[%28] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %27, %44 {alignment = 1 : i64} : i8, !llvm.ptr
+    cf.br ^bb8
+  ^bb8:  // pred: ^bb7
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 6 preds: ^bb2, ^bb5, ^bb10, ^bb11, ^bb20, ^bb21
+  ^bb1(%10: i8):  // 9 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12, ^bb13, ^bb22, ^bb23, ^bb24
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,276 +120,279 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %169 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %170 = llvm.getelementptr %169[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %172 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %171, %172 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c15_i256 = arith.constant 15 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c15_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c17_i256 = arith.constant 17 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256_4 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c15_i256 = arith.constant 15 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %56 : i256 to i64
-    %62 = arith.trunci %60 : i256 to i64
-    %63 = arith.addi %61, %62 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_6 : i8), ^bb11
+    %c0_i256_4 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %66 = llvm.load %65 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %61 : i256 to i64
+    %67 = arith.trunci %65 : i256 to i64
+    %68 = arith.addi %66, %67 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_6 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %67 = arith.addi %63, %c31_i64_7 : i64
-    %68 = arith.divui %67, %c32_i64_8 : i64
-    %69 = arith.muli %68, %c32_i64_8 : i64
-    %70 = arith.cmpi ult, %66, %69 : i64
-    scf.if %70 {
-      %169 = func.call @dora_fn_extend_memory(%arg0, %69) : (!llvm.ptr, i64) -> !llvm.ptr
-      %170 = llvm.getelementptr %169[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
-      llvm.store %69, %65 : i64, !llvm.ptr
-      %172 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %171, %172 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %52, %71 {alignment = 1 : i64} : i256, !llvm.ptr
-    %72 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %73, %74 {alignment = 1 : i64} : i64, !llvm.ptr
-    %75 = call @dora_fn_create(%arg0, %62, %61, %71, %74) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = arith.addi %68, %c31_i64_7 : i64
+    %71 = arith.divui %70, %c32_i64_8 : i64
+    %72 = arith.muli %71, %c32_i64_8 : i64
+    %73 = call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
+    %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %73[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %c0_i8, %77 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %78, ^bb1(%c94_i8 : i8), ^bb12
-  ^bb12:  // pred: ^bb11
-    %79 = llvm.load %71 : !llvm.ptr -> i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %c0_i8_9 = arith.constant 0 : i8
+    %78 = arith.cmpi ne, %77, %c0_i8_9 : i8
+    cf.cond_br %78, ^bb1(%77 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_9 = arith.constant 0 : i256
-    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_9, %84 : i256, !llvm.ptr
-    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %75, %79 : !llvm.ptr, !llvm.ptr
+    %80 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %72, %80 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %82 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %83 = llvm.load %82 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %84 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %83, %84 {alignment = 1 : i64} : i64, !llvm.ptr
+    %85 = call @dora_fn_create(%arg0, %67, %66, %81, %84) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %86 = llvm.getelementptr %85[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %87 = llvm.load %86 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %88 = arith.cmpi ne, %c0_i8_10, %87 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %88, ^bb1(%c94_i8 : i8), ^bb14
   ^bb14:  // pred: ^bb13
-    %c0_i256_10 = arith.constant 0 : i256
-    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %87 : i256, !llvm.ptr
-    %88 = llvm.getelementptr %87[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %89 = llvm.load %81 : !llvm.ptr -> i256
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %91 : i256, !llvm.ptr
+    %92 = llvm.getelementptr %91[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
     %c0_i256_11 = arith.constant 0 : i256
-    %89 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %90 = llvm.load %89 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %90 : i256, !llvm.ptr
-    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %91, %89 : !llvm.ptr, !llvm.ptr
+    %93 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %94 = llvm.load %93 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %94 : i256, !llvm.ptr
+    %95 = llvm.getelementptr %94[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %95, %93 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb16:  // pred: ^bb15
     %c0_i256_12 = arith.constant 0 : i256
-    %92 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_12, %93 : i256, !llvm.ptr
-    %94 = llvm.getelementptr %93[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %94, %92 : !llvm.ptr, !llvm.ptr
+    %96 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %97 : i256, !llvm.ptr
+    %98 = llvm.getelementptr %97[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %98, %96 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb17:  // pred: ^bb16
     %c0_i256_13 = arith.constant 0 : i256
-    %95 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %96 = llvm.load %95 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_13, %96 : i256, !llvm.ptr
-    %97 = llvm.getelementptr %96[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %97, %95 : !llvm.ptr, !llvm.ptr
+    %99 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %100 = llvm.load %99 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_13, %100 : i256, !llvm.ptr
+    %101 = llvm.getelementptr %100[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %101, %99 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %98 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %99 = llvm.load %98 : !llvm.ptr -> !llvm.ptr
-    %100 = llvm.getelementptr %99[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %101 = llvm.load %100 : !llvm.ptr -> i256
+    %c0_i256_14 = arith.constant 0 : i256
     %102 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %103 = llvm.load %102 : !llvm.ptr -> !llvm.ptr
-    llvm.store %101, %103 : i256, !llvm.ptr
+    llvm.store %c0_i256_14, %103 : i256, !llvm.ptr
     %104 = llvm.getelementptr %103[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %104, %102 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %c65535_i256 = arith.constant 65535 : i256
+    %c0_i256_15 = arith.constant 0 : i256
     %105 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %106 = llvm.load %105 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %106 : i256, !llvm.ptr
+    llvm.store %c0_i256_15, %106 : i256, !llvm.ptr
     %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %107, %105 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb20:  // pred: ^bb19
     %108 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %109 = llvm.load %108 : !llvm.ptr -> !llvm.ptr
-    %110 = llvm.getelementptr %109[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %110 = llvm.getelementptr %109[-6] : (!llvm.ptr) -> !llvm.ptr, i256
     %111 = llvm.load %110 : !llvm.ptr -> i256
-    llvm.store %110, %108 : !llvm.ptr, !llvm.ptr
     %112 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %113 = llvm.load %112 : !llvm.ptr -> !llvm.ptr
-    %114 = llvm.getelementptr %113[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %115 = llvm.load %114 : !llvm.ptr -> i256
+    llvm.store %111, %113 : i256, !llvm.ptr
+    %114 = llvm.getelementptr %113[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %114, %112 : !llvm.ptr, !llvm.ptr
-    %116 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %117 = llvm.load %116 : !llvm.ptr -> !llvm.ptr
-    %118 = llvm.getelementptr %117[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %119 = llvm.load %118 : !llvm.ptr -> i256
-    llvm.store %118, %116 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
-    %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %123 = llvm.load %122 : !llvm.ptr -> i256
-    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
-    %124 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-    %126 = llvm.getelementptr %125[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %127 = llvm.load %126 : !llvm.ptr -> i256
-    llvm.store %126, %124 : !llvm.ptr, !llvm.ptr
-    %128 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %129 = llvm.load %128 : !llvm.ptr -> !llvm.ptr
-    %130 = llvm.getelementptr %129[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %131 = llvm.load %130 : !llvm.ptr -> i256
-    llvm.store %130, %128 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
-    %134 = llvm.getelementptr %133[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %135 = llvm.load %134 : !llvm.ptr -> i256
-    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
-    %136 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %137 = llvm.load %136 : !llvm.ptr -> i1
-    %c0_i256_14 = arith.constant 0 : i256
-    %138 = arith.cmpi ne, %119, %c0_i256_14 : i256
-    %139 = arith.andi %137, %138 : i1
-    %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %139, ^bb1(%c86_i8 : i8), ^bb21
+    cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %140 = arith.trunci %111 : i256 to i64
-    %141 = arith.trunci %123 : i256 to i64
-    %142 = arith.trunci %127 : i256 to i64
-    %143 = arith.trunci %131 : i256 to i64
-    %144 = arith.trunci %135 : i256 to i64
-    %145 = arith.addi %141, %142 : i64
-    %146 = arith.addi %143, %144 : i64
-    %147 = arith.maxui %145, %146 : i64
-    %c0_i64_15 = arith.constant 0 : i64
-    %148 = arith.cmpi slt, %147, %c0_i64_15 : i64
-    %c84_i8_16 = arith.constant 84 : i8
-    cf.cond_br %148, ^bb1(%c84_i8_16 : i8), ^bb22
+    %c65535_i256 = arith.constant 65535 : i256
+    %115 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %116 = llvm.load %115 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %116 : i256, !llvm.ptr
+    %117 = llvm.getelementptr %116[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %117, %115 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb22
   ^bb22:  // pred: ^bb21
-    %149 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %150 = llvm.load %149 : !llvm.ptr -> i64
-    %c31_i64_17 = arith.constant 31 : i64
-    %c32_i64_18 = arith.constant 32 : i64
-    %151 = arith.addi %147, %c31_i64_17 : i64
-    %152 = arith.divui %151, %c32_i64_18 : i64
-    %153 = arith.muli %152, %c32_i64_18 : i64
-    %154 = arith.cmpi ult, %150, %153 : i64
-    scf.if %154 {
-      %169 = func.call @dora_fn_extend_memory(%arg0, %153) : (!llvm.ptr, i64) -> !llvm.ptr
-      %170 = llvm.getelementptr %169[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
-      llvm.store %153, %149 : i64, !llvm.ptr
-      %172 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %171, %172 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %155 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %156 = llvm.load %155 : !llvm.ptr -> i64
-    %c1_i256_19 = arith.constant 1 : i256
-    %157 = llvm.alloca %c1_i256_19 x i256 : (i256) -> !llvm.ptr
-    llvm.store %119, %157 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_20 = arith.constant 1 : i256
-    %158 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
-    llvm.store %115, %158 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_21 = arith.constant 1 : i64
-    %159 = llvm.alloca %c1_i64_21 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_22 = arith.constant 0 : i8
-    %160 = call @dora_fn_call(%arg0, %140, %158, %157, %141, %142, %143, %144, %156, %159, %c0_i8_22) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %161 = llvm.getelementptr %160[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %162 = llvm.load %161 : !llvm.ptr -> i8
-    %163 = llvm.load %159 : !llvm.ptr -> i64
-    %164 = arith.extui %162 : i8 to i256
-    %165 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> !llvm.ptr
-    llvm.store %164, %166 : i256, !llvm.ptr
-    %167 = llvm.getelementptr %166[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %167, %165 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %118 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %119 = llvm.load %118 : !llvm.ptr -> !llvm.ptr
+    %120 = llvm.getelementptr %119[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %121 = llvm.load %120 : !llvm.ptr -> i256
+    llvm.store %120, %118 : !llvm.ptr, !llvm.ptr
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    %124 = llvm.getelementptr %123[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %125 = llvm.load %124 : !llvm.ptr -> i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %130 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %131 = llvm.load %130 : !llvm.ptr -> !llvm.ptr
+    %132 = llvm.getelementptr %131[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %133 = llvm.load %132 : !llvm.ptr -> i256
+    llvm.store %132, %130 : !llvm.ptr, !llvm.ptr
+    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
+    %136 = llvm.getelementptr %135[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %137 = llvm.load %136 : !llvm.ptr -> i256
+    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    %140 = llvm.getelementptr %139[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %141 = llvm.load %140 : !llvm.ptr -> i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %142 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %143 = llvm.load %142 : !llvm.ptr -> !llvm.ptr
+    %144 = llvm.getelementptr %143[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %145 = llvm.load %144 : !llvm.ptr -> i256
+    llvm.store %144, %142 : !llvm.ptr, !llvm.ptr
+    %146 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %147 = llvm.load %146 : !llvm.ptr -> i1
+    %c0_i256_16 = arith.constant 0 : i256
+    %148 = arith.cmpi ne, %129, %c0_i256_16 : i256
+    %149 = arith.andi %147, %148 : i1
+    %c86_i8 = arith.constant 86 : i8
+    cf.cond_br %149, ^bb1(%c86_i8 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i64_23 = arith.constant 0 : i64
+    %150 = arith.trunci %121 : i256 to i64
+    %151 = arith.trunci %133 : i256 to i64
+    %152 = arith.trunci %137 : i256 to i64
+    %153 = arith.trunci %141 : i256 to i64
+    %154 = arith.trunci %145 : i256 to i64
+    %155 = arith.addi %151, %152 : i64
+    %156 = arith.addi %153, %154 : i64
+    %157 = arith.maxui %155, %156 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %158 = arith.cmpi slt, %157, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %158, ^bb1(%c84_i8_18 : i8), ^bb24
+  ^bb24:  // pred: ^bb23
+    %c31_i64_19 = arith.constant 31 : i64
+    %c32_i64_20 = arith.constant 32 : i64
+    %159 = arith.addi %157, %c31_i64_19 : i64
+    %160 = arith.divui %159, %c32_i64_20 : i64
+    %161 = arith.muli %160, %c32_i64_20 : i64
+    %162 = call @dora_fn_extend_memory(%arg0, %161) : (!llvm.ptr, i64) -> !llvm.ptr
+    %163 = llvm.getelementptr %162[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
+    %165 = llvm.getelementptr %162[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %166 = llvm.load %165 : !llvm.ptr -> i8
+    %c0_i8_21 = arith.constant 0 : i8
+    %167 = arith.cmpi ne, %166, %c0_i8_21 : i8
+    cf.cond_br %167, ^bb1(%166 : i8), ^bb25
+  ^bb25:  // pred: ^bb24
+    %168 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %164, %168 : !llvm.ptr, !llvm.ptr
+    %169 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %161, %169 : i64, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> i64
+    %c1_i256_22 = arith.constant 1 : i256
+    %172 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %129, %172 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %173 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %125, %173 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_24 = arith.constant 1 : i64
+    %174 = llvm.alloca %c1_i64_24 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_25 = arith.constant 0 : i8
+    %175 = call @dora_fn_call(%arg0, %150, %173, %172, %151, %152, %153, %154, %171, %174, %c0_i8_25) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %176 = llvm.getelementptr %175[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %177 = llvm.load %176 : !llvm.ptr -> i8
+    %178 = llvm.load %174 : !llvm.ptr -> i64
+    %179 = arith.extui %177 : i8 to i256
+    %180 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %181 = llvm.load %180 : !llvm.ptr -> !llvm.ptr
+    llvm.store %179, %181 : i256, !llvm.ptr
+    %182 = llvm.getelementptr %181[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %182, %180 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb26
+  ^bb26:  // pred: ^bb25
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %168 = call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %183 = call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 8 preds: ^bb2, ^bb5, ^bb10, ^bb11, ^bb20, ^bb21, ^bb30, ^bb31
+  ^bb1(%10: i8):  // 12 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12, ^bb13, ^bb22, ^bb23, ^bb24, ^bb33, ^bb34, ^bb35
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,431 +120,435 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %254 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %255 = llvm.getelementptr %254[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %257 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %256, %257 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c15_i256 = arith.constant 15 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c15_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c17_i256 = arith.constant 17 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256_4 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c15_i256 = arith.constant 15 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %56 : i256 to i64
-    %62 = arith.trunci %60 : i256 to i64
-    %63 = arith.addi %61, %62 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_6 : i8), ^bb11
+    %c0_i256_4 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %66 = llvm.load %65 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %61 : i256 to i64
+    %67 = arith.trunci %65 : i256 to i64
+    %68 = arith.addi %66, %67 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_6 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %67 = arith.addi %63, %c31_i64_7 : i64
-    %68 = arith.divui %67, %c32_i64_8 : i64
-    %69 = arith.muli %68, %c32_i64_8 : i64
-    %70 = arith.cmpi ult, %66, %69 : i64
-    scf.if %70 {
-      %254 = func.call @dora_fn_extend_memory(%arg0, %69) : (!llvm.ptr, i64) -> !llvm.ptr
-      %255 = llvm.getelementptr %254[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-      llvm.store %69, %65 : i64, !llvm.ptr
-      %257 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %256, %257 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %52, %71 {alignment = 1 : i64} : i256, !llvm.ptr
-    %72 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %73, %74 {alignment = 1 : i64} : i64, !llvm.ptr
-    %75 = call @dora_fn_create(%arg0, %62, %61, %71, %74) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = arith.addi %68, %c31_i64_7 : i64
+    %71 = arith.divui %70, %c32_i64_8 : i64
+    %72 = arith.muli %71, %c32_i64_8 : i64
+    %73 = call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
+    %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %73[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %c0_i8, %77 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %78, ^bb1(%c94_i8 : i8), ^bb12
-  ^bb12:  // pred: ^bb11
-    %79 = llvm.load %71 : !llvm.ptr -> i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %c0_i8_9 = arith.constant 0 : i8
+    %78 = arith.cmpi ne, %77, %c0_i8_9 : i8
+    cf.cond_br %78, ^bb1(%77 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_9 = arith.constant 0 : i256
-    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_9, %84 : i256, !llvm.ptr
-    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %75, %79 : !llvm.ptr, !llvm.ptr
+    %80 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %72, %80 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %82 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %83 = llvm.load %82 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %84 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %83, %84 {alignment = 1 : i64} : i64, !llvm.ptr
+    %85 = call @dora_fn_create(%arg0, %67, %66, %81, %84) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %86 = llvm.getelementptr %85[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %87 = llvm.load %86 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %88 = arith.cmpi ne, %c0_i8_10, %87 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %88, ^bb1(%c94_i8 : i8), ^bb14
   ^bb14:  // pred: ^bb13
-    %c0_i256_10 = arith.constant 0 : i256
-    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %87 : i256, !llvm.ptr
-    %88 = llvm.getelementptr %87[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %89 = llvm.load %81 : !llvm.ptr -> i256
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %91 : i256, !llvm.ptr
+    %92 = llvm.getelementptr %91[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
     %c0_i256_11 = arith.constant 0 : i256
-    %89 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %90 = llvm.load %89 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %90 : i256, !llvm.ptr
-    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %91, %89 : !llvm.ptr, !llvm.ptr
+    %93 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %94 = llvm.load %93 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %94 : i256, !llvm.ptr
+    %95 = llvm.getelementptr %94[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %95, %93 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb16:  // pred: ^bb15
     %c0_i256_12 = arith.constant 0 : i256
-    %92 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_12, %93 : i256, !llvm.ptr
-    %94 = llvm.getelementptr %93[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %94, %92 : !llvm.ptr, !llvm.ptr
+    %96 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %97 : i256, !llvm.ptr
+    %98 = llvm.getelementptr %97[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %98, %96 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb17:  // pred: ^bb16
     %c0_i256_13 = arith.constant 0 : i256
-    %95 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %96 = llvm.load %95 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_13, %96 : i256, !llvm.ptr
-    %97 = llvm.getelementptr %96[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %97, %95 : !llvm.ptr, !llvm.ptr
+    %99 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %100 = llvm.load %99 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_13, %100 : i256, !llvm.ptr
+    %101 = llvm.getelementptr %100[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %101, %99 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %98 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %99 = llvm.load %98 : !llvm.ptr -> !llvm.ptr
-    %100 = llvm.getelementptr %99[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %101 = llvm.load %100 : !llvm.ptr -> i256
+    %c0_i256_14 = arith.constant 0 : i256
     %102 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %103 = llvm.load %102 : !llvm.ptr -> !llvm.ptr
-    llvm.store %101, %103 : i256, !llvm.ptr
+    llvm.store %c0_i256_14, %103 : i256, !llvm.ptr
     %104 = llvm.getelementptr %103[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %104, %102 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %c65535_i256 = arith.constant 65535 : i256
+    %c0_i256_15 = arith.constant 0 : i256
     %105 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %106 = llvm.load %105 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %106 : i256, !llvm.ptr
+    llvm.store %c0_i256_15, %106 : i256, !llvm.ptr
     %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %107, %105 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb20:  // pred: ^bb19
     %108 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %109 = llvm.load %108 : !llvm.ptr -> !llvm.ptr
-    %110 = llvm.getelementptr %109[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %110 = llvm.getelementptr %109[-6] : (!llvm.ptr) -> !llvm.ptr, i256
     %111 = llvm.load %110 : !llvm.ptr -> i256
-    llvm.store %110, %108 : !llvm.ptr, !llvm.ptr
     %112 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %113 = llvm.load %112 : !llvm.ptr -> !llvm.ptr
-    %114 = llvm.getelementptr %113[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %115 = llvm.load %114 : !llvm.ptr -> i256
+    llvm.store %111, %113 : i256, !llvm.ptr
+    %114 = llvm.getelementptr %113[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %114, %112 : !llvm.ptr, !llvm.ptr
-    %116 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %117 = llvm.load %116 : !llvm.ptr -> !llvm.ptr
-    %118 = llvm.getelementptr %117[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %119 = llvm.load %118 : !llvm.ptr -> i256
-    llvm.store %118, %116 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
-    %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %123 = llvm.load %122 : !llvm.ptr -> i256
-    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
-    %124 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-    %126 = llvm.getelementptr %125[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %127 = llvm.load %126 : !llvm.ptr -> i256
-    llvm.store %126, %124 : !llvm.ptr, !llvm.ptr
-    %128 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %129 = llvm.load %128 : !llvm.ptr -> !llvm.ptr
-    %130 = llvm.getelementptr %129[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %131 = llvm.load %130 : !llvm.ptr -> i256
-    llvm.store %130, %128 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
-    %134 = llvm.getelementptr %133[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %135 = llvm.load %134 : !llvm.ptr -> i256
-    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
-    %136 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %137 = llvm.load %136 : !llvm.ptr -> i1
-    %c0_i256_14 = arith.constant 0 : i256
-    %138 = arith.cmpi ne, %119, %c0_i256_14 : i256
-    %139 = arith.andi %137, %138 : i1
-    %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %139, ^bb1(%c86_i8 : i8), ^bb21
+    cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %140 = arith.trunci %111 : i256 to i64
-    %141 = arith.trunci %123 : i256 to i64
-    %142 = arith.trunci %127 : i256 to i64
-    %143 = arith.trunci %131 : i256 to i64
-    %144 = arith.trunci %135 : i256 to i64
-    %145 = arith.addi %141, %142 : i64
-    %146 = arith.addi %143, %144 : i64
-    %147 = arith.maxui %145, %146 : i64
-    %c0_i64_15 = arith.constant 0 : i64
-    %148 = arith.cmpi slt, %147, %c0_i64_15 : i64
-    %c84_i8_16 = arith.constant 84 : i8
-    cf.cond_br %148, ^bb1(%c84_i8_16 : i8), ^bb22
+    %c65535_i256 = arith.constant 65535 : i256
+    %115 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %116 = llvm.load %115 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %116 : i256, !llvm.ptr
+    %117 = llvm.getelementptr %116[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %117, %115 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb22
   ^bb22:  // pred: ^bb21
-    %149 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %150 = llvm.load %149 : !llvm.ptr -> i64
-    %c31_i64_17 = arith.constant 31 : i64
-    %c32_i64_18 = arith.constant 32 : i64
-    %151 = arith.addi %147, %c31_i64_17 : i64
-    %152 = arith.divui %151, %c32_i64_18 : i64
-    %153 = arith.muli %152, %c32_i64_18 : i64
-    %154 = arith.cmpi ult, %150, %153 : i64
-    scf.if %154 {
-      %254 = func.call @dora_fn_extend_memory(%arg0, %153) : (!llvm.ptr, i64) -> !llvm.ptr
-      %255 = llvm.getelementptr %254[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-      llvm.store %153, %149 : i64, !llvm.ptr
-      %257 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %256, %257 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %155 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %156 = llvm.load %155 : !llvm.ptr -> i64
-    %c1_i256_19 = arith.constant 1 : i256
-    %157 = llvm.alloca %c1_i256_19 x i256 : (i256) -> !llvm.ptr
-    llvm.store %119, %157 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_20 = arith.constant 1 : i256
-    %158 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
-    llvm.store %115, %158 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_21 = arith.constant 1 : i64
-    %159 = llvm.alloca %c1_i64_21 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_22 = arith.constant 0 : i8
-    %160 = call @dora_fn_call(%arg0, %140, %158, %157, %141, %142, %143, %144, %156, %159, %c0_i8_22) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %161 = llvm.getelementptr %160[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %162 = llvm.load %161 : !llvm.ptr -> i8
-    %163 = llvm.load %159 : !llvm.ptr -> i64
-    %164 = arith.extui %162 : i8 to i256
-    %165 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> !llvm.ptr
-    llvm.store %164, %166 : i256, !llvm.ptr
-    %167 = llvm.getelementptr %166[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %167, %165 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %118 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %119 = llvm.load %118 : !llvm.ptr -> !llvm.ptr
+    %120 = llvm.getelementptr %119[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %121 = llvm.load %120 : !llvm.ptr -> i256
+    llvm.store %120, %118 : !llvm.ptr, !llvm.ptr
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    %124 = llvm.getelementptr %123[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %125 = llvm.load %124 : !llvm.ptr -> i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %130 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %131 = llvm.load %130 : !llvm.ptr -> !llvm.ptr
+    %132 = llvm.getelementptr %131[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %133 = llvm.load %132 : !llvm.ptr -> i256
+    llvm.store %132, %130 : !llvm.ptr, !llvm.ptr
+    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
+    %136 = llvm.getelementptr %135[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %137 = llvm.load %136 : !llvm.ptr -> i256
+    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    %140 = llvm.getelementptr %139[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %141 = llvm.load %140 : !llvm.ptr -> i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %142 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %143 = llvm.load %142 : !llvm.ptr -> !llvm.ptr
+    %144 = llvm.getelementptr %143[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %145 = llvm.load %144 : !llvm.ptr -> i256
+    llvm.store %144, %142 : !llvm.ptr, !llvm.ptr
+    %146 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %147 = llvm.load %146 : !llvm.ptr -> i1
+    %c0_i256_16 = arith.constant 0 : i256
+    %148 = arith.cmpi ne, %129, %c0_i256_16 : i256
+    %149 = arith.andi %147, %148 : i1
+    %c86_i8 = arith.constant 86 : i8
+    cf.cond_br %149, ^bb1(%c86_i8 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_23 = arith.constant 0 : i256
-    %168 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %169 = llvm.load %168 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_23, %169 : i256, !llvm.ptr
-    %170 = llvm.getelementptr %169[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %170, %168 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb24
+    %150 = arith.trunci %121 : i256 to i64
+    %151 = arith.trunci %133 : i256 to i64
+    %152 = arith.trunci %137 : i256 to i64
+    %153 = arith.trunci %141 : i256 to i64
+    %154 = arith.trunci %145 : i256 to i64
+    %155 = arith.addi %151, %152 : i64
+    %156 = arith.addi %153, %154 : i64
+    %157 = arith.maxui %155, %156 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %158 = arith.cmpi slt, %157, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %158, ^bb1(%c84_i8_18 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c0_i256_24 = arith.constant 0 : i256
-    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_24, %172 : i256, !llvm.ptr
-    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb25
+    %c31_i64_19 = arith.constant 31 : i64
+    %c32_i64_20 = arith.constant 32 : i64
+    %159 = arith.addi %157, %c31_i64_19 : i64
+    %160 = arith.divui %159, %c32_i64_20 : i64
+    %161 = arith.muli %160, %c32_i64_20 : i64
+    %162 = call @dora_fn_extend_memory(%arg0, %161) : (!llvm.ptr, i64) -> !llvm.ptr
+    %163 = llvm.getelementptr %162[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
+    %165 = llvm.getelementptr %162[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %166 = llvm.load %165 : !llvm.ptr -> i8
+    %c0_i8_21 = arith.constant 0 : i8
+    %167 = arith.cmpi ne, %166, %c0_i8_21 : i8
+    cf.cond_br %167, ^bb1(%166 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %c32_i256 = arith.constant 32 : i256
-    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %175 : i256, !llvm.ptr
-    %176 = llvm.getelementptr %175[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb26
-  ^bb26:  // pred: ^bb25
-    %c0_i256_25 = arith.constant 0 : i256
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_25, %178 : i256, !llvm.ptr
-    %179 = llvm.getelementptr %178[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb27
-  ^bb27:  // pred: ^bb26
-    %c0_i256_26 = arith.constant 0 : i256
+    %168 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %164, %168 : !llvm.ptr, !llvm.ptr
+    %169 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %161, %169 : i64, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> i64
+    %c1_i256_22 = arith.constant 1 : i256
+    %172 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %129, %172 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %173 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %125, %173 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_24 = arith.constant 1 : i64
+    %174 = llvm.alloca %c1_i64_24 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_25 = arith.constant 0 : i8
+    %175 = call @dora_fn_call(%arg0, %150, %173, %172, %151, %152, %153, %154, %171, %174, %c0_i8_25) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %176 = llvm.getelementptr %175[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %177 = llvm.load %176 : !llvm.ptr -> i8
+    %178 = llvm.load %174 : !llvm.ptr -> i64
+    %179 = arith.extui %177 : i8 to i256
     %180 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %181 = llvm.load %180 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_26, %181 : i256, !llvm.ptr
+    llvm.store %179, %181 : i256, !llvm.ptr
     %182 = llvm.getelementptr %181[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %182, %180 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb28
-  ^bb28:  // pred: ^bb27
+    cf.br ^bb26
+  ^bb26:  // pred: ^bb25
+    %c0_i256_26 = arith.constant 0 : i256
     %183 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %184 = llvm.load %183 : !llvm.ptr -> !llvm.ptr
-    %185 = llvm.getelementptr %184[-7] : (!llvm.ptr) -> !llvm.ptr, i256
-    %186 = llvm.load %185 : !llvm.ptr -> i256
-    %187 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %188 = llvm.load %187 : !llvm.ptr -> !llvm.ptr
-    llvm.store %186, %188 : i256, !llvm.ptr
-    %189 = llvm.getelementptr %188[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %189, %187 : !llvm.ptr, !llvm.ptr
+    llvm.store %c0_i256_26, %184 : i256, !llvm.ptr
+    %185 = llvm.getelementptr %184[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb27
+  ^bb27:  // pred: ^bb26
+    %c0_i256_27 = arith.constant 0 : i256
+    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_27, %187 : i256, !llvm.ptr
+    %188 = llvm.getelementptr %187[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb28
+  ^bb28:  // pred: ^bb27
+    %c32_i256 = arith.constant 32 : i256
+    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %190 : i256, !llvm.ptr
+    %191 = llvm.getelementptr %190[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb29:  // pred: ^bb28
-    %c65535_i256_27 = arith.constant 65535 : i256
-    %190 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256_27, %191 : i256, !llvm.ptr
-    %192 = llvm.getelementptr %191[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %192, %190 : !llvm.ptr, !llvm.ptr
+    %c0_i256_28 = arith.constant 0 : i256
+    %192 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %193 = llvm.load %192 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_28, %193 : i256, !llvm.ptr
+    %194 = llvm.getelementptr %193[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %194, %192 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb30:  // pred: ^bb29
-    %193 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
-    %195 = llvm.getelementptr %194[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    llvm.store %195, %193 : !llvm.ptr, !llvm.ptr
-    %197 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %198 = llvm.load %197 : !llvm.ptr -> !llvm.ptr
-    %199 = llvm.getelementptr %198[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %200 = llvm.load %199 : !llvm.ptr -> i256
-    llvm.store %199, %197 : !llvm.ptr, !llvm.ptr
-    %201 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %202 = llvm.load %201 : !llvm.ptr -> !llvm.ptr
-    %203 = llvm.getelementptr %202[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %204 = llvm.load %203 : !llvm.ptr -> i256
-    llvm.store %203, %201 : !llvm.ptr, !llvm.ptr
+    %c0_i256_29 = arith.constant 0 : i256
+    %195 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %196 = llvm.load %195 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_29, %196 : i256, !llvm.ptr
+    %197 = llvm.getelementptr %196[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %197, %195 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb31
+  ^bb31:  // pred: ^bb30
+    %198 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %199 = llvm.load %198 : !llvm.ptr -> !llvm.ptr
+    %200 = llvm.getelementptr %199[-7] : (!llvm.ptr) -> !llvm.ptr, i256
+    %201 = llvm.load %200 : !llvm.ptr -> i256
+    %202 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %203 = llvm.load %202 : !llvm.ptr -> !llvm.ptr
+    llvm.store %201, %203 : i256, !llvm.ptr
+    %204 = llvm.getelementptr %203[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %204, %202 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb32
+  ^bb32:  // pred: ^bb31
+    %c65535_i256_30 = arith.constant 65535 : i256
     %205 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %206 = llvm.load %205 : !llvm.ptr -> !llvm.ptr
-    %207 = llvm.getelementptr %206[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %208 = llvm.load %207 : !llvm.ptr -> i256
+    llvm.store %c65535_i256_30, %206 : i256, !llvm.ptr
+    %207 = llvm.getelementptr %206[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %207, %205 : !llvm.ptr, !llvm.ptr
-    %209 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %210 = llvm.load %209 : !llvm.ptr -> !llvm.ptr
-    %211 = llvm.getelementptr %210[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %212 = llvm.load %211 : !llvm.ptr -> i256
-    llvm.store %211, %209 : !llvm.ptr, !llvm.ptr
-    %213 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %214 = llvm.load %213 : !llvm.ptr -> !llvm.ptr
-    %215 = llvm.getelementptr %214[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %216 = llvm.load %215 : !llvm.ptr -> i256
-    llvm.store %215, %213 : !llvm.ptr, !llvm.ptr
-    %217 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %218 = llvm.load %217 : !llvm.ptr -> !llvm.ptr
-    %219 = llvm.getelementptr %218[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %220 = llvm.load %219 : !llvm.ptr -> i256
-    llvm.store %219, %217 : !llvm.ptr, !llvm.ptr
-    %221 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %222 = llvm.load %221 : !llvm.ptr -> i1
-    %c0_i256_28 = arith.constant 0 : i256
-    %223 = arith.cmpi ne, %204, %c0_i256_28 : i256
-    %224 = arith.andi %222, %223 : i1
-    %c86_i8_29 = arith.constant 86 : i8
-    cf.cond_br %224, ^bb1(%c86_i8_29 : i8), ^bb31
-  ^bb31:  // pred: ^bb30
-    %225 = arith.trunci %196 : i256 to i64
-    %226 = arith.trunci %208 : i256 to i64
-    %227 = arith.trunci %212 : i256 to i64
-    %228 = arith.trunci %216 : i256 to i64
-    %229 = arith.trunci %220 : i256 to i64
-    %230 = arith.addi %226, %227 : i64
-    %231 = arith.addi %228, %229 : i64
-    %232 = arith.maxui %230, %231 : i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %233 = arith.cmpi slt, %232, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %233, ^bb1(%c84_i8_31 : i8), ^bb32
-  ^bb32:  // pred: ^bb31
-    %234 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %235 = llvm.load %234 : !llvm.ptr -> i64
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %236 = arith.addi %232, %c31_i64_32 : i64
-    %237 = arith.divui %236, %c32_i64_33 : i64
-    %238 = arith.muli %237, %c32_i64_33 : i64
-    %239 = arith.cmpi ult, %235, %238 : i64
-    scf.if %239 {
-      %254 = func.call @dora_fn_extend_memory(%arg0, %238) : (!llvm.ptr, i64) -> !llvm.ptr
-      %255 = llvm.getelementptr %254[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-      llvm.store %238, %234 : i64, !llvm.ptr
-      %257 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %256, %257 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %240 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %241 = llvm.load %240 : !llvm.ptr -> i64
-    %c1_i256_34 = arith.constant 1 : i256
-    %242 = llvm.alloca %c1_i256_34 x i256 : (i256) -> !llvm.ptr
-    llvm.store %204, %242 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_35 = arith.constant 1 : i256
-    %243 = llvm.alloca %c1_i256_35 x i256 : (i256) -> !llvm.ptr
-    llvm.store %200, %243 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_36 = arith.constant 1 : i64
-    %244 = llvm.alloca %c1_i64_36 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_37 = arith.constant 0 : i8
-    %245 = call @dora_fn_call(%arg0, %225, %243, %242, %226, %227, %228, %229, %241, %244, %c0_i8_37) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %246 = llvm.getelementptr %245[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %247 = llvm.load %246 : !llvm.ptr -> i8
-    %248 = llvm.load %244 : !llvm.ptr -> i64
-    %249 = arith.extui %247 : i8 to i256
-    %250 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %251 = llvm.load %250 : !llvm.ptr -> !llvm.ptr
-    llvm.store %249, %251 : i256, !llvm.ptr
-    %252 = llvm.getelementptr %251[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %252, %250 : !llvm.ptr, !llvm.ptr
     cf.br ^bb33
   ^bb33:  // pred: ^bb32
-    %c0_i64_38 = arith.constant 0 : i64
+    %208 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %209 = llvm.load %208 : !llvm.ptr -> !llvm.ptr
+    %210 = llvm.getelementptr %209[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %211 = llvm.load %210 : !llvm.ptr -> i256
+    llvm.store %210, %208 : !llvm.ptr, !llvm.ptr
+    %212 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %213 = llvm.load %212 : !llvm.ptr -> !llvm.ptr
+    %214 = llvm.getelementptr %213[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %215 = llvm.load %214 : !llvm.ptr -> i256
+    llvm.store %214, %212 : !llvm.ptr, !llvm.ptr
+    %216 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
+    %218 = llvm.getelementptr %217[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %219 = llvm.load %218 : !llvm.ptr -> i256
+    llvm.store %218, %216 : !llvm.ptr, !llvm.ptr
+    %220 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
+    %222 = llvm.getelementptr %221[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %223 = llvm.load %222 : !llvm.ptr -> i256
+    llvm.store %222, %220 : !llvm.ptr, !llvm.ptr
+    %224 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %225 = llvm.load %224 : !llvm.ptr -> !llvm.ptr
+    %226 = llvm.getelementptr %225[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %227 = llvm.load %226 : !llvm.ptr -> i256
+    llvm.store %226, %224 : !llvm.ptr, !llvm.ptr
+    %228 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %229 = llvm.load %228 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    llvm.store %230, %228 : !llvm.ptr, !llvm.ptr
+    %232 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %233 = llvm.load %232 : !llvm.ptr -> !llvm.ptr
+    %234 = llvm.getelementptr %233[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %235 = llvm.load %234 : !llvm.ptr -> i256
+    llvm.store %234, %232 : !llvm.ptr, !llvm.ptr
+    %236 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %237 = llvm.load %236 : !llvm.ptr -> i1
+    %c0_i256_31 = arith.constant 0 : i256
+    %238 = arith.cmpi ne, %219, %c0_i256_31 : i256
+    %239 = arith.andi %237, %238 : i1
+    %c86_i8_32 = arith.constant 86 : i8
+    cf.cond_br %239, ^bb1(%c86_i8_32 : i8), ^bb34
+  ^bb34:  // pred: ^bb33
+    %240 = arith.trunci %211 : i256 to i64
+    %241 = arith.trunci %223 : i256 to i64
+    %242 = arith.trunci %227 : i256 to i64
+    %243 = arith.trunci %231 : i256 to i64
+    %244 = arith.trunci %235 : i256 to i64
+    %245 = arith.addi %241, %242 : i64
+    %246 = arith.addi %243, %244 : i64
+    %247 = arith.maxui %245, %246 : i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %248 = arith.cmpi slt, %247, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %248, ^bb1(%c84_i8_34 : i8), ^bb35
+  ^bb35:  // pred: ^bb34
+    %c31_i64_35 = arith.constant 31 : i64
+    %c32_i64_36 = arith.constant 32 : i64
+    %249 = arith.addi %247, %c31_i64_35 : i64
+    %250 = arith.divui %249, %c32_i64_36 : i64
+    %251 = arith.muli %250, %c32_i64_36 : i64
+    %252 = call @dora_fn_extend_memory(%arg0, %251) : (!llvm.ptr, i64) -> !llvm.ptr
+    %253 = llvm.getelementptr %252[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
+    %255 = llvm.getelementptr %252[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %256 = llvm.load %255 : !llvm.ptr -> i8
+    %c0_i8_37 = arith.constant 0 : i8
+    %257 = arith.cmpi ne, %256, %c0_i8_37 : i8
+    cf.cond_br %257, ^bb1(%256 : i8), ^bb36
+  ^bb36:  // pred: ^bb35
+    %258 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %254, %258 : !llvm.ptr, !llvm.ptr
+    %259 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %251, %259 : i64, !llvm.ptr
+    %260 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %261 = llvm.load %260 : !llvm.ptr -> i64
+    %c1_i256_38 = arith.constant 1 : i256
+    %262 = llvm.alloca %c1_i256_38 x i256 : (i256) -> !llvm.ptr
+    llvm.store %219, %262 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_39 = arith.constant 1 : i256
+    %263 = llvm.alloca %c1_i256_39 x i256 : (i256) -> !llvm.ptr
+    llvm.store %215, %263 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_40 = arith.constant 1 : i64
+    %264 = llvm.alloca %c1_i64_40 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_41 = arith.constant 0 : i8
+    %265 = call @dora_fn_call(%arg0, %240, %263, %262, %241, %242, %243, %244, %261, %264, %c0_i8_41) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %266 = llvm.getelementptr %265[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %267 = llvm.load %266 : !llvm.ptr -> i8
+    %268 = llvm.load %264 : !llvm.ptr -> i64
+    %269 = arith.extui %267 : i8 to i256
+    %270 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %271 = llvm.load %270 : !llvm.ptr -> !llvm.ptr
+    llvm.store %269, %271 : i256, !llvm.ptr
+    %272 = llvm.getelementptr %271[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %272, %270 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb37
+  ^bb37:  // pred: ^bb36
+    %c0_i64_42 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %253 = call @dora_fn_write_result(%arg0, %c0_i64_38, %c0_i64_38, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %273 = call @dora_fn_write_result(%arg0, %c0_i64_42, %c0_i64_42, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 8 preds: ^bb2, ^bb5, ^bb10, ^bb11, ^bb20, ^bb21, ^bb33, ^bb34
+  ^bb1(%10: i8):  // 12 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12, ^bb13, ^bb22, ^bb23, ^bb24, ^bb36, ^bb37, ^bb38
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,466 +120,470 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %271 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %272 = llvm.getelementptr %271[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %273 = llvm.load %272 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %274 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %273, %274 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c15_i256 = arith.constant 15 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c15_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c17_i256 = arith.constant 17 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256_4 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c15_i256 = arith.constant 15 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %56 : i256 to i64
-    %62 = arith.trunci %60 : i256 to i64
-    %63 = arith.addi %61, %62 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_6 : i8), ^bb11
+    %c0_i256_4 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %66 = llvm.load %65 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %61 : i256 to i64
+    %67 = arith.trunci %65 : i256 to i64
+    %68 = arith.addi %66, %67 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_6 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %67 = arith.addi %63, %c31_i64_7 : i64
-    %68 = arith.divui %67, %c32_i64_8 : i64
-    %69 = arith.muli %68, %c32_i64_8 : i64
-    %70 = arith.cmpi ult, %66, %69 : i64
-    scf.if %70 {
-      %271 = func.call @dora_fn_extend_memory(%arg0, %69) : (!llvm.ptr, i64) -> !llvm.ptr
-      %272 = llvm.getelementptr %271[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %273 = llvm.load %272 : !llvm.ptr -> !llvm.ptr
-      llvm.store %69, %65 : i64, !llvm.ptr
-      %274 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %273, %274 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %52, %71 {alignment = 1 : i64} : i256, !llvm.ptr
-    %72 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %73, %74 {alignment = 1 : i64} : i64, !llvm.ptr
-    %75 = call @dora_fn_create(%arg0, %62, %61, %71, %74) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = arith.addi %68, %c31_i64_7 : i64
+    %71 = arith.divui %70, %c32_i64_8 : i64
+    %72 = arith.muli %71, %c32_i64_8 : i64
+    %73 = call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
+    %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %73[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %c0_i8, %77 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %78, ^bb1(%c94_i8 : i8), ^bb12
-  ^bb12:  // pred: ^bb11
-    %79 = llvm.load %71 : !llvm.ptr -> i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %c0_i8_9 = arith.constant 0 : i8
+    %78 = arith.cmpi ne, %77, %c0_i8_9 : i8
+    cf.cond_br %78, ^bb1(%77 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_9 = arith.constant 0 : i256
-    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_9, %84 : i256, !llvm.ptr
-    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %75, %79 : !llvm.ptr, !llvm.ptr
+    %80 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %72, %80 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %82 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %83 = llvm.load %82 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %84 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %83, %84 {alignment = 1 : i64} : i64, !llvm.ptr
+    %85 = call @dora_fn_create(%arg0, %67, %66, %81, %84) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %86 = llvm.getelementptr %85[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %87 = llvm.load %86 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %88 = arith.cmpi ne, %c0_i8_10, %87 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %88, ^bb1(%c94_i8 : i8), ^bb14
   ^bb14:  // pred: ^bb13
-    %c0_i256_10 = arith.constant 0 : i256
-    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %87 : i256, !llvm.ptr
-    %88 = llvm.getelementptr %87[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %89 = llvm.load %81 : !llvm.ptr -> i256
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %91 : i256, !llvm.ptr
+    %92 = llvm.getelementptr %91[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
     %c0_i256_11 = arith.constant 0 : i256
-    %89 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %90 = llvm.load %89 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %90 : i256, !llvm.ptr
-    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %91, %89 : !llvm.ptr, !llvm.ptr
+    %93 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %94 = llvm.load %93 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %94 : i256, !llvm.ptr
+    %95 = llvm.getelementptr %94[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %95, %93 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb16:  // pred: ^bb15
     %c0_i256_12 = arith.constant 0 : i256
-    %92 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_12, %93 : i256, !llvm.ptr
-    %94 = llvm.getelementptr %93[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %94, %92 : !llvm.ptr, !llvm.ptr
+    %96 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %97 : i256, !llvm.ptr
+    %98 = llvm.getelementptr %97[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %98, %96 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb17:  // pred: ^bb16
     %c0_i256_13 = arith.constant 0 : i256
-    %95 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %96 = llvm.load %95 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_13, %96 : i256, !llvm.ptr
-    %97 = llvm.getelementptr %96[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %97, %95 : !llvm.ptr, !llvm.ptr
+    %99 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %100 = llvm.load %99 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_13, %100 : i256, !llvm.ptr
+    %101 = llvm.getelementptr %100[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %101, %99 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %98 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %99 = llvm.load %98 : !llvm.ptr -> !llvm.ptr
-    %100 = llvm.getelementptr %99[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %101 = llvm.load %100 : !llvm.ptr -> i256
+    %c0_i256_14 = arith.constant 0 : i256
     %102 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %103 = llvm.load %102 : !llvm.ptr -> !llvm.ptr
-    llvm.store %101, %103 : i256, !llvm.ptr
+    llvm.store %c0_i256_14, %103 : i256, !llvm.ptr
     %104 = llvm.getelementptr %103[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %104, %102 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %c65535_i256 = arith.constant 65535 : i256
+    %c0_i256_15 = arith.constant 0 : i256
     %105 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %106 = llvm.load %105 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %106 : i256, !llvm.ptr
+    llvm.store %c0_i256_15, %106 : i256, !llvm.ptr
     %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %107, %105 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb20:  // pred: ^bb19
     %108 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %109 = llvm.load %108 : !llvm.ptr -> !llvm.ptr
-    %110 = llvm.getelementptr %109[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %110 = llvm.getelementptr %109[-6] : (!llvm.ptr) -> !llvm.ptr, i256
     %111 = llvm.load %110 : !llvm.ptr -> i256
-    llvm.store %110, %108 : !llvm.ptr, !llvm.ptr
     %112 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %113 = llvm.load %112 : !llvm.ptr -> !llvm.ptr
-    %114 = llvm.getelementptr %113[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %115 = llvm.load %114 : !llvm.ptr -> i256
+    llvm.store %111, %113 : i256, !llvm.ptr
+    %114 = llvm.getelementptr %113[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %114, %112 : !llvm.ptr, !llvm.ptr
-    %116 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %117 = llvm.load %116 : !llvm.ptr -> !llvm.ptr
-    %118 = llvm.getelementptr %117[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %119 = llvm.load %118 : !llvm.ptr -> i256
-    llvm.store %118, %116 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
-    %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %123 = llvm.load %122 : !llvm.ptr -> i256
-    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
-    %124 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-    %126 = llvm.getelementptr %125[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %127 = llvm.load %126 : !llvm.ptr -> i256
-    llvm.store %126, %124 : !llvm.ptr, !llvm.ptr
-    %128 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %129 = llvm.load %128 : !llvm.ptr -> !llvm.ptr
-    %130 = llvm.getelementptr %129[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %131 = llvm.load %130 : !llvm.ptr -> i256
-    llvm.store %130, %128 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
-    %134 = llvm.getelementptr %133[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %135 = llvm.load %134 : !llvm.ptr -> i256
-    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
-    %136 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %137 = llvm.load %136 : !llvm.ptr -> i1
-    %c0_i256_14 = arith.constant 0 : i256
-    %138 = arith.cmpi ne, %119, %c0_i256_14 : i256
-    %139 = arith.andi %137, %138 : i1
-    %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %139, ^bb1(%c86_i8 : i8), ^bb21
+    cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %140 = arith.trunci %111 : i256 to i64
-    %141 = arith.trunci %123 : i256 to i64
-    %142 = arith.trunci %127 : i256 to i64
-    %143 = arith.trunci %131 : i256 to i64
-    %144 = arith.trunci %135 : i256 to i64
-    %145 = arith.addi %141, %142 : i64
-    %146 = arith.addi %143, %144 : i64
-    %147 = arith.maxui %145, %146 : i64
-    %c0_i64_15 = arith.constant 0 : i64
-    %148 = arith.cmpi slt, %147, %c0_i64_15 : i64
-    %c84_i8_16 = arith.constant 84 : i8
-    cf.cond_br %148, ^bb1(%c84_i8_16 : i8), ^bb22
+    %c65535_i256 = arith.constant 65535 : i256
+    %115 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %116 = llvm.load %115 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %116 : i256, !llvm.ptr
+    %117 = llvm.getelementptr %116[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %117, %115 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb22
   ^bb22:  // pred: ^bb21
-    %149 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %150 = llvm.load %149 : !llvm.ptr -> i64
-    %c31_i64_17 = arith.constant 31 : i64
-    %c32_i64_18 = arith.constant 32 : i64
-    %151 = arith.addi %147, %c31_i64_17 : i64
-    %152 = arith.divui %151, %c32_i64_18 : i64
-    %153 = arith.muli %152, %c32_i64_18 : i64
-    %154 = arith.cmpi ult, %150, %153 : i64
-    scf.if %154 {
-      %271 = func.call @dora_fn_extend_memory(%arg0, %153) : (!llvm.ptr, i64) -> !llvm.ptr
-      %272 = llvm.getelementptr %271[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %273 = llvm.load %272 : !llvm.ptr -> !llvm.ptr
-      llvm.store %153, %149 : i64, !llvm.ptr
-      %274 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %273, %274 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %155 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %156 = llvm.load %155 : !llvm.ptr -> i64
-    %c1_i256_19 = arith.constant 1 : i256
-    %157 = llvm.alloca %c1_i256_19 x i256 : (i256) -> !llvm.ptr
-    llvm.store %119, %157 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_20 = arith.constant 1 : i256
-    %158 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
-    llvm.store %115, %158 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_21 = arith.constant 1 : i64
-    %159 = llvm.alloca %c1_i64_21 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_22 = arith.constant 0 : i8
-    %160 = call @dora_fn_call(%arg0, %140, %158, %157, %141, %142, %143, %144, %156, %159, %c0_i8_22) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %161 = llvm.getelementptr %160[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %162 = llvm.load %161 : !llvm.ptr -> i8
-    %163 = llvm.load %159 : !llvm.ptr -> i64
-    %164 = arith.extui %162 : i8 to i256
-    %165 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> !llvm.ptr
-    llvm.store %164, %166 : i256, !llvm.ptr
-    %167 = llvm.getelementptr %166[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %167, %165 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %118 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %119 = llvm.load %118 : !llvm.ptr -> !llvm.ptr
+    %120 = llvm.getelementptr %119[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %121 = llvm.load %120 : !llvm.ptr -> i256
+    llvm.store %120, %118 : !llvm.ptr, !llvm.ptr
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    %124 = llvm.getelementptr %123[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %125 = llvm.load %124 : !llvm.ptr -> i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %130 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %131 = llvm.load %130 : !llvm.ptr -> !llvm.ptr
+    %132 = llvm.getelementptr %131[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %133 = llvm.load %132 : !llvm.ptr -> i256
+    llvm.store %132, %130 : !llvm.ptr, !llvm.ptr
+    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
+    %136 = llvm.getelementptr %135[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %137 = llvm.load %136 : !llvm.ptr -> i256
+    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    %140 = llvm.getelementptr %139[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %141 = llvm.load %140 : !llvm.ptr -> i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %142 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %143 = llvm.load %142 : !llvm.ptr -> !llvm.ptr
+    %144 = llvm.getelementptr %143[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %145 = llvm.load %144 : !llvm.ptr -> i256
+    llvm.store %144, %142 : !llvm.ptr, !llvm.ptr
+    %146 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %147 = llvm.load %146 : !llvm.ptr -> i1
+    %c0_i256_16 = arith.constant 0 : i256
+    %148 = arith.cmpi ne, %129, %c0_i256_16 : i256
+    %149 = arith.andi %147, %148 : i1
+    %c86_i8 = arith.constant 86 : i8
+    cf.cond_br %149, ^bb1(%c86_i8 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c1_i256_23 = arith.constant 1 : i256
-    %168 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %169 = llvm.load %168 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c1_i256_23, %169 : i256, !llvm.ptr
-    %170 = llvm.getelementptr %169[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %170, %168 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb24
+    %150 = arith.trunci %121 : i256 to i64
+    %151 = arith.trunci %133 : i256 to i64
+    %152 = arith.trunci %137 : i256 to i64
+    %153 = arith.trunci %141 : i256 to i64
+    %154 = arith.trunci %145 : i256 to i64
+    %155 = arith.addi %151, %152 : i64
+    %156 = arith.addi %153, %154 : i64
+    %157 = arith.maxui %155, %156 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %158 = arith.cmpi slt, %157, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %158, ^bb1(%c84_i8_18 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c0_i256_24 = arith.constant 0 : i256
-    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_24, %172 : i256, !llvm.ptr
-    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb25
+    %c31_i64_19 = arith.constant 31 : i64
+    %c32_i64_20 = arith.constant 32 : i64
+    %159 = arith.addi %157, %c31_i64_19 : i64
+    %160 = arith.divui %159, %c32_i64_20 : i64
+    %161 = arith.muli %160, %c32_i64_20 : i64
+    %162 = call @dora_fn_extend_memory(%arg0, %161) : (!llvm.ptr, i64) -> !llvm.ptr
+    %163 = llvm.getelementptr %162[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
+    %165 = llvm.getelementptr %162[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %166 = llvm.load %165 : !llvm.ptr -> i8
+    %c0_i8_21 = arith.constant 0 : i8
+    %167 = arith.cmpi ne, %166, %c0_i8_21 : i8
+    cf.cond_br %167, ^bb1(%166 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
-    %176 = llvm.getelementptr %175[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %177 = llvm.load %176 : !llvm.ptr -> i256
-    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
-    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
-    %180 = llvm.getelementptr %179[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %181 = llvm.load %180 : !llvm.ptr -> i256
-    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
-    %c1_i256_25 = arith.constant 1 : i256
-    %182 = llvm.alloca %c1_i256_25 x i256 : (i256) -> !llvm.ptr
-    llvm.store %177, %182 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_26 = arith.constant 1 : i256
-    %183 = llvm.alloca %c1_i256_26 x i256 : (i256) -> !llvm.ptr
-    llvm.store %181, %183 {alignment = 1 : i64} : i256, !llvm.ptr
-    %184 = call @dora_fn_write_storage(%arg0, %182, %183) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %168 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %164, %168 : !llvm.ptr, !llvm.ptr
+    %169 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %161, %169 : i64, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> i64
+    %c1_i256_22 = arith.constant 1 : i256
+    %172 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %129, %172 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %173 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %125, %173 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_24 = arith.constant 1 : i64
+    %174 = llvm.alloca %c1_i64_24 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_25 = arith.constant 0 : i8
+    %175 = call @dora_fn_call(%arg0, %150, %173, %172, %151, %152, %153, %154, %171, %174, %c0_i8_25) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %176 = llvm.getelementptr %175[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %177 = llvm.load %176 : !llvm.ptr -> i8
+    %178 = llvm.load %174 : !llvm.ptr -> i64
+    %179 = arith.extui %177 : i8 to i256
+    %180 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %181 = llvm.load %180 : !llvm.ptr -> !llvm.ptr
+    llvm.store %179, %181 : i256, !llvm.ptr
+    %182 = llvm.getelementptr %181[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %182, %180 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i256_27 = arith.constant 0 : i256
-    %185 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_27, %186 : i256, !llvm.ptr
-    %187 = llvm.getelementptr %186[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %187, %185 : !llvm.ptr, !llvm.ptr
+    %c1_i256_26 = arith.constant 1 : i256
+    %183 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %184 = llvm.load %183 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_26, %184 : i256, !llvm.ptr
+    %185 = llvm.getelementptr %184[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb27:  // pred: ^bb26
-    %c0_i256_28 = arith.constant 0 : i256
-    %188 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %189 = llvm.load %188 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_28, %189 : i256, !llvm.ptr
-    %190 = llvm.getelementptr %189[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %190, %188 : !llvm.ptr, !llvm.ptr
+    %c0_i256_27 = arith.constant 0 : i256
+    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_27, %187 : i256, !llvm.ptr
+    %188 = llvm.getelementptr %187[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
     cf.br ^bb28
   ^bb28:  // pred: ^bb27
-    %c32_i256 = arith.constant 32 : i256
-    %191 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %192 = llvm.load %191 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %192 : i256, !llvm.ptr
-    %193 = llvm.getelementptr %192[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %193, %191 : !llvm.ptr, !llvm.ptr
+    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
+    %191 = llvm.getelementptr %190[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %192 = llvm.load %191 : !llvm.ptr -> i256
+    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
+    %193 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
+    %195 = llvm.getelementptr %194[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %196 = llvm.load %195 : !llvm.ptr -> i256
+    llvm.store %195, %193 : !llvm.ptr, !llvm.ptr
+    %c1_i256_28 = arith.constant 1 : i256
+    %197 = llvm.alloca %c1_i256_28 x i256 : (i256) -> !llvm.ptr
+    llvm.store %192, %197 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_29 = arith.constant 1 : i256
+    %198 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
+    llvm.store %196, %198 {alignment = 1 : i64} : i256, !llvm.ptr
+    %199 = call @dora_fn_write_storage(%arg0, %197, %198) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
     cf.br ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i256_29 = arith.constant 0 : i256
-    %194 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %195 = llvm.load %194 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_29, %195 : i256, !llvm.ptr
-    %196 = llvm.getelementptr %195[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %196, %194 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb30
-  ^bb30:  // pred: ^bb29
     %c0_i256_30 = arith.constant 0 : i256
-    %197 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %198 = llvm.load %197 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_30, %198 : i256, !llvm.ptr
-    %199 = llvm.getelementptr %198[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %199, %197 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb31
-  ^bb31:  // pred: ^bb30
     %200 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %201 = llvm.load %200 : !llvm.ptr -> !llvm.ptr
-    %202 = llvm.getelementptr %201[-7] : (!llvm.ptr) -> !llvm.ptr, i256
-    %203 = llvm.load %202 : !llvm.ptr -> i256
-    %204 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %205 = llvm.load %204 : !llvm.ptr -> !llvm.ptr
-    llvm.store %203, %205 : i256, !llvm.ptr
-    %206 = llvm.getelementptr %205[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %206, %204 : !llvm.ptr, !llvm.ptr
+    llvm.store %c0_i256_30, %201 : i256, !llvm.ptr
+    %202 = llvm.getelementptr %201[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %202, %200 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb30
+  ^bb30:  // pred: ^bb29
+    %c0_i256_31 = arith.constant 0 : i256
+    %203 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %204 = llvm.load %203 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_31, %204 : i256, !llvm.ptr
+    %205 = llvm.getelementptr %204[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %205, %203 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb31
+  ^bb31:  // pred: ^bb30
+    %c32_i256 = arith.constant 32 : i256
+    %206 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %207 = llvm.load %206 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %207 : i256, !llvm.ptr
+    %208 = llvm.getelementptr %207[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %208, %206 : !llvm.ptr, !llvm.ptr
     cf.br ^bb32
   ^bb32:  // pred: ^bb31
-    %c65535_i256_31 = arith.constant 65535 : i256
-    %207 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %208 = llvm.load %207 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256_31, %208 : i256, !llvm.ptr
-    %209 = llvm.getelementptr %208[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %209, %207 : !llvm.ptr, !llvm.ptr
+    %c0_i256_32 = arith.constant 0 : i256
+    %209 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %210 = llvm.load %209 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_32, %210 : i256, !llvm.ptr
+    %211 = llvm.getelementptr %210[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %211, %209 : !llvm.ptr, !llvm.ptr
     cf.br ^bb33
   ^bb33:  // pred: ^bb32
-    %210 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %211 = llvm.load %210 : !llvm.ptr -> !llvm.ptr
-    %212 = llvm.getelementptr %211[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %213 = llvm.load %212 : !llvm.ptr -> i256
-    llvm.store %212, %210 : !llvm.ptr, !llvm.ptr
-    %214 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %215 = llvm.load %214 : !llvm.ptr -> !llvm.ptr
-    %216 = llvm.getelementptr %215[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %217 = llvm.load %216 : !llvm.ptr -> i256
-    llvm.store %216, %214 : !llvm.ptr, !llvm.ptr
-    %218 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %219 = llvm.load %218 : !llvm.ptr -> !llvm.ptr
-    %220 = llvm.getelementptr %219[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %221 = llvm.load %220 : !llvm.ptr -> i256
-    llvm.store %220, %218 : !llvm.ptr, !llvm.ptr
+    %c0_i256_33 = arith.constant 0 : i256
+    %212 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %213 = llvm.load %212 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_33, %213 : i256, !llvm.ptr
+    %214 = llvm.getelementptr %213[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %214, %212 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb34
+  ^bb34:  // pred: ^bb33
+    %215 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
+    %217 = llvm.getelementptr %216[-7] : (!llvm.ptr) -> !llvm.ptr, i256
+    %218 = llvm.load %217 : !llvm.ptr -> i256
+    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
+    llvm.store %218, %220 : i256, !llvm.ptr
+    %221 = llvm.getelementptr %220[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb35
+  ^bb35:  // pred: ^bb34
+    %c65535_i256_34 = arith.constant 65535 : i256
     %222 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %223 = llvm.load %222 : !llvm.ptr -> !llvm.ptr
-    %224 = llvm.getelementptr %223[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %225 = llvm.load %224 : !llvm.ptr -> i256
+    llvm.store %c65535_i256_34, %223 : i256, !llvm.ptr
+    %224 = llvm.getelementptr %223[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %224, %222 : !llvm.ptr, !llvm.ptr
-    %226 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %227 = llvm.load %226 : !llvm.ptr -> !llvm.ptr
-    %228 = llvm.getelementptr %227[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %229 = llvm.load %228 : !llvm.ptr -> i256
-    llvm.store %228, %226 : !llvm.ptr, !llvm.ptr
-    %230 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %231 = llvm.load %230 : !llvm.ptr -> !llvm.ptr
-    %232 = llvm.getelementptr %231[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %233 = llvm.load %232 : !llvm.ptr -> i256
-    llvm.store %232, %230 : !llvm.ptr, !llvm.ptr
-    %234 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %235 = llvm.load %234 : !llvm.ptr -> !llvm.ptr
-    %236 = llvm.getelementptr %235[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %237 = llvm.load %236 : !llvm.ptr -> i256
-    llvm.store %236, %234 : !llvm.ptr, !llvm.ptr
-    %238 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %239 = llvm.load %238 : !llvm.ptr -> i1
-    %c0_i256_32 = arith.constant 0 : i256
-    %240 = arith.cmpi ne, %221, %c0_i256_32 : i256
-    %241 = arith.andi %239, %240 : i1
-    %c86_i8_33 = arith.constant 86 : i8
-    cf.cond_br %241, ^bb1(%c86_i8_33 : i8), ^bb34
-  ^bb34:  // pred: ^bb33
-    %242 = arith.trunci %213 : i256 to i64
-    %243 = arith.trunci %225 : i256 to i64
-    %244 = arith.trunci %229 : i256 to i64
-    %245 = arith.trunci %233 : i256 to i64
-    %246 = arith.trunci %237 : i256 to i64
-    %247 = arith.addi %243, %244 : i64
-    %248 = arith.addi %245, %246 : i64
-    %249 = arith.maxui %247, %248 : i64
-    %c0_i64_34 = arith.constant 0 : i64
-    %250 = arith.cmpi slt, %249, %c0_i64_34 : i64
-    %c84_i8_35 = arith.constant 84 : i8
-    cf.cond_br %250, ^bb1(%c84_i8_35 : i8), ^bb35
-  ^bb35:  // pred: ^bb34
-    %251 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %252 = llvm.load %251 : !llvm.ptr -> i64
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %253 = arith.addi %249, %c31_i64_36 : i64
-    %254 = arith.divui %253, %c32_i64_37 : i64
-    %255 = arith.muli %254, %c32_i64_37 : i64
-    %256 = arith.cmpi ult, %252, %255 : i64
-    scf.if %256 {
-      %271 = func.call @dora_fn_extend_memory(%arg0, %255) : (!llvm.ptr, i64) -> !llvm.ptr
-      %272 = llvm.getelementptr %271[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %273 = llvm.load %272 : !llvm.ptr -> !llvm.ptr
-      llvm.store %255, %251 : i64, !llvm.ptr
-      %274 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %273, %274 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %257 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %258 = llvm.load %257 : !llvm.ptr -> i64
-    %c1_i256_38 = arith.constant 1 : i256
-    %259 = llvm.alloca %c1_i256_38 x i256 : (i256) -> !llvm.ptr
-    llvm.store %221, %259 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_39 = arith.constant 1 : i256
-    %260 = llvm.alloca %c1_i256_39 x i256 : (i256) -> !llvm.ptr
-    llvm.store %217, %260 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_40 = arith.constant 1 : i64
-    %261 = llvm.alloca %c1_i64_40 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_41 = arith.constant 0 : i8
-    %262 = call @dora_fn_call(%arg0, %242, %260, %259, %243, %244, %245, %246, %258, %261, %c0_i8_41) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %263 = llvm.getelementptr %262[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %264 = llvm.load %263 : !llvm.ptr -> i8
-    %265 = llvm.load %261 : !llvm.ptr -> i64
-    %266 = arith.extui %264 : i8 to i256
-    %267 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %268 = llvm.load %267 : !llvm.ptr -> !llvm.ptr
-    llvm.store %266, %268 : i256, !llvm.ptr
-    %269 = llvm.getelementptr %268[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %269, %267 : !llvm.ptr, !llvm.ptr
     cf.br ^bb36
   ^bb36:  // pred: ^bb35
-    %c0_i64_42 = arith.constant 0 : i64
+    %225 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %226 = llvm.load %225 : !llvm.ptr -> !llvm.ptr
+    %227 = llvm.getelementptr %226[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %228 = llvm.load %227 : !llvm.ptr -> i256
+    llvm.store %227, %225 : !llvm.ptr, !llvm.ptr
+    %229 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %230 = llvm.load %229 : !llvm.ptr -> !llvm.ptr
+    %231 = llvm.getelementptr %230[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %232 = llvm.load %231 : !llvm.ptr -> i256
+    llvm.store %231, %229 : !llvm.ptr, !llvm.ptr
+    %233 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %234 = llvm.load %233 : !llvm.ptr -> !llvm.ptr
+    %235 = llvm.getelementptr %234[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %236 = llvm.load %235 : !llvm.ptr -> i256
+    llvm.store %235, %233 : !llvm.ptr, !llvm.ptr
+    %237 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %238 = llvm.load %237 : !llvm.ptr -> !llvm.ptr
+    %239 = llvm.getelementptr %238[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %240 = llvm.load %239 : !llvm.ptr -> i256
+    llvm.store %239, %237 : !llvm.ptr, !llvm.ptr
+    %241 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %242 = llvm.load %241 : !llvm.ptr -> !llvm.ptr
+    %243 = llvm.getelementptr %242[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %244 = llvm.load %243 : !llvm.ptr -> i256
+    llvm.store %243, %241 : !llvm.ptr, !llvm.ptr
+    %245 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %246 = llvm.load %245 : !llvm.ptr -> !llvm.ptr
+    %247 = llvm.getelementptr %246[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %248 = llvm.load %247 : !llvm.ptr -> i256
+    llvm.store %247, %245 : !llvm.ptr, !llvm.ptr
+    %249 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %250 = llvm.load %249 : !llvm.ptr -> !llvm.ptr
+    %251 = llvm.getelementptr %250[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %252 = llvm.load %251 : !llvm.ptr -> i256
+    llvm.store %251, %249 : !llvm.ptr, !llvm.ptr
+    %253 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %254 = llvm.load %253 : !llvm.ptr -> i1
+    %c0_i256_35 = arith.constant 0 : i256
+    %255 = arith.cmpi ne, %236, %c0_i256_35 : i256
+    %256 = arith.andi %254, %255 : i1
+    %c86_i8_36 = arith.constant 86 : i8
+    cf.cond_br %256, ^bb1(%c86_i8_36 : i8), ^bb37
+  ^bb37:  // pred: ^bb36
+    %257 = arith.trunci %228 : i256 to i64
+    %258 = arith.trunci %240 : i256 to i64
+    %259 = arith.trunci %244 : i256 to i64
+    %260 = arith.trunci %248 : i256 to i64
+    %261 = arith.trunci %252 : i256 to i64
+    %262 = arith.addi %258, %259 : i64
+    %263 = arith.addi %260, %261 : i64
+    %264 = arith.maxui %262, %263 : i64
+    %c0_i64_37 = arith.constant 0 : i64
+    %265 = arith.cmpi slt, %264, %c0_i64_37 : i64
+    %c84_i8_38 = arith.constant 84 : i8
+    cf.cond_br %265, ^bb1(%c84_i8_38 : i8), ^bb38
+  ^bb38:  // pred: ^bb37
+    %c31_i64_39 = arith.constant 31 : i64
+    %c32_i64_40 = arith.constant 32 : i64
+    %266 = arith.addi %264, %c31_i64_39 : i64
+    %267 = arith.divui %266, %c32_i64_40 : i64
+    %268 = arith.muli %267, %c32_i64_40 : i64
+    %269 = call @dora_fn_extend_memory(%arg0, %268) : (!llvm.ptr, i64) -> !llvm.ptr
+    %270 = llvm.getelementptr %269[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %271 = llvm.load %270 : !llvm.ptr -> !llvm.ptr
+    %272 = llvm.getelementptr %269[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %273 = llvm.load %272 : !llvm.ptr -> i8
+    %c0_i8_41 = arith.constant 0 : i8
+    %274 = arith.cmpi ne, %273, %c0_i8_41 : i8
+    cf.cond_br %274, ^bb1(%273 : i8), ^bb39
+  ^bb39:  // pred: ^bb38
+    %275 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %271, %275 : !llvm.ptr, !llvm.ptr
+    %276 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %268, %276 : i64, !llvm.ptr
+    %277 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %278 = llvm.load %277 : !llvm.ptr -> i64
+    %c1_i256_42 = arith.constant 1 : i256
+    %279 = llvm.alloca %c1_i256_42 x i256 : (i256) -> !llvm.ptr
+    llvm.store %236, %279 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_43 = arith.constant 1 : i256
+    %280 = llvm.alloca %c1_i256_43 x i256 : (i256) -> !llvm.ptr
+    llvm.store %232, %280 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_44 = arith.constant 1 : i64
+    %281 = llvm.alloca %c1_i64_44 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_45 = arith.constant 0 : i8
+    %282 = call @dora_fn_call(%arg0, %257, %280, %279, %258, %259, %260, %261, %278, %281, %c0_i8_45) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %283 = llvm.getelementptr %282[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %284 = llvm.load %283 : !llvm.ptr -> i8
+    %285 = llvm.load %281 : !llvm.ptr -> i64
+    %286 = arith.extui %284 : i8 to i256
+    %287 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %288 = llvm.load %287 : !llvm.ptr -> !llvm.ptr
+    llvm.store %286, %288 : i256, !llvm.ptr
+    %289 = llvm.getelementptr %288[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %289, %287 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb40
+  ^bb40:  // pred: ^bb39
+    %c0_i64_46 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %270 = call @dora_fn_write_result(%arg0, %c0_i64_42, %c0_i64_42, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %290 = call @dora_fn_write_result(%arg0, %c0_i64_46, %c0_i64_46, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 6 preds: ^bb2, ^bb5, ^bb10, ^bb11, ^bb20, ^bb31
+  ^bb1(%10: i8):  // 10 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12, ^bb13, ^bb22, ^bb23, ^bb34, ^bb35
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,434 +120,438 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %252 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %253 = llvm.getelementptr %252[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %255 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %254, %255 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c15_i256 = arith.constant 15 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c15_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c17_i256 = arith.constant 17 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256_4 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c15_i256 = arith.constant 15 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %56 : i256 to i64
-    %62 = arith.trunci %60 : i256 to i64
-    %63 = arith.addi %61, %62 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_6 : i8), ^bb11
+    %c0_i256_4 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %66 = llvm.load %65 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %61 : i256 to i64
+    %67 = arith.trunci %65 : i256 to i64
+    %68 = arith.addi %66, %67 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_6 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %67 = arith.addi %63, %c31_i64_7 : i64
-    %68 = arith.divui %67, %c32_i64_8 : i64
-    %69 = arith.muli %68, %c32_i64_8 : i64
-    %70 = arith.cmpi ult, %66, %69 : i64
-    scf.if %70 {
-      %252 = func.call @dora_fn_extend_memory(%arg0, %69) : (!llvm.ptr, i64) -> !llvm.ptr
-      %253 = llvm.getelementptr %252[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
-      llvm.store %69, %65 : i64, !llvm.ptr
-      %255 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %254, %255 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %52, %71 {alignment = 1 : i64} : i256, !llvm.ptr
-    %72 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %73, %74 {alignment = 1 : i64} : i64, !llvm.ptr
-    %75 = call @dora_fn_create(%arg0, %62, %61, %71, %74) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = arith.addi %68, %c31_i64_7 : i64
+    %71 = arith.divui %70, %c32_i64_8 : i64
+    %72 = arith.muli %71, %c32_i64_8 : i64
+    %73 = call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
+    %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %73[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %c0_i8, %77 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %78, ^bb1(%c94_i8 : i8), ^bb12
-  ^bb12:  // pred: ^bb11
-    %79 = llvm.load %71 : !llvm.ptr -> i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %c0_i8_9 = arith.constant 0 : i8
+    %78 = arith.cmpi ne, %77, %c0_i8_9 : i8
+    cf.cond_br %78, ^bb1(%77 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_9 = arith.constant 0 : i256
-    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_9, %84 : i256, !llvm.ptr
-    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %75, %79 : !llvm.ptr, !llvm.ptr
+    %80 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %72, %80 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %82 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %83 = llvm.load %82 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %84 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %83, %84 {alignment = 1 : i64} : i64, !llvm.ptr
+    %85 = call @dora_fn_create(%arg0, %67, %66, %81, %84) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %86 = llvm.getelementptr %85[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %87 = llvm.load %86 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %88 = arith.cmpi ne, %c0_i8_10, %87 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %88, ^bb1(%c94_i8 : i8), ^bb14
   ^bb14:  // pred: ^bb13
-    %c0_i256_10 = arith.constant 0 : i256
-    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %87 : i256, !llvm.ptr
-    %88 = llvm.getelementptr %87[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %89 = llvm.load %81 : !llvm.ptr -> i256
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %91 : i256, !llvm.ptr
+    %92 = llvm.getelementptr %91[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
     %c0_i256_11 = arith.constant 0 : i256
-    %89 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %90 = llvm.load %89 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %90 : i256, !llvm.ptr
-    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %91, %89 : !llvm.ptr, !llvm.ptr
+    %93 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %94 = llvm.load %93 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %94 : i256, !llvm.ptr
+    %95 = llvm.getelementptr %94[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %95, %93 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb16:  // pred: ^bb15
     %c0_i256_12 = arith.constant 0 : i256
-    %92 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_12, %93 : i256, !llvm.ptr
-    %94 = llvm.getelementptr %93[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %94, %92 : !llvm.ptr, !llvm.ptr
+    %96 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %97 = llvm.load %96 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %97 : i256, !llvm.ptr
+    %98 = llvm.getelementptr %97[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %98, %96 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb17:  // pred: ^bb16
     %c0_i256_13 = arith.constant 0 : i256
-    %95 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %96 = llvm.load %95 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_13, %96 : i256, !llvm.ptr
-    %97 = llvm.getelementptr %96[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %97, %95 : !llvm.ptr, !llvm.ptr
+    %99 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %100 = llvm.load %99 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_13, %100 : i256, !llvm.ptr
+    %101 = llvm.getelementptr %100[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %101, %99 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %98 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %99 = llvm.load %98 : !llvm.ptr -> !llvm.ptr
-    %100 = llvm.getelementptr %99[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %101 = llvm.load %100 : !llvm.ptr -> i256
+    %c0_i256_14 = arith.constant 0 : i256
     %102 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %103 = llvm.load %102 : !llvm.ptr -> !llvm.ptr
-    llvm.store %101, %103 : i256, !llvm.ptr
+    llvm.store %c0_i256_14, %103 : i256, !llvm.ptr
     %104 = llvm.getelementptr %103[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %104, %102 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %c65535_i256 = arith.constant 65535 : i256
+    %c0_i256_15 = arith.constant 0 : i256
     %105 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %106 = llvm.load %105 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %106 : i256, !llvm.ptr
+    llvm.store %c0_i256_15, %106 : i256, !llvm.ptr
     %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %107, %105 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb20:  // pred: ^bb19
     %108 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %109 = llvm.load %108 : !llvm.ptr -> !llvm.ptr
-    %110 = llvm.getelementptr %109[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %110 = llvm.getelementptr %109[-5] : (!llvm.ptr) -> !llvm.ptr, i256
     %111 = llvm.load %110 : !llvm.ptr -> i256
-    llvm.store %110, %108 : !llvm.ptr, !llvm.ptr
     %112 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %113 = llvm.load %112 : !llvm.ptr -> !llvm.ptr
-    %114 = llvm.getelementptr %113[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %115 = llvm.load %114 : !llvm.ptr -> i256
+    llvm.store %111, %113 : i256, !llvm.ptr
+    %114 = llvm.getelementptr %113[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %114, %112 : !llvm.ptr, !llvm.ptr
-    %116 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %117 = llvm.load %116 : !llvm.ptr -> !llvm.ptr
-    %118 = llvm.getelementptr %117[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %119 = llvm.load %118 : !llvm.ptr -> i256
-    llvm.store %118, %116 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
-    %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %123 = llvm.load %122 : !llvm.ptr -> i256
-    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
-    %124 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-    %126 = llvm.getelementptr %125[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %127 = llvm.load %126 : !llvm.ptr -> i256
-    llvm.store %126, %124 : !llvm.ptr, !llvm.ptr
-    %128 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %129 = llvm.load %128 : !llvm.ptr -> !llvm.ptr
-    %130 = llvm.getelementptr %129[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %131 = llvm.load %130 : !llvm.ptr -> i256
-    llvm.store %130, %128 : !llvm.ptr, !llvm.ptr
-    %c0_i256_14 = arith.constant 0 : i256
-    %132 = arith.trunci %111 : i256 to i64
-    %133 = arith.trunci %119 : i256 to i64
-    %134 = arith.trunci %123 : i256 to i64
-    %135 = arith.trunci %127 : i256 to i64
-    %136 = arith.trunci %131 : i256 to i64
-    %137 = arith.addi %133, %134 : i64
-    %138 = arith.addi %135, %136 : i64
-    %139 = arith.maxui %137, %138 : i64
-    %c0_i64_15 = arith.constant 0 : i64
-    %140 = arith.cmpi slt, %139, %c0_i64_15 : i64
-    %c84_i8_16 = arith.constant 84 : i8
-    cf.cond_br %140, ^bb1(%c84_i8_16 : i8), ^bb21
+    cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %141 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %142 = llvm.load %141 : !llvm.ptr -> i64
-    %c31_i64_17 = arith.constant 31 : i64
-    %c32_i64_18 = arith.constant 32 : i64
-    %143 = arith.addi %139, %c31_i64_17 : i64
-    %144 = arith.divui %143, %c32_i64_18 : i64
-    %145 = arith.muli %144, %c32_i64_18 : i64
-    %146 = arith.cmpi ult, %142, %145 : i64
-    scf.if %146 {
-      %252 = func.call @dora_fn_extend_memory(%arg0, %145) : (!llvm.ptr, i64) -> !llvm.ptr
-      %253 = llvm.getelementptr %252[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
-      llvm.store %145, %141 : i64, !llvm.ptr
-      %255 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %254, %255 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %147 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> i64
-    %c1_i256_19 = arith.constant 1 : i256
-    %149 = llvm.alloca %c1_i256_19 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_14, %149 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_20 = arith.constant 1 : i256
-    %150 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
-    llvm.store %115, %150 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_21 = arith.constant 1 : i64
-    %151 = llvm.alloca %c1_i64_21 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_22 = arith.constant 0 : i8
-    %152 = call @dora_fn_call(%arg0, %132, %150, %149, %133, %134, %135, %136, %148, %151, %c0_i8_22) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %153 = llvm.getelementptr %152[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %154 = llvm.load %153 : !llvm.ptr -> i8
-    %155 = llvm.load %151 : !llvm.ptr -> i64
-    %156 = arith.extui %154 : i8 to i256
-    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
-    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
+    %c65535_i256 = arith.constant 65535 : i256
+    %115 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %116 = llvm.load %115 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %116 : i256, !llvm.ptr
+    %117 = llvm.getelementptr %116[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %117, %115 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb22:  // pred: ^bb21
-    %c1_i256_23 = arith.constant 1 : i256
-    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c1_i256_23, %161 : i256, !llvm.ptr
-    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %118 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %119 = llvm.load %118 : !llvm.ptr -> !llvm.ptr
+    %120 = llvm.getelementptr %119[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %121 = llvm.load %120 : !llvm.ptr -> i256
+    llvm.store %120, %118 : !llvm.ptr, !llvm.ptr
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    %124 = llvm.getelementptr %123[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %125 = llvm.load %124 : !llvm.ptr -> i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %130 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %131 = llvm.load %130 : !llvm.ptr -> !llvm.ptr
+    %132 = llvm.getelementptr %131[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %133 = llvm.load %132 : !llvm.ptr -> i256
+    llvm.store %132, %130 : !llvm.ptr, !llvm.ptr
+    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
+    %136 = llvm.getelementptr %135[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %137 = llvm.load %136 : !llvm.ptr -> i256
+    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    %140 = llvm.getelementptr %139[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %141 = llvm.load %140 : !llvm.ptr -> i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %c0_i256_16 = arith.constant 0 : i256
+    %142 = arith.trunci %121 : i256 to i64
+    %143 = arith.trunci %129 : i256 to i64
+    %144 = arith.trunci %133 : i256 to i64
+    %145 = arith.trunci %137 : i256 to i64
+    %146 = arith.trunci %141 : i256 to i64
+    %147 = arith.addi %143, %144 : i64
+    %148 = arith.addi %145, %146 : i64
+    %149 = arith.maxui %147, %148 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %150 = arith.cmpi slt, %149, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %150, ^bb1(%c84_i8_18 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_24 = arith.constant 0 : i256
-    %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_24, %164 : i256, !llvm.ptr
-    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb24
+    %c31_i64_19 = arith.constant 31 : i64
+    %c32_i64_20 = arith.constant 32 : i64
+    %151 = arith.addi %149, %c31_i64_19 : i64
+    %152 = arith.divui %151, %c32_i64_20 : i64
+    %153 = arith.muli %152, %c32_i64_20 : i64
+    %154 = call @dora_fn_extend_memory(%arg0, %153) : (!llvm.ptr, i64) -> !llvm.ptr
+    %155 = llvm.getelementptr %154[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %156 = llvm.load %155 : !llvm.ptr -> !llvm.ptr
+    %157 = llvm.getelementptr %154[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %158 = llvm.load %157 : !llvm.ptr -> i8
+    %c0_i8_21 = arith.constant 0 : i8
+    %159 = arith.cmpi ne, %158, %c0_i8_21 : i8
+    cf.cond_br %159, ^bb1(%158 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
-    %168 = llvm.getelementptr %167[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %169 = llvm.load %168 : !llvm.ptr -> i256
-    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
-    %170 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
-    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %173 = llvm.load %172 : !llvm.ptr -> i256
-    llvm.store %172, %170 : !llvm.ptr, !llvm.ptr
-    %c1_i256_25 = arith.constant 1 : i256
-    %174 = llvm.alloca %c1_i256_25 x i256 : (i256) -> !llvm.ptr
-    llvm.store %169, %174 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_26 = arith.constant 1 : i256
-    %175 = llvm.alloca %c1_i256_26 x i256 : (i256) -> !llvm.ptr
-    llvm.store %173, %175 {alignment = 1 : i64} : i256, !llvm.ptr
-    %176 = call @dora_fn_write_storage(%arg0, %174, %175) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %160 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %156, %160 : !llvm.ptr, !llvm.ptr
+    %161 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %153, %161 : i64, !llvm.ptr
+    %162 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %163 = llvm.load %162 : !llvm.ptr -> i64
+    %c1_i256_22 = arith.constant 1 : i256
+    %164 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_16, %164 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %165 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %125, %165 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_24 = arith.constant 1 : i64
+    %166 = llvm.alloca %c1_i64_24 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_25 = arith.constant 0 : i8
+    %167 = call @dora_fn_call(%arg0, %142, %165, %164, %143, %144, %145, %146, %163, %166, %c0_i8_25) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %168 = llvm.getelementptr %167[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %169 = llvm.load %168 : !llvm.ptr -> i8
+    %170 = llvm.load %166 : !llvm.ptr -> i64
+    %171 = arith.extui %169 : i8 to i256
+    %172 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %173 = llvm.load %172 : !llvm.ptr -> !llvm.ptr
+    llvm.store %171, %173 : i256, !llvm.ptr
+    %174 = llvm.getelementptr %173[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %174, %172 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %c0_i256_27 = arith.constant 0 : i256
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_27, %178 : i256, !llvm.ptr
-    %179 = llvm.getelementptr %178[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
+    %c1_i256_26 = arith.constant 1 : i256
+    %175 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_26, %176 : i256, !llvm.ptr
+    %177 = llvm.getelementptr %176[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %177, %175 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i256_28 = arith.constant 0 : i256
-    %180 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %181 = llvm.load %180 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_28, %181 : i256, !llvm.ptr
-    %182 = llvm.getelementptr %181[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %182, %180 : !llvm.ptr, !llvm.ptr
+    %c0_i256_27 = arith.constant 0 : i256
+    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_27, %179 : i256, !llvm.ptr
+    %180 = llvm.getelementptr %179[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb27:  // pred: ^bb26
-    %c32_i256 = arith.constant 32 : i256
-    %183 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %184 : i256, !llvm.ptr
-    %185 = llvm.getelementptr %184[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
+    %181 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %182 = llvm.load %181 : !llvm.ptr -> !llvm.ptr
+    %183 = llvm.getelementptr %182[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %184 = llvm.load %183 : !llvm.ptr -> i256
+    llvm.store %183, %181 : !llvm.ptr, !llvm.ptr
+    %185 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
+    %187 = llvm.getelementptr %186[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %188 = llvm.load %187 : !llvm.ptr -> i256
+    llvm.store %187, %185 : !llvm.ptr, !llvm.ptr
+    %c1_i256_28 = arith.constant 1 : i256
+    %189 = llvm.alloca %c1_i256_28 x i256 : (i256) -> !llvm.ptr
+    llvm.store %184, %189 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_29 = arith.constant 1 : i256
+    %190 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
+    llvm.store %188, %190 {alignment = 1 : i64} : i256, !llvm.ptr
+    %191 = call @dora_fn_write_storage(%arg0, %189, %190) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
     cf.br ^bb28
   ^bb28:  // pred: ^bb27
-    %c0_i256_29 = arith.constant 0 : i256
-    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_29, %187 : i256, !llvm.ptr
-    %188 = llvm.getelementptr %187[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
+    %c0_i256_30 = arith.constant 0 : i256
+    %192 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %193 = llvm.load %192 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_30, %193 : i256, !llvm.ptr
+    %194 = llvm.getelementptr %193[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %194, %192 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb29:  // pred: ^bb28
-    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
-    %191 = llvm.getelementptr %190[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    %193 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
-    llvm.store %192, %194 : i256, !llvm.ptr
-    %195 = llvm.getelementptr %194[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %195, %193 : !llvm.ptr, !llvm.ptr
+    %c0_i256_31 = arith.constant 0 : i256
+    %195 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %196 = llvm.load %195 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_31, %196 : i256, !llvm.ptr
+    %197 = llvm.getelementptr %196[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %197, %195 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb30:  // pred: ^bb29
-    %c65535_i256_30 = arith.constant 65535 : i256
-    %196 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %197 = llvm.load %196 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256_30, %197 : i256, !llvm.ptr
-    %198 = llvm.getelementptr %197[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %198, %196 : !llvm.ptr, !llvm.ptr
+    %c32_i256 = arith.constant 32 : i256
+    %198 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %199 = llvm.load %198 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %199 : i256, !llvm.ptr
+    %200 = llvm.getelementptr %199[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %200, %198 : !llvm.ptr, !llvm.ptr
     cf.br ^bb31
   ^bb31:  // pred: ^bb30
-    %199 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %200 = llvm.load %199 : !llvm.ptr -> !llvm.ptr
-    %201 = llvm.getelementptr %200[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %202 = llvm.load %201 : !llvm.ptr -> i256
-    llvm.store %201, %199 : !llvm.ptr, !llvm.ptr
-    %203 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %204 = llvm.load %203 : !llvm.ptr -> !llvm.ptr
-    %205 = llvm.getelementptr %204[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %206 = llvm.load %205 : !llvm.ptr -> i256
-    llvm.store %205, %203 : !llvm.ptr, !llvm.ptr
-    %207 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %208 = llvm.load %207 : !llvm.ptr -> !llvm.ptr
-    %209 = llvm.getelementptr %208[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %210 = llvm.load %209 : !llvm.ptr -> i256
-    llvm.store %209, %207 : !llvm.ptr, !llvm.ptr
-    %211 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-    %213 = llvm.getelementptr %212[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %214 = llvm.load %213 : !llvm.ptr -> i256
-    llvm.store %213, %211 : !llvm.ptr, !llvm.ptr
-    %215 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
-    %217 = llvm.getelementptr %216[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %218 = llvm.load %217 : !llvm.ptr -> i256
-    llvm.store %217, %215 : !llvm.ptr, !llvm.ptr
-    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
-    %221 = llvm.getelementptr %220[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %222 = llvm.load %221 : !llvm.ptr -> i256
-    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
-    %c0_i256_31 = arith.constant 0 : i256
-    %223 = arith.trunci %202 : i256 to i64
-    %224 = arith.trunci %210 : i256 to i64
-    %225 = arith.trunci %214 : i256 to i64
-    %226 = arith.trunci %218 : i256 to i64
-    %227 = arith.trunci %222 : i256 to i64
-    %228 = arith.addi %224, %225 : i64
-    %229 = arith.addi %226, %227 : i64
-    %230 = arith.maxui %228, %229 : i64
-    %c0_i64_32 = arith.constant 0 : i64
-    %231 = arith.cmpi slt, %230, %c0_i64_32 : i64
-    %c84_i8_33 = arith.constant 84 : i8
-    cf.cond_br %231, ^bb1(%c84_i8_33 : i8), ^bb32
+    %c0_i256_32 = arith.constant 0 : i256
+    %201 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %202 = llvm.load %201 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_32, %202 : i256, !llvm.ptr
+    %203 = llvm.getelementptr %202[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %203, %201 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb32
   ^bb32:  // pred: ^bb31
-    %232 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %233 = llvm.load %232 : !llvm.ptr -> i64
-    %c31_i64_34 = arith.constant 31 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %234 = arith.addi %230, %c31_i64_34 : i64
-    %235 = arith.divui %234, %c32_i64_35 : i64
-    %236 = arith.muli %235, %c32_i64_35 : i64
-    %237 = arith.cmpi ult, %233, %236 : i64
-    scf.if %237 {
-      %252 = func.call @dora_fn_extend_memory(%arg0, %236) : (!llvm.ptr, i64) -> !llvm.ptr
-      %253 = llvm.getelementptr %252[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
-      llvm.store %236, %232 : i64, !llvm.ptr
-      %255 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %254, %255 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %238 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %239 = llvm.load %238 : !llvm.ptr -> i64
-    %c1_i256_36 = arith.constant 1 : i256
-    %240 = llvm.alloca %c1_i256_36 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_31, %240 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_37 = arith.constant 1 : i256
-    %241 = llvm.alloca %c1_i256_37 x i256 : (i256) -> !llvm.ptr
-    llvm.store %206, %241 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_38 = arith.constant 1 : i64
-    %242 = llvm.alloca %c1_i64_38 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_39 = arith.constant 0 : i8
-    %243 = call @dora_fn_call(%arg0, %223, %241, %240, %224, %225, %226, %227, %239, %242, %c0_i8_39) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %244 = llvm.getelementptr %243[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %245 = llvm.load %244 : !llvm.ptr -> i8
-    %246 = llvm.load %242 : !llvm.ptr -> i64
-    %247 = arith.extui %245 : i8 to i256
-    %248 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %249 = llvm.load %248 : !llvm.ptr -> !llvm.ptr
-    llvm.store %247, %249 : i256, !llvm.ptr
-    %250 = llvm.getelementptr %249[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %250, %248 : !llvm.ptr, !llvm.ptr
+    %204 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %205 = llvm.load %204 : !llvm.ptr -> !llvm.ptr
+    %206 = llvm.getelementptr %205[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %207 = llvm.load %206 : !llvm.ptr -> i256
+    %208 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %209 = llvm.load %208 : !llvm.ptr -> !llvm.ptr
+    llvm.store %207, %209 : i256, !llvm.ptr
+    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %210, %208 : !llvm.ptr, !llvm.ptr
     cf.br ^bb33
   ^bb33:  // pred: ^bb32
-    %c0_i64_40 = arith.constant 0 : i64
+    %c65535_i256_33 = arith.constant 65535 : i256
+    %211 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_33, %212 : i256, !llvm.ptr
+    %213 = llvm.getelementptr %212[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %213, %211 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb34
+  ^bb34:  // pred: ^bb33
+    %214 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %215 = llvm.load %214 : !llvm.ptr -> !llvm.ptr
+    %216 = llvm.getelementptr %215[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %217 = llvm.load %216 : !llvm.ptr -> i256
+    llvm.store %216, %214 : !llvm.ptr, !llvm.ptr
+    %218 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %219 = llvm.load %218 : !llvm.ptr -> !llvm.ptr
+    %220 = llvm.getelementptr %219[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %221 = llvm.load %220 : !llvm.ptr -> i256
+    llvm.store %220, %218 : !llvm.ptr, !llvm.ptr
+    %222 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %223 = llvm.load %222 : !llvm.ptr -> !llvm.ptr
+    %224 = llvm.getelementptr %223[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %225 = llvm.load %224 : !llvm.ptr -> i256
+    llvm.store %224, %222 : !llvm.ptr, !llvm.ptr
+    %226 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %227 = llvm.load %226 : !llvm.ptr -> !llvm.ptr
+    %228 = llvm.getelementptr %227[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %229 = llvm.load %228 : !llvm.ptr -> i256
+    llvm.store %228, %226 : !llvm.ptr, !llvm.ptr
+    %230 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %231 = llvm.load %230 : !llvm.ptr -> !llvm.ptr
+    %232 = llvm.getelementptr %231[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %233 = llvm.load %232 : !llvm.ptr -> i256
+    llvm.store %232, %230 : !llvm.ptr, !llvm.ptr
+    %234 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %235 = llvm.load %234 : !llvm.ptr -> !llvm.ptr
+    %236 = llvm.getelementptr %235[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %237 = llvm.load %236 : !llvm.ptr -> i256
+    llvm.store %236, %234 : !llvm.ptr, !llvm.ptr
+    %c0_i256_34 = arith.constant 0 : i256
+    %238 = arith.trunci %217 : i256 to i64
+    %239 = arith.trunci %225 : i256 to i64
+    %240 = arith.trunci %229 : i256 to i64
+    %241 = arith.trunci %233 : i256 to i64
+    %242 = arith.trunci %237 : i256 to i64
+    %243 = arith.addi %239, %240 : i64
+    %244 = arith.addi %241, %242 : i64
+    %245 = arith.maxui %243, %244 : i64
+    %c0_i64_35 = arith.constant 0 : i64
+    %246 = arith.cmpi slt, %245, %c0_i64_35 : i64
+    %c84_i8_36 = arith.constant 84 : i8
+    cf.cond_br %246, ^bb1(%c84_i8_36 : i8), ^bb35
+  ^bb35:  // pred: ^bb34
+    %c31_i64_37 = arith.constant 31 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %247 = arith.addi %245, %c31_i64_37 : i64
+    %248 = arith.divui %247, %c32_i64_38 : i64
+    %249 = arith.muli %248, %c32_i64_38 : i64
+    %250 = call @dora_fn_extend_memory(%arg0, %249) : (!llvm.ptr, i64) -> !llvm.ptr
+    %251 = llvm.getelementptr %250[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %252 = llvm.load %251 : !llvm.ptr -> !llvm.ptr
+    %253 = llvm.getelementptr %250[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %254 = llvm.load %253 : !llvm.ptr -> i8
+    %c0_i8_39 = arith.constant 0 : i8
+    %255 = arith.cmpi ne, %254, %c0_i8_39 : i8
+    cf.cond_br %255, ^bb1(%254 : i8), ^bb36
+  ^bb36:  // pred: ^bb35
+    %256 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %252, %256 : !llvm.ptr, !llvm.ptr
+    %257 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %249, %257 : i64, !llvm.ptr
+    %258 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %259 = llvm.load %258 : !llvm.ptr -> i64
+    %c1_i256_40 = arith.constant 1 : i256
+    %260 = llvm.alloca %c1_i256_40 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_34, %260 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_41 = arith.constant 1 : i256
+    %261 = llvm.alloca %c1_i256_41 x i256 : (i256) -> !llvm.ptr
+    llvm.store %221, %261 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_42 = arith.constant 1 : i64
+    %262 = llvm.alloca %c1_i64_42 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_43 = arith.constant 0 : i8
+    %263 = call @dora_fn_call(%arg0, %238, %261, %260, %239, %240, %241, %242, %259, %262, %c0_i8_43) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %264 = llvm.getelementptr %263[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %265 = llvm.load %264 : !llvm.ptr -> i8
+    %266 = llvm.load %262 : !llvm.ptr -> i64
+    %267 = arith.extui %265 : i8 to i256
+    %268 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %269 = llvm.load %268 : !llvm.ptr -> !llvm.ptr
+    llvm.store %267, %269 : i256, !llvm.ptr
+    %270 = llvm.getelementptr %269[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %270, %268 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb37
+  ^bb37:  // pred: ^bb36
+    %c0_i64_44 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %251 = call @dora_fn_write_result(%arg0, %c0_i64_40, %c0_i64_40, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %271 = call @dora_fn_write_result(%arg0, %c0_i64_44, %c0_i64_44, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 8 preds: ^bb2, ^bb5, ^bb9, ^bb14, ^bb15, ^bb19, ^bb23, ^bb29
+  ^bb1(%10: i8):  // 14 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11, ^bb16, ^bb17, ^bb18, ^bb22, ^bb23, ^bb27, ^bb28, ^bb34, ^bb35
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,382 +120,388 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %210 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %211 = llvm.getelementptr %210[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %213 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %212, %213 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c170141183460469231731687303715884105727_i256_4 = arith.constant 170141183460469231731687303715884105727 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c170141183460469231731687303715884105727_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c32_i256 = arith.constant 32 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c170141183460469231731687303715884105727_i256_4 = arith.constant 170141183460469231731687303715884105727 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c170141183460469231731687303715884105727_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %c32_i64_5 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c32_i64_5 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %56 = arith.cmpi slt, %55, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %56, ^bb1(%c84_i8_7 : i8), ^bb10
+    %c32_i256 = arith.constant 32 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %60 = arith.addi %59, %c32_i64_5 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_7 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %59 = arith.addi %55, %c31_i64_8 : i64
-    %60 = arith.divui %59, %c32_i64_9 : i64
-    %61 = arith.muli %60, %c32_i64_9 : i64
-    %62 = arith.cmpi ult, %58, %61 : i64
-    scf.if %62 {
-      %210 = func.call @dora_fn_extend_memory(%arg0, %61) : (!llvm.ptr, i64) -> !llvm.ptr
-      %211 = llvm.getelementptr %210[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-      llvm.store %61, %57 : i64, !llvm.ptr
-      %213 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %212, %213 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> !llvm.ptr
-    %65 = llvm.getelementptr %64[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %66 = llvm.intr.bswap(%53)  : (i256) -> i256
-    llvm.store %66, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c41_i256 = arith.constant 41 : i256
-    %67 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c41_i256, %68 : i256, !llvm.ptr
-    %69 = llvm.getelementptr %68[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %69, %67 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb12
+    %62 = arith.addi %60, %c31_i64_8 : i64
+    %63 = arith.divui %62, %c32_i64_9 : i64
+    %64 = arith.muli %63, %c32_i64_9 : i64
+    %65 = call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
+    %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_10 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i256_10 = arith.constant 0 : i256
-    %70 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %71 : i256, !llvm.ptr
-    %72 = llvm.getelementptr %71[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %72, %70 : !llvm.ptr, !llvm.ptr
+    %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %67, %71 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %64, %72 : i64, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
+    %75 = llvm.getelementptr %74[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %76 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %76, %75 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_11 = arith.constant 0 : i256
-    %73 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %74 : i256, !llvm.ptr
-    %75 = llvm.getelementptr %74[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
+    %c41_i256 = arith.constant 41 : i256
+    %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c41_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %76 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %77 = llvm.load %76 : !llvm.ptr -> !llvm.ptr
-    %78 = llvm.getelementptr %77[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %79 = llvm.load %78 : !llvm.ptr -> i256
-    llvm.store %78, %76 : !llvm.ptr, !llvm.ptr
+    %c0_i256_11 = arith.constant 0 : i256
     %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    %82 = llvm.getelementptr %81[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %83 = llvm.load %82 : !llvm.ptr -> i256
+    llvm.store %c0_i256_11, %81 : i256, !llvm.ptr
+    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    %84 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> !llvm.ptr
-    %86 = llvm.getelementptr %85[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %87 = llvm.load %86 : !llvm.ptr -> i256
-    llvm.store %86, %84 : !llvm.ptr, !llvm.ptr
-    %88 = arith.trunci %83 : i256 to i64
-    %89 = arith.trunci %87 : i256 to i64
-    %90 = arith.addi %88, %89 : i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %91 = arith.cmpi slt, %90, %c0_i64_12 : i64
-    %c84_i8_13 = arith.constant 84 : i8
-    cf.cond_br %91, ^bb1(%c84_i8_13 : i8), ^bb15
+    cf.br ^bb15
   ^bb15:  // pred: ^bb14
-    %92 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> i64
-    %c31_i64_14 = arith.constant 31 : i64
-    %c32_i64_15 = arith.constant 32 : i64
-    %94 = arith.addi %90, %c31_i64_14 : i64
-    %95 = arith.divui %94, %c32_i64_15 : i64
-    %96 = arith.muli %95, %c32_i64_15 : i64
-    %97 = arith.cmpi ult, %93, %96 : i64
-    scf.if %97 {
-      %210 = func.call @dora_fn_extend_memory(%arg0, %96) : (!llvm.ptr, i64) -> !llvm.ptr
-      %211 = llvm.getelementptr %210[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-      llvm.store %96, %92 : i64, !llvm.ptr
-      %213 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %212, %213 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %98 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %79, %98 {alignment = 1 : i64} : i256, !llvm.ptr
-    %99 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %100 = llvm.load %99 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %101 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %100, %101 {alignment = 1 : i64} : i64, !llvm.ptr
-    %102 = call @dora_fn_create(%arg0, %89, %88, %98, %101) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %c0_i8, %104 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %105, ^bb1(%c94_i8 : i8), ^bb16
+    %c0_i256_12 = arith.constant 0 : i256
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %84 : i256, !llvm.ptr
+    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb16
   ^bb16:  // pred: ^bb15
-    %106 = llvm.load %98 : !llvm.ptr -> i256
-    %107 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %108 = llvm.load %107 : !llvm.ptr -> !llvm.ptr
-    llvm.store %106, %108 : i256, !llvm.ptr
-    %109 = llvm.getelementptr %108[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %109, %107 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb17
+    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
+    %88 = llvm.getelementptr %87[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %89 = llvm.load %88 : !llvm.ptr -> i256
+    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    %92 = llvm.getelementptr %91[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %93 = llvm.load %92 : !llvm.ptr -> i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
+    %94 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %95 = llvm.load %94 : !llvm.ptr -> !llvm.ptr
+    %96 = llvm.getelementptr %95[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %97 = llvm.load %96 : !llvm.ptr -> i256
+    llvm.store %96, %94 : !llvm.ptr, !llvm.ptr
+    %98 = arith.trunci %93 : i256 to i64
+    %99 = arith.trunci %97 : i256 to i64
+    %100 = arith.addi %98, %99 : i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %101 = arith.cmpi slt, %100, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %101, ^bb1(%c84_i8_14 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i256_16 = arith.constant 0 : i256
-    %110 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_16, %111 : i256, !llvm.ptr
-    %112 = llvm.getelementptr %111[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %112, %110 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb18
+    %c31_i64_15 = arith.constant 31 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %102 = arith.addi %100, %c31_i64_15 : i64
+    %103 = arith.divui %102, %c32_i64_16 : i64
+    %104 = arith.muli %103, %c32_i64_16 : i64
+    %105 = call @dora_fn_extend_memory(%arg0, %104) : (!llvm.ptr, i64) -> !llvm.ptr
+    %106 = llvm.getelementptr %105[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %107 = llvm.load %106 : !llvm.ptr -> !llvm.ptr
+    %108 = llvm.getelementptr %105[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %109 = llvm.load %108 : !llvm.ptr -> i8
+    %c0_i8_17 = arith.constant 0 : i8
+    %110 = arith.cmpi ne, %109, %c0_i8_17 : i8
+    cf.cond_br %110, ^bb1(%109 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i256_17 = arith.constant 0 : i256
-    %113 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %114 = llvm.load %113 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_17, %114 : i256, !llvm.ptr
-    %115 = llvm.getelementptr %114[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %115, %113 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb19
+    %111 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %107, %111 : !llvm.ptr, !llvm.ptr
+    %112 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %104, %112 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %113 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %89, %113 {alignment = 1 : i64} : i256, !llvm.ptr
+    %114 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %116 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %115, %116 {alignment = 1 : i64} : i64, !llvm.ptr
+    %117 = call @dora_fn_create(%arg0, %99, %98, %113, %116) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %118 = llvm.getelementptr %117[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %119 = llvm.load %118 : !llvm.ptr -> i8
+    %c0_i8_18 = arith.constant 0 : i8
+    %120 = arith.cmpi ne, %c0_i8_18, %119 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %120, ^bb1(%c94_i8 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %116 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %117 = llvm.load %116 : !llvm.ptr -> !llvm.ptr
-    %118 = llvm.getelementptr %117[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %119 = llvm.load %118 : !llvm.ptr -> i256
-    llvm.store %118, %116 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
-    %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %123 = llvm.load %122 : !llvm.ptr -> i256
-    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
-    %124 = arith.trunci %119 : i256 to i64
-    %c32_i64_18 = arith.constant 32 : i64
-    %125 = arith.addi %124, %c32_i64_18 : i64
-    %c0_i64_19 = arith.constant 0 : i64
-    %126 = arith.cmpi slt, %125, %c0_i64_19 : i64
-    %c84_i8_20 = arith.constant 84 : i8
-    cf.cond_br %126, ^bb1(%c84_i8_20 : i8), ^bb20
+    %121 = llvm.load %113 : !llvm.ptr -> i256
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    llvm.store %121, %123 : i256, !llvm.ptr
+    %124 = llvm.getelementptr %123[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb20
   ^bb20:  // pred: ^bb19
-    %127 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %128 = llvm.load %127 : !llvm.ptr -> i64
-    %c31_i64_21 = arith.constant 31 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %129 = arith.addi %125, %c31_i64_21 : i64
-    %130 = arith.divui %129, %c32_i64_22 : i64
-    %131 = arith.muli %130, %c32_i64_22 : i64
-    %132 = arith.cmpi ult, %128, %131 : i64
-    scf.if %132 {
-      %210 = func.call @dora_fn_extend_memory(%arg0, %131) : (!llvm.ptr, i64) -> !llvm.ptr
-      %211 = llvm.getelementptr %210[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-      llvm.store %131, %127 : i64, !llvm.ptr
-      %213 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %212, %213 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %133 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %134 = llvm.load %133 : !llvm.ptr -> !llvm.ptr
-    %135 = llvm.getelementptr %134[%124] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %136 = llvm.intr.bswap(%123)  : (i256) -> i256
-    llvm.store %136, %135 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i256_19 = arith.constant 0 : i256
+    %125 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %126 = llvm.load %125 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_19, %126 : i256, !llvm.ptr
+    %127 = llvm.getelementptr %126[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %127, %125 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_23 = arith.constant 0 : i256
-    %137 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %138 = llvm.load %137 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_23, %138 : i256, !llvm.ptr
-    %139 = llvm.getelementptr %138[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %139, %137 : !llvm.ptr, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %128 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %129 = llvm.load %128 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %129 : i256, !llvm.ptr
+    %130 = llvm.getelementptr %129[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %130, %128 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb22:  // pred: ^bb21
-    %c32_i256_24 = arith.constant 32 : i256
-    %140 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %141 = llvm.load %140 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_24, %141 : i256, !llvm.ptr
-    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %142, %140 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %131 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %132 = llvm.load %131 : !llvm.ptr -> !llvm.ptr
+    %133 = llvm.getelementptr %132[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %134 = llvm.load %133 : !llvm.ptr -> i256
+    llvm.store %133, %131 : !llvm.ptr, !llvm.ptr
+    %135 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %136 = llvm.load %135 : !llvm.ptr -> !llvm.ptr
+    %137 = llvm.getelementptr %136[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %138 = llvm.load %137 : !llvm.ptr -> i256
+    llvm.store %137, %135 : !llvm.ptr, !llvm.ptr
+    %139 = arith.trunci %134 : i256 to i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %140 = arith.addi %139, %c32_i64_21 : i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %141 = arith.cmpi slt, %140, %c0_i64_22 : i64
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %141, ^bb1(%c84_i8_23 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %143 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %144 = llvm.load %143 : !llvm.ptr -> !llvm.ptr
-    %145 = llvm.getelementptr %144[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %146 = llvm.load %145 : !llvm.ptr -> i256
-    llvm.store %145, %143 : !llvm.ptr, !llvm.ptr
-    %147 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> !llvm.ptr
-    %149 = llvm.getelementptr %148[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %150 = llvm.load %149 : !llvm.ptr -> i256
-    llvm.store %149, %147 : !llvm.ptr, !llvm.ptr
-    %151 = arith.trunci %146 : i256 to i64
+    %c31_i64_24 = arith.constant 31 : i64
     %c32_i64_25 = arith.constant 32 : i64
-    %152 = arith.addi %151, %c32_i64_25 : i64
-    %c0_i64_26 = arith.constant 0 : i64
-    %153 = arith.cmpi slt, %152, %c0_i64_26 : i64
-    %c84_i8_27 = arith.constant 84 : i8
-    cf.cond_br %153, ^bb1(%c84_i8_27 : i8), ^bb24
+    %142 = arith.addi %140, %c31_i64_24 : i64
+    %143 = arith.divui %142, %c32_i64_25 : i64
+    %144 = arith.muli %143, %c32_i64_25 : i64
+    %145 = call @dora_fn_extend_memory(%arg0, %144) : (!llvm.ptr, i64) -> !llvm.ptr
+    %146 = llvm.getelementptr %145[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %147 = llvm.load %146 : !llvm.ptr -> !llvm.ptr
+    %148 = llvm.getelementptr %145[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %149 = llvm.load %148 : !llvm.ptr -> i8
+    %c0_i8_26 = arith.constant 0 : i8
+    %150 = arith.cmpi ne, %149, %c0_i8_26 : i8
+    cf.cond_br %150, ^bb1(%149 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %154 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %155 = llvm.load %154 : !llvm.ptr -> i64
-    %c31_i64_28 = arith.constant 31 : i64
-    %c32_i64_29 = arith.constant 32 : i64
-    %156 = arith.addi %152, %c31_i64_28 : i64
-    %157 = arith.divui %156, %c32_i64_29 : i64
-    %158 = arith.muli %157, %c32_i64_29 : i64
-    %159 = arith.cmpi ult, %155, %158 : i64
-    scf.if %159 {
-      %210 = func.call @dora_fn_extend_memory(%arg0, %158) : (!llvm.ptr, i64) -> !llvm.ptr
-      %211 = llvm.getelementptr %210[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-      llvm.store %158, %154 : i64, !llvm.ptr
-      %213 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %212, %213 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %160 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
-    %162 = llvm.getelementptr %161[%151] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %163 = llvm.intr.bswap(%150)  : (i256) -> i256
-    llvm.store %163, %162 {alignment = 1 : i64} : i256, !llvm.ptr
+    %151 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %147, %151 : !llvm.ptr, !llvm.ptr
+    %152 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %144, %152 : i64, !llvm.ptr
+    %153 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
+    %155 = llvm.getelementptr %154[%139] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %156 = llvm.intr.bswap(%138)  : (i256) -> i256
+    llvm.store %156, %155 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %c32_i256_30 = arith.constant 32 : i256
-    %164 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %165 = llvm.load %164 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_30, %165 : i256, !llvm.ptr
-    %166 = llvm.getelementptr %165[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %166, %164 : !llvm.ptr, !llvm.ptr
+    %c0_i256_27 = arith.constant 0 : i256
+    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_27, %158 : i256, !llvm.ptr
+    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i256_31 = arith.constant 0 : i256
-    %167 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %168 = llvm.load %167 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_31, %168 : i256, !llvm.ptr
-    %169 = llvm.getelementptr %168[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %169, %167 : !llvm.ptr, !llvm.ptr
+    %c32_i256_28 = arith.constant 32 : i256
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_28, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb27:  // pred: ^bb26
-    %c0_i256_32 = arith.constant 0 : i256
-    %170 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_32, %171 : i256, !llvm.ptr
-    %172 = llvm.getelementptr %171[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %172, %170 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb28
+    %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
+    %165 = llvm.getelementptr %164[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %166 = llvm.load %165 : !llvm.ptr -> i256
+    llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
+    %167 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %168 = llvm.load %167 : !llvm.ptr -> !llvm.ptr
+    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %170 = llvm.load %169 : !llvm.ptr -> i256
+    llvm.store %169, %167 : !llvm.ptr, !llvm.ptr
+    %171 = arith.trunci %166 : i256 to i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %172 = arith.addi %171, %c32_i64_29 : i64
+    %c0_i64_30 = arith.constant 0 : i64
+    %173 = arith.cmpi slt, %172, %c0_i64_30 : i64
+    %c84_i8_31 = arith.constant 84 : i8
+    cf.cond_br %173, ^bb1(%c84_i8_31 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
-    %175 = llvm.getelementptr %174[-4] : (!llvm.ptr) -> !llvm.ptr, i256
-    %176 = llvm.load %175 : !llvm.ptr -> i256
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    llvm.store %176, %178 : i256, !llvm.ptr
-    %179 = llvm.getelementptr %178[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb29
+    %c31_i64_32 = arith.constant 31 : i64
+    %c32_i64_33 = arith.constant 32 : i64
+    %174 = arith.addi %172, %c31_i64_32 : i64
+    %175 = arith.divui %174, %c32_i64_33 : i64
+    %176 = arith.muli %175, %c32_i64_33 : i64
+    %177 = call @dora_fn_extend_memory(%arg0, %176) : (!llvm.ptr, i64) -> !llvm.ptr
+    %178 = llvm.getelementptr %177[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    %180 = llvm.getelementptr %177[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %181 = llvm.load %180 : !llvm.ptr -> i8
+    %c0_i8_34 = arith.constant 0 : i8
+    %182 = arith.cmpi ne, %181, %c0_i8_34 : i8
+    cf.cond_br %182, ^bb1(%181 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %180 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %181 = llvm.load %180 : !llvm.ptr -> !llvm.ptr
-    %182 = llvm.getelementptr %181[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %183 = llvm.load %182 : !llvm.ptr -> i256
-    llvm.store %182, %180 : !llvm.ptr, !llvm.ptr
-    %184 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %185 = llvm.load %184 : !llvm.ptr -> !llvm.ptr
-    %186 = llvm.getelementptr %185[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %187 = llvm.load %186 : !llvm.ptr -> i256
-    llvm.store %186, %184 : !llvm.ptr, !llvm.ptr
-    %188 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %189 = llvm.load %188 : !llvm.ptr -> !llvm.ptr
-    %190 = llvm.getelementptr %189[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %191 = llvm.load %190 : !llvm.ptr -> i256
-    llvm.store %190, %188 : !llvm.ptr, !llvm.ptr
-    %192 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %193 = llvm.load %192 : !llvm.ptr -> !llvm.ptr
-    %194 = llvm.getelementptr %193[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %195 = llvm.load %194 : !llvm.ptr -> i256
-    llvm.store %194, %192 : !llvm.ptr, !llvm.ptr
-    %196 = arith.trunci %191 : i256 to i64
-    %197 = arith.trunci %195 : i256 to i64
-    %198 = arith.trunci %187 : i256 to i64
-    %c1_i256_33 = arith.constant 1 : i256
-    %199 = llvm.alloca %c1_i256_33 x i256 : (i256) -> !llvm.ptr
-    llvm.store %183, %199 {alignment = 1 : i64} : i256, !llvm.ptr
-    %200 = arith.addi %198, %197 : i64
-    %c0_i64_34 = arith.constant 0 : i64
-    %201 = arith.cmpi slt, %200, %c0_i64_34 : i64
-    %c84_i8_35 = arith.constant 84 : i8
-    cf.cond_br %201, ^bb1(%c84_i8_35 : i8), ^bb30
+    %183 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %179, %183 : !llvm.ptr, !llvm.ptr
+    %184 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %176, %184 : i64, !llvm.ptr
+    %185 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
+    %187 = llvm.getelementptr %186[%171] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %188 = llvm.intr.bswap(%170)  : (i256) -> i256
+    llvm.store %188, %187 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb30
   ^bb30:  // pred: ^bb29
-    %202 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %203 = llvm.load %202 : !llvm.ptr -> i64
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %204 = arith.addi %200, %c31_i64_36 : i64
-    %205 = arith.divui %204, %c32_i64_37 : i64
-    %206 = arith.muli %205, %c32_i64_37 : i64
-    %207 = arith.cmpi ult, %203, %206 : i64
-    scf.if %207 {
-      %210 = func.call @dora_fn_extend_memory(%arg0, %206) : (!llvm.ptr, i64) -> !llvm.ptr
-      %211 = llvm.getelementptr %210[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-      llvm.store %206, %202 : i64, !llvm.ptr
-      %213 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %212, %213 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %208 = call @dora_fn_copy_ext_code_to_memory(%arg0, %199, %196, %197, %198) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    %c32_i256_35 = arith.constant 32 : i256
+    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_35, %190 : i256, !llvm.ptr
+    %191 = llvm.getelementptr %190[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
     cf.br ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_38 = arith.constant 0 : i64
+    %c0_i256_36 = arith.constant 0 : i256
+    %192 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %193 = llvm.load %192 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_36, %193 : i256, !llvm.ptr
+    %194 = llvm.getelementptr %193[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %194, %192 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb32
+  ^bb32:  // pred: ^bb31
+    %c0_i256_37 = arith.constant 0 : i256
+    %195 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %196 = llvm.load %195 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_37, %196 : i256, !llvm.ptr
+    %197 = llvm.getelementptr %196[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %197, %195 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb33
+  ^bb33:  // pred: ^bb32
+    %198 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %199 = llvm.load %198 : !llvm.ptr -> !llvm.ptr
+    %200 = llvm.getelementptr %199[-4] : (!llvm.ptr) -> !llvm.ptr, i256
+    %201 = llvm.load %200 : !llvm.ptr -> i256
+    %202 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %203 = llvm.load %202 : !llvm.ptr -> !llvm.ptr
+    llvm.store %201, %203 : i256, !llvm.ptr
+    %204 = llvm.getelementptr %203[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %204, %202 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb34
+  ^bb34:  // pred: ^bb33
+    %205 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %206 = llvm.load %205 : !llvm.ptr -> !llvm.ptr
+    %207 = llvm.getelementptr %206[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %208 = llvm.load %207 : !llvm.ptr -> i256
+    llvm.store %207, %205 : !llvm.ptr, !llvm.ptr
+    %209 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %210 = llvm.load %209 : !llvm.ptr -> !llvm.ptr
+    %211 = llvm.getelementptr %210[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %212 = llvm.load %211 : !llvm.ptr -> i256
+    llvm.store %211, %209 : !llvm.ptr, !llvm.ptr
+    %213 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %214 = llvm.load %213 : !llvm.ptr -> !llvm.ptr
+    %215 = llvm.getelementptr %214[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %216 = llvm.load %215 : !llvm.ptr -> i256
+    llvm.store %215, %213 : !llvm.ptr, !llvm.ptr
+    %217 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %218 = llvm.load %217 : !llvm.ptr -> !llvm.ptr
+    %219 = llvm.getelementptr %218[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %220 = llvm.load %219 : !llvm.ptr -> i256
+    llvm.store %219, %217 : !llvm.ptr, !llvm.ptr
+    %221 = arith.trunci %216 : i256 to i64
+    %222 = arith.trunci %220 : i256 to i64
+    %223 = arith.trunci %212 : i256 to i64
+    %c1_i256_38 = arith.constant 1 : i256
+    %224 = llvm.alloca %c1_i256_38 x i256 : (i256) -> !llvm.ptr
+    llvm.store %208, %224 {alignment = 1 : i64} : i256, !llvm.ptr
+    %225 = arith.addi %223, %222 : i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %226 = arith.cmpi slt, %225, %c0_i64_39 : i64
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %226, ^bb1(%c84_i8_40 : i8), ^bb35
+  ^bb35:  // pred: ^bb34
+    %c31_i64_41 = arith.constant 31 : i64
+    %c32_i64_42 = arith.constant 32 : i64
+    %227 = arith.addi %225, %c31_i64_41 : i64
+    %228 = arith.divui %227, %c32_i64_42 : i64
+    %229 = arith.muli %228, %c32_i64_42 : i64
+    %230 = call @dora_fn_extend_memory(%arg0, %229) : (!llvm.ptr, i64) -> !llvm.ptr
+    %231 = llvm.getelementptr %230[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %232 = llvm.load %231 : !llvm.ptr -> !llvm.ptr
+    %233 = llvm.getelementptr %230[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %234 = llvm.load %233 : !llvm.ptr -> i8
+    %c0_i8_43 = arith.constant 0 : i8
+    %235 = arith.cmpi ne, %234, %c0_i8_43 : i8
+    cf.cond_br %235, ^bb1(%234 : i8), ^bb36
+  ^bb36:  // pred: ^bb35
+    %236 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %232, %236 : !llvm.ptr, !llvm.ptr
+    %237 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %229, %237 : i64, !llvm.ptr
+    %238 = call @dora_fn_copy_ext_code_to_memory(%arg0, %224, %221, %222, %223) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb37
+  ^bb37:  // pred: ^bb36
+    %c0_i64_44 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %209 = call @dora_fn_write_result(%arg0, %c0_i64_38, %c0_i64_38, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %239 = call @dora_fn_write_result(%arg0, %c0_i64_44, %c0_i64_44, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 4 preds: ^bb2, ^bb5, ^bb10, ^bb11
+  ^bb1(%10: i8):  // 6 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12, ^bb13
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,138 +120,140 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %94 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %95 = llvm.getelementptr %94[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %96 = llvm.load %95 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %97 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %96, %97 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c13_i256 = arith.constant 13 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c13_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i256_4 = arith.constant 0 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c13_i256 = arith.constant 13 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c13_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256_5 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_5, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c0_i256_4 = arith.constant 0 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %56 : i256 to i64
-    %62 = arith.trunci %60 : i256 to i64
-    %63 = arith.addi %61, %62 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_7 : i8), ^bb11
+    %c0_i256_5 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_5, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %66 = llvm.load %65 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %61 : i256 to i64
+    %67 = arith.trunci %65 : i256 to i64
+    %68 = arith.addi %66, %67 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_7 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %67 = arith.addi %63, %c31_i64_8 : i64
-    %68 = arith.divui %67, %c32_i64_9 : i64
-    %69 = arith.muli %68, %c32_i64_9 : i64
-    %70 = arith.cmpi ult, %66, %69 : i64
-    scf.if %70 {
-      %94 = func.call @dora_fn_extend_memory(%arg0, %69) : (!llvm.ptr, i64) -> !llvm.ptr
-      %95 = llvm.getelementptr %94[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %96 = llvm.load %95 : !llvm.ptr -> !llvm.ptr
-      llvm.store %69, %65 : i64, !llvm.ptr
-      %97 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %96, %97 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %52, %71 {alignment = 1 : i64} : i256, !llvm.ptr
-    %72 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %73, %74 {alignment = 1 : i64} : i64, !llvm.ptr
-    %75 = call @dora_fn_create(%arg0, %62, %61, %71, %74) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = arith.addi %68, %c31_i64_8 : i64
+    %71 = arith.divui %70, %c32_i64_9 : i64
+    %72 = arith.muli %71, %c32_i64_9 : i64
+    %73 = call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
+    %74 = llvm.getelementptr %73[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %73[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %c0_i8, %77 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %78, ^bb1(%c94_i8 : i8), ^bb12
-  ^bb12:  // pred: ^bb11
-    %79 = llvm.load %71 : !llvm.ptr -> i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
+    %c0_i8_10 = arith.constant 0 : i8
+    %78 = arith.cmpi ne, %77, %c0_i8_10 : i8
+    cf.cond_br %78, ^bb1(%77 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
-    %85 = llvm.getelementptr %84[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %86 = llvm.load %85 : !llvm.ptr -> i256
-    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
-    %c1_i256_10 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256_10 x i256 : (i256) -> !llvm.ptr
-    llvm.store %86, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = call @dora_fn_code_hash(%arg0, %87) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %89 = llvm.load %87 : !llvm.ptr -> i256
+    %79 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %75, %79 : !llvm.ptr, !llvm.ptr
+    %80 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %72, %80 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %82 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %83 = llvm.load %82 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %84 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %83, %84 {alignment = 1 : i64} : i64, !llvm.ptr
+    %85 = call @dora_fn_create(%arg0, %67, %66, %81, %84) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %86 = llvm.getelementptr %85[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %87 = llvm.load %86 : !llvm.ptr -> i8
+    %c0_i8_11 = arith.constant 0 : i8
+    %88 = arith.cmpi ne, %c0_i8_11, %87 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %88, ^bb1(%c94_i8 : i8), ^bb14
+  ^bb14:  // pred: ^bb13
+    %89 = llvm.load %81 : !llvm.ptr -> i256
     %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
     llvm.store %89, %91 : i256, !llvm.ptr
     %92 = llvm.getelementptr %91[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
-  ^bb14:  // pred: ^bb13
-    %c0_i64_11 = arith.constant 0 : i64
+    cf.br ^bb15
+  ^bb15:  // pred: ^bb14
+    %93 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %94 = llvm.load %93 : !llvm.ptr -> !llvm.ptr
+    %95 = llvm.getelementptr %94[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %96 = llvm.load %95 : !llvm.ptr -> i256
+    llvm.store %95, %93 : !llvm.ptr, !llvm.ptr
+    %c1_i256_12 = arith.constant 1 : i256
+    %97 = llvm.alloca %c1_i256_12 x i256 : (i256) -> !llvm.ptr
+    llvm.store %96, %97 {alignment = 1 : i64} : i256, !llvm.ptr
+    %98 = call @dora_fn_code_hash(%arg0, %97) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %99 = llvm.load %97 : !llvm.ptr -> i256
+    %100 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %101 = llvm.load %100 : !llvm.ptr -> !llvm.ptr
+    llvm.store %99, %101 : i256, !llvm.ptr
+    %102 = llvm.getelementptr %101[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %102, %100 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb16
+  ^bb16:  // pred: ^bb15
+    %c0_i64_13 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %93 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %103 = call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb9, ^bb14, ^bb15
+  ^bb1(%10: i8):  // 8 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11, ^bb16, ^bb17, ^bb18
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,198 +120,201 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %123 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %124 = llvm.getelementptr %123[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %126 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %125, %126 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c170141183460469231731687303715884105727_i256_4 = arith.constant 170141183460469231731687303715884105727 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c170141183460469231731687303715884105727_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c32_i256 = arith.constant 32 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c170141183460469231731687303715884105727_i256_4 = arith.constant 170141183460469231731687303715884105727 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c170141183460469231731687303715884105727_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %c32_i64_5 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c32_i64_5 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %56 = arith.cmpi slt, %55, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %56, ^bb1(%c84_i8_7 : i8), ^bb10
+    %c32_i256 = arith.constant 32 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %60 = arith.addi %59, %c32_i64_5 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_7 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %59 = arith.addi %55, %c31_i64_8 : i64
-    %60 = arith.divui %59, %c32_i64_9 : i64
-    %61 = arith.muli %60, %c32_i64_9 : i64
-    %62 = arith.cmpi ult, %58, %61 : i64
-    scf.if %62 {
-      %123 = func.call @dora_fn_extend_memory(%arg0, %61) : (!llvm.ptr, i64) -> !llvm.ptr
-      %124 = llvm.getelementptr %123[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-      llvm.store %61, %57 : i64, !llvm.ptr
-      %126 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %125, %126 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> !llvm.ptr
-    %65 = llvm.getelementptr %64[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %66 = llvm.intr.bswap(%53)  : (i256) -> i256
-    llvm.store %66, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c41_i256 = arith.constant 41 : i256
-    %67 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c41_i256, %68 : i256, !llvm.ptr
-    %69 = llvm.getelementptr %68[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %69, %67 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb12
+    %62 = arith.addi %60, %c31_i64_8 : i64
+    %63 = arith.divui %62, %c32_i64_9 : i64
+    %64 = arith.muli %63, %c32_i64_9 : i64
+    %65 = call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
+    %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_10 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i256_10 = arith.constant 0 : i256
-    %70 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_10, %71 : i256, !llvm.ptr
-    %72 = llvm.getelementptr %71[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %72, %70 : !llvm.ptr, !llvm.ptr
+    %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %67, %71 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %64, %72 : i64, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
+    %75 = llvm.getelementptr %74[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %76 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %76, %75 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i256_11 = arith.constant 0 : i256
-    %73 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_11, %74 : i256, !llvm.ptr
-    %75 = llvm.getelementptr %74[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
+    %c41_i256 = arith.constant 41 : i256
+    %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c41_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %76 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %77 = llvm.load %76 : !llvm.ptr -> !llvm.ptr
-    %78 = llvm.getelementptr %77[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %79 = llvm.load %78 : !llvm.ptr -> i256
-    llvm.store %78, %76 : !llvm.ptr, !llvm.ptr
+    %c0_i256_11 = arith.constant 0 : i256
     %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    %82 = llvm.getelementptr %81[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %83 = llvm.load %82 : !llvm.ptr -> i256
+    llvm.store %c0_i256_11, %81 : i256, !llvm.ptr
+    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    %84 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> !llvm.ptr
-    %86 = llvm.getelementptr %85[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %87 = llvm.load %86 : !llvm.ptr -> i256
-    llvm.store %86, %84 : !llvm.ptr, !llvm.ptr
-    %88 = arith.trunci %83 : i256 to i64
-    %89 = arith.trunci %87 : i256 to i64
-    %90 = arith.addi %88, %89 : i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %91 = arith.cmpi slt, %90, %c0_i64_12 : i64
-    %c84_i8_13 = arith.constant 84 : i8
-    cf.cond_br %91, ^bb1(%c84_i8_13 : i8), ^bb15
+    cf.br ^bb15
   ^bb15:  // pred: ^bb14
-    %92 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> i64
-    %c31_i64_14 = arith.constant 31 : i64
-    %c32_i64_15 = arith.constant 32 : i64
-    %94 = arith.addi %90, %c31_i64_14 : i64
-    %95 = arith.divui %94, %c32_i64_15 : i64
-    %96 = arith.muli %95, %c32_i64_15 : i64
-    %97 = arith.cmpi ult, %93, %96 : i64
-    scf.if %97 {
-      %123 = func.call @dora_fn_extend_memory(%arg0, %96) : (!llvm.ptr, i64) -> !llvm.ptr
-      %124 = llvm.getelementptr %123[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %125 = llvm.load %124 : !llvm.ptr -> !llvm.ptr
-      llvm.store %96, %92 : i64, !llvm.ptr
-      %126 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %125, %126 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %98 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %79, %98 {alignment = 1 : i64} : i256, !llvm.ptr
-    %99 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %100 = llvm.load %99 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %101 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %100, %101 {alignment = 1 : i64} : i64, !llvm.ptr
-    %102 = call @dora_fn_create(%arg0, %89, %88, %98, %101) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %c0_i8, %104 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %105, ^bb1(%c94_i8 : i8), ^bb16
+    %c0_i256_12 = arith.constant 0 : i256
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_12, %84 : i256, !llvm.ptr
+    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb16
   ^bb16:  // pred: ^bb15
-    %106 = llvm.load %98 : !llvm.ptr -> i256
-    %107 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %108 = llvm.load %107 : !llvm.ptr -> !llvm.ptr
-    llvm.store %106, %108 : i256, !llvm.ptr
-    %109 = llvm.getelementptr %108[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %109, %107 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb17
+    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
+    %88 = llvm.getelementptr %87[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %89 = llvm.load %88 : !llvm.ptr -> i256
+    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
+    %90 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
+    %92 = llvm.getelementptr %91[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %93 = llvm.load %92 : !llvm.ptr -> i256
+    llvm.store %92, %90 : !llvm.ptr, !llvm.ptr
+    %94 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %95 = llvm.load %94 : !llvm.ptr -> !llvm.ptr
+    %96 = llvm.getelementptr %95[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %97 = llvm.load %96 : !llvm.ptr -> i256
+    llvm.store %96, %94 : !llvm.ptr, !llvm.ptr
+    %98 = arith.trunci %93 : i256 to i64
+    %99 = arith.trunci %97 : i256 to i64
+    %100 = arith.addi %98, %99 : i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %101 = arith.cmpi slt, %100, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %101, ^bb1(%c84_i8_14 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %110 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> !llvm.ptr
-    %112 = llvm.getelementptr %111[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %113 = llvm.load %112 : !llvm.ptr -> i256
-    llvm.store %112, %110 : !llvm.ptr, !llvm.ptr
-    %c1_i256_16 = arith.constant 1 : i256
-    %114 = llvm.alloca %c1_i256_16 x i256 : (i256) -> !llvm.ptr
-    llvm.store %113, %114 {alignment = 1 : i64} : i256, !llvm.ptr
-    %115 = call @dora_fn_extcodesize(%arg0, %114) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %116 = llvm.getelementptr %115[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %117 = llvm.load %116 : !llvm.ptr -> i64
-    %118 = arith.extui %117 : i64 to i256
-    %119 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %120 = llvm.load %119 : !llvm.ptr -> !llvm.ptr
-    llvm.store %118, %120 : i256, !llvm.ptr
-    %121 = llvm.getelementptr %120[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %121, %119 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb18
+    %c31_i64_15 = arith.constant 31 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %102 = arith.addi %100, %c31_i64_15 : i64
+    %103 = arith.divui %102, %c32_i64_16 : i64
+    %104 = arith.muli %103, %c32_i64_16 : i64
+    %105 = call @dora_fn_extend_memory(%arg0, %104) : (!llvm.ptr, i64) -> !llvm.ptr
+    %106 = llvm.getelementptr %105[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %107 = llvm.load %106 : !llvm.ptr -> !llvm.ptr
+    %108 = llvm.getelementptr %105[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %109 = llvm.load %108 : !llvm.ptr -> i8
+    %c0_i8_17 = arith.constant 0 : i8
+    %110 = arith.cmpi ne, %109, %c0_i8_17 : i8
+    cf.cond_br %110, ^bb1(%109 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i64_17 = arith.constant 0 : i64
+    %111 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %107, %111 : !llvm.ptr, !llvm.ptr
+    %112 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %104, %112 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %113 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %89, %113 {alignment = 1 : i64} : i256, !llvm.ptr
+    %114 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %116 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %115, %116 {alignment = 1 : i64} : i64, !llvm.ptr
+    %117 = call @dora_fn_create(%arg0, %99, %98, %113, %116) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %118 = llvm.getelementptr %117[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %119 = llvm.load %118 : !llvm.ptr -> i8
+    %c0_i8_18 = arith.constant 0 : i8
+    %120 = arith.cmpi ne, %c0_i8_18, %119 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %120, ^bb1(%c94_i8 : i8), ^bb19
+  ^bb19:  // pred: ^bb18
+    %121 = llvm.load %113 : !llvm.ptr -> i256
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    llvm.store %121, %123 : i256, !llvm.ptr
+    %124 = llvm.getelementptr %123[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb20
+  ^bb20:  // pred: ^bb19
+    %125 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %126 = llvm.load %125 : !llvm.ptr -> !llvm.ptr
+    %127 = llvm.getelementptr %126[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %128 = llvm.load %127 : !llvm.ptr -> i256
+    llvm.store %127, %125 : !llvm.ptr, !llvm.ptr
+    %c1_i256_19 = arith.constant 1 : i256
+    %129 = llvm.alloca %c1_i256_19 x i256 : (i256) -> !llvm.ptr
+    llvm.store %128, %129 {alignment = 1 : i64} : i256, !llvm.ptr
+    %130 = call @dora_fn_extcodesize(%arg0, %129) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %131 = llvm.getelementptr %130[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %132 = llvm.load %131 : !llvm.ptr -> i64
+    %133 = arith.extui %132 : i64 to i256
+    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
+    llvm.store %133, %135 : i256, !llvm.ptr
+    %136 = llvm.getelementptr %135[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb21
+  ^bb21:  // pred: ^bb20
+    %c0_i64_20 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %122 = call @dora_fn_write_result(%arg0, %c0_i64_17, %c0_i64_17, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %137 = call @dora_fn_write_result(%arg0, %c0_i64_20, %c0_i64_20, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 11 preds: ^bb2, ^bb5, ^bb9, ^bb13, ^bb18, ^bb19, ^bb27, ^bb33, ^bb37, ^bb41, ^bb46
+  ^bb1(%10: i8):  // 20 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11, ^bb15, ^bb16, ^bb21, ^bb22, ^bb23, ^bb31, ^bb32, ^bb38, ^bb39, ^bb43, ^bb44, ^bb48, ^bb49, ^bb54, ^bb55
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,628 +120,637 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256 = arith.constant -282693306169198560872784742741978202424711039104693490077813924759764729856 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c32_i256 = arith.constant 32 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256 = arith.constant -282693306169198560872784742741978202424711039104693490077813924759764729856 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %c32_i64_4 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c32_i64_4 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %56 = arith.cmpi slt, %55, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %56, ^bb1(%c84_i8_6 : i8), ^bb10
+    %c32_i256 = arith.constant 32 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %60 = arith.addi %59, %c32_i64_4 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_6 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %59 = arith.addi %55, %c31_i64_7 : i64
-    %60 = arith.divui %59, %c32_i64_8 : i64
-    %61 = arith.muli %60, %c32_i64_8 : i64
-    %62 = arith.cmpi ult, %58, %61 : i64
-    scf.if %62 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %61) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %61, %57 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> !llvm.ptr
-    %65 = llvm.getelementptr %64[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %66 = llvm.intr.bswap(%53)  : (i256) -> i256
-    llvm.store %66, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c10123276409175967808859434475862811765392092841461775252157603250176_i256 = arith.constant 10123276409175967808859434475862811765392092841461775252157603250176 : i256
-    %67 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %68 : i256, !llvm.ptr
-    %69 = llvm.getelementptr %68[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %69, %67 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb12
+    %62 = arith.addi %60, %c31_i64_7 : i64
+    %63 = arith.divui %62, %c32_i64_8 : i64
+    %64 = arith.muli %63, %c32_i64_8 : i64
+    %65 = call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
+    %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_9 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_9 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c64_i256 = arith.constant 64 : i256
-    %70 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c64_i256, %71 : i256, !llvm.ptr
-    %72 = llvm.getelementptr %71[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %72, %70 : !llvm.ptr, !llvm.ptr
+    %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %67, %71 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %64, %72 : i64, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
+    %75 = llvm.getelementptr %74[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %76 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %76, %75 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %73 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
-    %75 = llvm.getelementptr %74[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %76 = llvm.load %75 : !llvm.ptr -> i256
-    llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
+    %c10123276409175967808859434475862811765392092841461775252157603250176_i256 = arith.constant 10123276409175967808859434475862811765392092841461775252157603250176 : i256
     %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
-    %79 = llvm.getelementptr %78[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %80 = llvm.load %79 : !llvm.ptr -> i256
+    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
-    %81 = arith.trunci %76 : i256 to i64
-    %c32_i64_9 = arith.constant 32 : i64
-    %82 = arith.addi %81, %c32_i64_9 : i64
-    %c0_i64_10 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_10 : i64
-    %c84_i8_11 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_11 : i8), ^bb14
+    cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %84 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> i64
-    %c31_i64_12 = arith.constant 31 : i64
-    %c32_i64_13 = arith.constant 32 : i64
-    %86 = arith.addi %82, %c31_i64_12 : i64
-    %87 = arith.divui %86, %c32_i64_13 : i64
-    %88 = arith.muli %87, %c32_i64_13 : i64
-    %89 = arith.cmpi ult, %85, %88 : i64
-    scf.if %89 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %88) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %88, %84 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %90 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
-    %92 = llvm.getelementptr %91[%81] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %93 = llvm.intr.bswap(%80)  : (i256) -> i256
-    llvm.store %93, %92 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c64_i256 = arith.constant 64 : i256
+    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %81 : i256, !llvm.ptr
+    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
-    %c77_i256 = arith.constant 77 : i256
-    %94 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %95 = llvm.load %94 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c77_i256, %95 : i256, !llvm.ptr
-    %96 = llvm.getelementptr %95[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %96, %94 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb16
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    %85 = llvm.getelementptr %84[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %86 = llvm.load %85 : !llvm.ptr -> i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    %87 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %88 = llvm.load %87 : !llvm.ptr -> !llvm.ptr
+    %89 = llvm.getelementptr %88[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %90 = llvm.load %89 : !llvm.ptr -> i256
+    llvm.store %89, %87 : !llvm.ptr, !llvm.ptr
+    %91 = arith.trunci %86 : i256 to i64
+    %c32_i64_10 = arith.constant 32 : i64
+    %92 = arith.addi %91, %c32_i64_10 : i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_12 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %c0_i256_14 = arith.constant 0 : i256
-    %97 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %98 = llvm.load %97 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_14, %98 : i256, !llvm.ptr
-    %99 = llvm.getelementptr %98[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %99, %97 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb17
+    %c31_i64_13 = arith.constant 31 : i64
+    %c32_i64_14 = arith.constant 32 : i64
+    %94 = arith.addi %92, %c31_i64_13 : i64
+    %95 = arith.divui %94, %c32_i64_14 : i64
+    %96 = arith.muli %95, %c32_i64_14 : i64
+    %97 = call @dora_fn_extend_memory(%arg0, %96) : (!llvm.ptr, i64) -> !llvm.ptr
+    %98 = llvm.getelementptr %97[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %99 = llvm.load %98 : !llvm.ptr -> !llvm.ptr
+    %100 = llvm.getelementptr %97[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %101 = llvm.load %100 : !llvm.ptr -> i8
+    %c0_i8_15 = arith.constant 0 : i8
+    %102 = arith.cmpi ne, %101, %c0_i8_15 : i8
+    cf.cond_br %102, ^bb1(%101 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i256_15 = arith.constant 0 : i256
-    %100 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %101 = llvm.load %100 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_15, %101 : i256, !llvm.ptr
-    %102 = llvm.getelementptr %101[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %102, %100 : !llvm.ptr, !llvm.ptr
+    %103 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %99, %103 : !llvm.ptr, !llvm.ptr
+    %104 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %96, %104 : i64, !llvm.ptr
+    %105 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %106 = llvm.load %105 : !llvm.ptr -> !llvm.ptr
+    %107 = llvm.getelementptr %106[%91] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %108 = llvm.intr.bswap(%90)  : (i256) -> i256
+    llvm.store %108, %107 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %103 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %104 = llvm.load %103 : !llvm.ptr -> !llvm.ptr
-    %105 = llvm.getelementptr %104[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %106 = llvm.load %105 : !llvm.ptr -> i256
-    llvm.store %105, %103 : !llvm.ptr, !llvm.ptr
-    %107 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %108 = llvm.load %107 : !llvm.ptr -> !llvm.ptr
-    %109 = llvm.getelementptr %108[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %110 = llvm.load %109 : !llvm.ptr -> i256
-    llvm.store %109, %107 : !llvm.ptr, !llvm.ptr
-    %111 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %112 = llvm.load %111 : !llvm.ptr -> !llvm.ptr
-    %113 = llvm.getelementptr %112[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %114 = llvm.load %113 : !llvm.ptr -> i256
-    llvm.store %113, %111 : !llvm.ptr, !llvm.ptr
-    %115 = arith.trunci %110 : i256 to i64
-    %116 = arith.trunci %114 : i256 to i64
-    %117 = arith.addi %115, %116 : i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %118 = arith.cmpi slt, %117, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8_17 : i8), ^bb19
+    %c77_i256 = arith.constant 77 : i256
+    %109 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %110 = llvm.load %109 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c77_i256, %110 : i256, !llvm.ptr
+    %111 = llvm.getelementptr %110[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %111, %109 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %119 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %120 = llvm.load %119 : !llvm.ptr -> i64
-    %c31_i64_18 = arith.constant 31 : i64
-    %c32_i64_19 = arith.constant 32 : i64
-    %121 = arith.addi %117, %c31_i64_18 : i64
-    %122 = arith.divui %121, %c32_i64_19 : i64
-    %123 = arith.muli %122, %c32_i64_19 : i64
-    %124 = arith.cmpi ult, %120, %123 : i64
-    scf.if %124 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %123) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %123, %119 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %125 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %106, %125 {alignment = 1 : i64} : i256, !llvm.ptr
-    %126 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %127 = llvm.load %126 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %128 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %127, %128 {alignment = 1 : i64} : i64, !llvm.ptr
-    %129 = call @dora_fn_create(%arg0, %116, %115, %125, %128) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %130 = llvm.getelementptr %129[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %131 = llvm.load %130 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %132 = arith.cmpi ne, %c0_i8, %131 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %132, ^bb1(%c94_i8 : i8), ^bb20
+    %c0_i256_16 = arith.constant 0 : i256
+    %112 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %113 = llvm.load %112 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_16, %113 : i256, !llvm.ptr
+    %114 = llvm.getelementptr %113[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %114, %112 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb20
   ^bb20:  // pred: ^bb19
-    %133 = llvm.load %125 : !llvm.ptr -> i256
-    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
-    llvm.store %133, %135 : i256, !llvm.ptr
-    %136 = llvm.getelementptr %135[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    %c0_i256_17 = arith.constant 0 : i256
+    %115 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %116 = llvm.load %115 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_17, %116 : i256, !llvm.ptr
+    %117 = llvm.getelementptr %116[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %117, %115 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_20 = arith.constant 0 : i256
-    %137 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %138 = llvm.load %137 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_20, %138 : i256, !llvm.ptr
-    %139 = llvm.getelementptr %138[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %139, %137 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb22
+    %118 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %119 = llvm.load %118 : !llvm.ptr -> !llvm.ptr
+    %120 = llvm.getelementptr %119[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %121 = llvm.load %120 : !llvm.ptr -> i256
+    llvm.store %120, %118 : !llvm.ptr, !llvm.ptr
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    %124 = llvm.getelementptr %123[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %125 = llvm.load %124 : !llvm.ptr -> i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %130 = arith.trunci %125 : i256 to i64
+    %131 = arith.trunci %129 : i256 to i64
+    %132 = arith.addi %130, %131 : i64
+    %c0_i64_18 = arith.constant 0 : i64
+    %133 = arith.cmpi slt, %132, %c0_i64_18 : i64
+    %c84_i8_19 = arith.constant 84 : i8
+    cf.cond_br %133, ^bb1(%c84_i8_19 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_21 = arith.constant 0 : i256
-    %140 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %141 = llvm.load %140 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_21, %141 : i256, !llvm.ptr
-    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %142, %140 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %134 = arith.addi %132, %c31_i64_20 : i64
+    %135 = arith.divui %134, %c32_i64_21 : i64
+    %136 = arith.muli %135, %c32_i64_21 : i64
+    %137 = call @dora_fn_extend_memory(%arg0, %136) : (!llvm.ptr, i64) -> !llvm.ptr
+    %138 = llvm.getelementptr %137[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    %140 = llvm.getelementptr %137[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %141 = llvm.load %140 : !llvm.ptr -> i8
+    %c0_i8_22 = arith.constant 0 : i8
+    %142 = arith.cmpi ne, %141, %c0_i8_22 : i8
+    cf.cond_br %142, ^bb1(%141 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_22 = arith.constant 0 : i256
-    %143 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %144 = llvm.load %143 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_22, %144 : i256, !llvm.ptr
-    %145 = llvm.getelementptr %144[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %145, %143 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb24
+    %143 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %139, %143 : !llvm.ptr, !llvm.ptr
+    %144 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %136, %144 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %145 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %121, %145 {alignment = 1 : i64} : i256, !llvm.ptr
+    %146 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %147 = llvm.load %146 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %148 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %147, %148 {alignment = 1 : i64} : i64, !llvm.ptr
+    %149 = call @dora_fn_create(%arg0, %131, %130, %145, %148) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %150 = llvm.getelementptr %149[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %151 = llvm.load %150 : !llvm.ptr -> i8
+    %c0_i8_23 = arith.constant 0 : i8
+    %152 = arith.cmpi ne, %c0_i8_23, %151 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %152, ^bb1(%c94_i8 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c0_i256_23 = arith.constant 0 : i256
-    %146 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %147 = llvm.load %146 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_23, %147 : i256, !llvm.ptr
-    %148 = llvm.getelementptr %147[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %148, %146 : !llvm.ptr, !llvm.ptr
+    %153 = llvm.load %145 : !llvm.ptr -> i256
+    %154 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %155 = llvm.load %154 : !llvm.ptr -> !llvm.ptr
+    llvm.store %153, %155 : i256, !llvm.ptr
+    %156 = llvm.getelementptr %155[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %156, %154 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %149 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %150 = llvm.load %149 : !llvm.ptr -> !llvm.ptr
-    %151 = llvm.getelementptr %150[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %152 = llvm.load %151 : !llvm.ptr -> i256
-    %153 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
-    llvm.store %152, %154 : i256, !llvm.ptr
-    %155 = llvm.getelementptr %154[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %155, %153 : !llvm.ptr, !llvm.ptr
+    %c0_i256_24 = arith.constant 0 : i256
+    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_24, %158 : i256, !llvm.ptr
+    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb26:  // pred: ^bb25
-    %c4294967295_i256 = arith.constant 4294967295 : i256
-    %156 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %157 = llvm.load %156 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c4294967295_i256, %157 : i256, !llvm.ptr
-    %158 = llvm.getelementptr %157[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
+    %c0_i256_25 = arith.constant 0 : i256
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_25, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb27:  // pred: ^bb26
-    %159 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %160 = llvm.load %159 : !llvm.ptr -> !llvm.ptr
-    %161 = llvm.getelementptr %160[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %162 = llvm.load %161 : !llvm.ptr -> i256
-    llvm.store %161, %159 : !llvm.ptr, !llvm.ptr
+    %c0_i256_26 = arith.constant 0 : i256
     %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    %165 = llvm.getelementptr %164[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %166 = llvm.load %165 : !llvm.ptr -> i256
+    llvm.store %c0_i256_26, %164 : i256, !llvm.ptr
+    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    %167 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %168 = llvm.load %167 : !llvm.ptr -> !llvm.ptr
-    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %170 = llvm.load %169 : !llvm.ptr -> i256
-    llvm.store %169, %167 : !llvm.ptr, !llvm.ptr
-    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
-    %173 = llvm.getelementptr %172[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %174 = llvm.load %173 : !llvm.ptr -> i256
-    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
-    %175 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-    %177 = llvm.getelementptr %176[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %178 = llvm.load %177 : !llvm.ptr -> i256
-    llvm.store %177, %175 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb28
+  ^bb28:  // pred: ^bb27
+    %c0_i256_27 = arith.constant 0 : i256
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_27, %167 : i256, !llvm.ptr
+    %168 = llvm.getelementptr %167[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb29
+  ^bb29:  // pred: ^bb28
+    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
+    %171 = llvm.getelementptr %170[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %172 = llvm.load %171 : !llvm.ptr -> i256
+    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
+    llvm.store %172, %174 : i256, !llvm.ptr
+    %175 = llvm.getelementptr %174[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %175, %173 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb30
+  ^bb30:  // pred: ^bb29
+    %c4294967295_i256 = arith.constant 4294967295 : i256
+    %176 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %177 = llvm.load %176 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4294967295_i256, %177 : i256, !llvm.ptr
+    %178 = llvm.getelementptr %177[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %178, %176 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb31
+  ^bb31:  // pred: ^bb30
     %179 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %180 = llvm.load %179 : !llvm.ptr -> !llvm.ptr
     %181 = llvm.getelementptr %180[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %182 = llvm.load %181 : !llvm.ptr -> i256
     llvm.store %181, %179 : !llvm.ptr, !llvm.ptr
-    %c0_i256_24 = arith.constant 0 : i256
-    %183 = arith.trunci %162 : i256 to i64
-    %184 = arith.trunci %170 : i256 to i64
-    %185 = arith.trunci %174 : i256 to i64
-    %186 = arith.trunci %178 : i256 to i64
-    %187 = arith.trunci %182 : i256 to i64
-    %188 = arith.addi %184, %185 : i64
-    %189 = arith.addi %186, %187 : i64
-    %190 = arith.maxui %188, %189 : i64
-    %c0_i64_25 = arith.constant 0 : i64
-    %191 = arith.cmpi slt, %190, %c0_i64_25 : i64
-    %c84_i8_26 = arith.constant 84 : i8
-    cf.cond_br %191, ^bb1(%c84_i8_26 : i8), ^bb28
-  ^bb28:  // pred: ^bb27
-    %192 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %193 = llvm.load %192 : !llvm.ptr -> i64
-    %c31_i64_27 = arith.constant 31 : i64
-    %c32_i64_28 = arith.constant 32 : i64
-    %194 = arith.addi %190, %c31_i64_27 : i64
-    %195 = arith.divui %194, %c32_i64_28 : i64
-    %196 = arith.muli %195, %c32_i64_28 : i64
-    %197 = arith.cmpi ult, %193, %196 : i64
-    scf.if %197 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %196) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %196, %192 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %198 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %199 = llvm.load %198 : !llvm.ptr -> i64
-    %c1_i256_29 = arith.constant 1 : i256
-    %200 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_24, %200 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_30 = arith.constant 1 : i256
-    %201 = llvm.alloca %c1_i256_30 x i256 : (i256) -> !llvm.ptr
-    llvm.store %166, %201 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_31 = arith.constant 1 : i64
-    %202 = llvm.alloca %c1_i64_31 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_32 = arith.constant 0 : i8
-    %203 = call @dora_fn_call(%arg0, %183, %201, %200, %184, %185, %186, %187, %199, %202, %c0_i8_32) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %204 = llvm.getelementptr %203[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %205 = llvm.load %204 : !llvm.ptr -> i8
-    %206 = llvm.load %202 : !llvm.ptr -> i64
-    %207 = arith.extui %205 : i8 to i256
-    %208 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %209 = llvm.load %208 : !llvm.ptr -> !llvm.ptr
-    llvm.store %207, %209 : i256, !llvm.ptr
-    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %210, %208 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb29
-  ^bb29:  // pred: ^bb28
-    %211 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %212 = llvm.load %211 : !llvm.ptr -> !llvm.ptr
-    %213 = llvm.getelementptr %212[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %214 = llvm.load %213 : !llvm.ptr -> i256
-    llvm.store %213, %211 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb30
-  ^bb30:  // pred: ^bb29
-    %215 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
-    %217 = llvm.getelementptr %216[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %218 = llvm.load %217 : !llvm.ptr -> i256
-    llvm.store %217, %215 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb31
-  ^bb31:  // pred: ^bb30
-    %c0_i256_33 = arith.constant 0 : i256
-    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_33, %220 : i256, !llvm.ptr
-    %221 = llvm.getelementptr %220[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb32
+    %183 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %184 = llvm.load %183 : !llvm.ptr -> !llvm.ptr
+    %185 = llvm.getelementptr %184[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %186 = llvm.load %185 : !llvm.ptr -> i256
+    llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
+    %187 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %188 = llvm.load %187 : !llvm.ptr -> !llvm.ptr
+    %189 = llvm.getelementptr %188[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %190 = llvm.load %189 : !llvm.ptr -> i256
+    llvm.store %189, %187 : !llvm.ptr, !llvm.ptr
+    %191 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %192 = llvm.load %191 : !llvm.ptr -> !llvm.ptr
+    %193 = llvm.getelementptr %192[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %194 = llvm.load %193 : !llvm.ptr -> i256
+    llvm.store %193, %191 : !llvm.ptr, !llvm.ptr
+    %195 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %196 = llvm.load %195 : !llvm.ptr -> !llvm.ptr
+    %197 = llvm.getelementptr %196[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %198 = llvm.load %197 : !llvm.ptr -> i256
+    llvm.store %197, %195 : !llvm.ptr, !llvm.ptr
+    %199 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %200 = llvm.load %199 : !llvm.ptr -> !llvm.ptr
+    %201 = llvm.getelementptr %200[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %202 = llvm.load %201 : !llvm.ptr -> i256
+    llvm.store %201, %199 : !llvm.ptr, !llvm.ptr
+    %c0_i256_28 = arith.constant 0 : i256
+    %203 = arith.trunci %182 : i256 to i64
+    %204 = arith.trunci %190 : i256 to i64
+    %205 = arith.trunci %194 : i256 to i64
+    %206 = arith.trunci %198 : i256 to i64
+    %207 = arith.trunci %202 : i256 to i64
+    %208 = arith.addi %204, %205 : i64
+    %209 = arith.addi %206, %207 : i64
+    %210 = arith.maxui %208, %209 : i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %211 = arith.cmpi slt, %210, %c0_i64_29 : i64
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %211, ^bb1(%c84_i8_30 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i256_34 = arith.constant 0 : i256
-    %222 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %223 = llvm.load %222 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_34, %223 : i256, !llvm.ptr
-    %224 = llvm.getelementptr %223[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %224, %222 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb33
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %212 = arith.addi %210, %c31_i64_31 : i64
+    %213 = arith.divui %212, %c32_i64_32 : i64
+    %214 = arith.muli %213, %c32_i64_32 : i64
+    %215 = call @dora_fn_extend_memory(%arg0, %214) : (!llvm.ptr, i64) -> !llvm.ptr
+    %216 = llvm.getelementptr %215[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
+    %218 = llvm.getelementptr %215[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %219 = llvm.load %218 : !llvm.ptr -> i8
+    %c0_i8_33 = arith.constant 0 : i8
+    %220 = arith.cmpi ne, %219, %c0_i8_33 : i8
+    cf.cond_br %220, ^bb1(%219 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %225 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %226 = llvm.load %225 : !llvm.ptr -> !llvm.ptr
-    %227 = llvm.getelementptr %226[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %228 = llvm.load %227 : !llvm.ptr -> i256
-    llvm.store %227, %225 : !llvm.ptr, !llvm.ptr
-    %229 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %230 = llvm.load %229 : !llvm.ptr -> !llvm.ptr
-    %231 = llvm.getelementptr %230[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %232 = llvm.load %231 : !llvm.ptr -> i256
-    llvm.store %231, %229 : !llvm.ptr, !llvm.ptr
-    %233 = arith.trunci %228 : i256 to i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %234 = arith.addi %233, %c32_i64_35 : i64
-    %c0_i64_36 = arith.constant 0 : i64
-    %235 = arith.cmpi slt, %234, %c0_i64_36 : i64
-    %c84_i8_37 = arith.constant 84 : i8
-    cf.cond_br %235, ^bb1(%c84_i8_37 : i8), ^bb34
+    %221 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %217, %221 : !llvm.ptr, !llvm.ptr
+    %222 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %214, %222 : i64, !llvm.ptr
+    %223 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %224 = llvm.load %223 : !llvm.ptr -> i64
+    %c1_i256_34 = arith.constant 1 : i256
+    %225 = llvm.alloca %c1_i256_34 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_28, %225 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_35 = arith.constant 1 : i256
+    %226 = llvm.alloca %c1_i256_35 x i256 : (i256) -> !llvm.ptr
+    llvm.store %186, %226 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_36 = arith.constant 1 : i64
+    %227 = llvm.alloca %c1_i64_36 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_37 = arith.constant 0 : i8
+    %228 = call @dora_fn_call(%arg0, %203, %226, %225, %204, %205, %206, %207, %224, %227, %c0_i8_37) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %229 = llvm.getelementptr %228[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %230 = llvm.load %229 : !llvm.ptr -> i8
+    %231 = llvm.load %227 : !llvm.ptr -> i64
+    %232 = arith.extui %230 : i8 to i256
+    %233 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %234 = llvm.load %233 : !llvm.ptr -> !llvm.ptr
+    llvm.store %232, %234 : i256, !llvm.ptr
+    %235 = llvm.getelementptr %234[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %235, %233 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb34
   ^bb34:  // pred: ^bb33
-    %236 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %237 = llvm.load %236 : !llvm.ptr -> i64
-    %c31_i64_38 = arith.constant 31 : i64
-    %c32_i64_39 = arith.constant 32 : i64
-    %238 = arith.addi %234, %c31_i64_38 : i64
-    %239 = arith.divui %238, %c32_i64_39 : i64
-    %240 = arith.muli %239, %c32_i64_39 : i64
-    %241 = arith.cmpi ult, %237, %240 : i64
-    scf.if %241 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %240) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %240, %236 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %242 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %243 = llvm.load %242 : !llvm.ptr -> !llvm.ptr
-    %244 = llvm.getelementptr %243[%233] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %245 = llvm.intr.bswap(%232)  : (i256) -> i256
-    llvm.store %245, %244 {alignment = 1 : i64} : i256, !llvm.ptr
+    %236 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %237 = llvm.load %236 : !llvm.ptr -> !llvm.ptr
+    %238 = llvm.getelementptr %237[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %239 = llvm.load %238 : !llvm.ptr -> i256
+    llvm.store %238, %236 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb35:  // pred: ^bb34
-    %c0_i256_40 = arith.constant 0 : i256
-    %246 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %247 = llvm.load %246 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_40, %247 : i256, !llvm.ptr
-    %248 = llvm.getelementptr %247[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %248, %246 : !llvm.ptr, !llvm.ptr
+    %240 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %241 = llvm.load %240 : !llvm.ptr -> !llvm.ptr
+    %242 = llvm.getelementptr %241[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %243 = llvm.load %242 : !llvm.ptr -> i256
+    llvm.store %242, %240 : !llvm.ptr, !llvm.ptr
     cf.br ^bb36
   ^bb36:  // pred: ^bb35
-    %c32_i256_41 = arith.constant 32 : i256
-    %249 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %250 = llvm.load %249 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_41, %250 : i256, !llvm.ptr
-    %251 = llvm.getelementptr %250[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %251, %249 : !llvm.ptr, !llvm.ptr
+    %c0_i256_38 = arith.constant 0 : i256
+    %244 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %245 = llvm.load %244 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_38, %245 : i256, !llvm.ptr
+    %246 = llvm.getelementptr %245[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %246, %244 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb37:  // pred: ^bb36
-    %252 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %253 = llvm.load %252 : !llvm.ptr -> !llvm.ptr
-    %254 = llvm.getelementptr %253[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %255 = llvm.load %254 : !llvm.ptr -> i256
-    llvm.store %254, %252 : !llvm.ptr, !llvm.ptr
-    %256 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %257 = llvm.load %256 : !llvm.ptr -> !llvm.ptr
-    %258 = llvm.getelementptr %257[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %259 = llvm.load %258 : !llvm.ptr -> i256
-    llvm.store %258, %256 : !llvm.ptr, !llvm.ptr
-    %260 = arith.trunci %255 : i256 to i64
-    %c32_i64_42 = arith.constant 32 : i64
-    %261 = arith.addi %260, %c32_i64_42 : i64
-    %c0_i64_43 = arith.constant 0 : i64
-    %262 = arith.cmpi slt, %261, %c0_i64_43 : i64
-    %c84_i8_44 = arith.constant 84 : i8
-    cf.cond_br %262, ^bb1(%c84_i8_44 : i8), ^bb38
+    %c0_i256_39 = arith.constant 0 : i256
+    %247 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %248 = llvm.load %247 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_39, %248 : i256, !llvm.ptr
+    %249 = llvm.getelementptr %248[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %249, %247 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb38
   ^bb38:  // pred: ^bb37
-    %263 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %264 = llvm.load %263 : !llvm.ptr -> i64
-    %c31_i64_45 = arith.constant 31 : i64
-    %c32_i64_46 = arith.constant 32 : i64
-    %265 = arith.addi %261, %c31_i64_45 : i64
-    %266 = arith.divui %265, %c32_i64_46 : i64
-    %267 = arith.muli %266, %c32_i64_46 : i64
-    %268 = arith.cmpi ult, %264, %267 : i64
-    scf.if %268 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %267) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %267, %263 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %269 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %270 = llvm.load %269 : !llvm.ptr -> !llvm.ptr
-    %271 = llvm.getelementptr %270[%260] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %272 = llvm.intr.bswap(%259)  : (i256) -> i256
-    llvm.store %272, %271 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb39
+    %250 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %251 = llvm.load %250 : !llvm.ptr -> !llvm.ptr
+    %252 = llvm.getelementptr %251[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %253 = llvm.load %252 : !llvm.ptr -> i256
+    llvm.store %252, %250 : !llvm.ptr, !llvm.ptr
+    %254 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %255 = llvm.load %254 : !llvm.ptr -> !llvm.ptr
+    %256 = llvm.getelementptr %255[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %257 = llvm.load %256 : !llvm.ptr -> i256
+    llvm.store %256, %254 : !llvm.ptr, !llvm.ptr
+    %258 = arith.trunci %253 : i256 to i64
+    %c32_i64_40 = arith.constant 32 : i64
+    %259 = arith.addi %258, %c32_i64_40 : i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %260 = arith.cmpi slt, %259, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %260, ^bb1(%c84_i8_42 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %c0_i256_47 = arith.constant 0 : i256
-    %273 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %274 = llvm.load %273 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_47, %274 : i256, !llvm.ptr
-    %275 = llvm.getelementptr %274[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %275, %273 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb40
+    %c31_i64_43 = arith.constant 31 : i64
+    %c32_i64_44 = arith.constant 32 : i64
+    %261 = arith.addi %259, %c31_i64_43 : i64
+    %262 = arith.divui %261, %c32_i64_44 : i64
+    %263 = arith.muli %262, %c32_i64_44 : i64
+    %264 = call @dora_fn_extend_memory(%arg0, %263) : (!llvm.ptr, i64) -> !llvm.ptr
+    %265 = llvm.getelementptr %264[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %266 = llvm.load %265 : !llvm.ptr -> !llvm.ptr
+    %267 = llvm.getelementptr %264[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %268 = llvm.load %267 : !llvm.ptr -> i8
+    %c0_i8_45 = arith.constant 0 : i8
+    %269 = arith.cmpi ne, %268, %c0_i8_45 : i8
+    cf.cond_br %269, ^bb1(%268 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %c64_i256_48 = arith.constant 64 : i256
-    %276 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %277 = llvm.load %276 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c64_i256_48, %277 : i256, !llvm.ptr
-    %278 = llvm.getelementptr %277[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %278, %276 : !llvm.ptr, !llvm.ptr
+    %270 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %266, %270 : !llvm.ptr, !llvm.ptr
+    %271 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %263, %271 : i64, !llvm.ptr
+    %272 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %273 = llvm.load %272 : !llvm.ptr -> !llvm.ptr
+    %274 = llvm.getelementptr %273[%258] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %275 = llvm.intr.bswap(%257)  : (i256) -> i256
+    llvm.store %275, %274 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb41
   ^bb41:  // pred: ^bb40
+    %c0_i256_46 = arith.constant 0 : i256
+    %276 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %277 = llvm.load %276 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_46, %277 : i256, !llvm.ptr
+    %278 = llvm.getelementptr %277[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %278, %276 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb42
+  ^bb42:  // pred: ^bb41
+    %c32_i256_47 = arith.constant 32 : i256
     %279 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %280 = llvm.load %279 : !llvm.ptr -> !llvm.ptr
-    %281 = llvm.getelementptr %280[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %282 = llvm.load %281 : !llvm.ptr -> i256
+    llvm.store %c32_i256_47, %280 : i256, !llvm.ptr
+    %281 = llvm.getelementptr %280[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %281, %279 : !llvm.ptr, !llvm.ptr
-    %283 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %284 = llvm.load %283 : !llvm.ptr -> !llvm.ptr
-    %285 = llvm.getelementptr %284[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %286 = llvm.load %285 : !llvm.ptr -> i256
-    llvm.store %285, %283 : !llvm.ptr, !llvm.ptr
-    %287 = arith.trunci %282 : i256 to i64
-    %c32_i64_49 = arith.constant 32 : i64
-    %288 = arith.addi %287, %c32_i64_49 : i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %289 = arith.cmpi slt, %288, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %289, ^bb1(%c84_i8_51 : i8), ^bb42
-  ^bb42:  // pred: ^bb41
-    %290 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %291 = llvm.load %290 : !llvm.ptr -> i64
-    %c31_i64_52 = arith.constant 31 : i64
-    %c32_i64_53 = arith.constant 32 : i64
-    %292 = arith.addi %288, %c31_i64_52 : i64
-    %293 = arith.divui %292, %c32_i64_53 : i64
-    %294 = arith.muli %293, %c32_i64_53 : i64
-    %295 = arith.cmpi ult, %291, %294 : i64
-    scf.if %295 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %294) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %294, %290 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %296 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %297 = llvm.load %296 : !llvm.ptr -> !llvm.ptr
-    %298 = llvm.getelementptr %297[%287] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %299 = llvm.intr.bswap(%286)  : (i256) -> i256
-    llvm.store %299, %298 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb43
   ^bb43:  // pred: ^bb42
-    %c32_i256_54 = arith.constant 32 : i256
-    %300 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %301 = llvm.load %300 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_54, %301 : i256, !llvm.ptr
-    %302 = llvm.getelementptr %301[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %302, %300 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb44
+    %282 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %283 = llvm.load %282 : !llvm.ptr -> !llvm.ptr
+    %284 = llvm.getelementptr %283[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %285 = llvm.load %284 : !llvm.ptr -> i256
+    llvm.store %284, %282 : !llvm.ptr, !llvm.ptr
+    %286 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %287 = llvm.load %286 : !llvm.ptr -> !llvm.ptr
+    %288 = llvm.getelementptr %287[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %289 = llvm.load %288 : !llvm.ptr -> i256
+    llvm.store %288, %286 : !llvm.ptr, !llvm.ptr
+    %290 = arith.trunci %285 : i256 to i64
+    %c32_i64_48 = arith.constant 32 : i64
+    %291 = arith.addi %290, %c32_i64_48 : i64
+    %c0_i64_49 = arith.constant 0 : i64
+    %292 = arith.cmpi slt, %291, %c0_i64_49 : i64
+    %c84_i8_50 = arith.constant 84 : i8
+    cf.cond_br %292, ^bb1(%c84_i8_50 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c0_i256_55 = arith.constant 0 : i256
-    %303 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %304 = llvm.load %303 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_55, %304 : i256, !llvm.ptr
-    %305 = llvm.getelementptr %304[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %305, %303 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb45
+    %c31_i64_51 = arith.constant 31 : i64
+    %c32_i64_52 = arith.constant 32 : i64
+    %293 = arith.addi %291, %c31_i64_51 : i64
+    %294 = arith.divui %293, %c32_i64_52 : i64
+    %295 = arith.muli %294, %c32_i64_52 : i64
+    %296 = call @dora_fn_extend_memory(%arg0, %295) : (!llvm.ptr, i64) -> !llvm.ptr
+    %297 = llvm.getelementptr %296[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %298 = llvm.load %297 : !llvm.ptr -> !llvm.ptr
+    %299 = llvm.getelementptr %296[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %300 = llvm.load %299 : !llvm.ptr -> i8
+    %c0_i8_53 = arith.constant 0 : i8
+    %301 = arith.cmpi ne, %300, %c0_i8_53 : i8
+    cf.cond_br %301, ^bb1(%300 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %c0_i256_56 = arith.constant 0 : i256
-    %306 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %307 = llvm.load %306 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_56, %307 : i256, !llvm.ptr
-    %308 = llvm.getelementptr %307[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %308, %306 : !llvm.ptr, !llvm.ptr
+    %302 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %298, %302 : !llvm.ptr, !llvm.ptr
+    %303 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %295, %303 : i64, !llvm.ptr
+    %304 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %305 = llvm.load %304 : !llvm.ptr -> !llvm.ptr
+    %306 = llvm.getelementptr %305[%290] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %307 = llvm.intr.bswap(%289)  : (i256) -> i256
+    llvm.store %307, %306 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb46
   ^bb46:  // pred: ^bb45
-    %309 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %310 = llvm.load %309 : !llvm.ptr -> !llvm.ptr
-    %311 = llvm.getelementptr %310[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %312 = llvm.load %311 : !llvm.ptr -> i256
-    llvm.store %311, %309 : !llvm.ptr, !llvm.ptr
-    %313 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %314 = llvm.load %313 : !llvm.ptr -> !llvm.ptr
-    %315 = llvm.getelementptr %314[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %316 = llvm.load %315 : !llvm.ptr -> i256
-    llvm.store %315, %313 : !llvm.ptr, !llvm.ptr
-    %317 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %318 = llvm.load %317 : !llvm.ptr -> !llvm.ptr
-    %319 = llvm.getelementptr %318[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %320 = llvm.load %319 : !llvm.ptr -> i256
-    llvm.store %319, %317 : !llvm.ptr, !llvm.ptr
-    %321 = arith.trunci %312 : i256 to i64
-    %322 = arith.trunci %316 : i256 to i64
-    %323 = arith.trunci %320 : i256 to i64
-    %324 = arith.addi %321, %323 : i64
-    %c0_i64_57 = arith.constant 0 : i64
-    %325 = arith.cmpi slt, %324, %c0_i64_57 : i64
-    %c84_i8_58 = arith.constant 84 : i8
-    cf.cond_br %325, ^bb1(%c84_i8_58 : i8), ^bb47
+    %c0_i256_54 = arith.constant 0 : i256
+    %308 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %309 = llvm.load %308 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_54, %309 : i256, !llvm.ptr
+    %310 = llvm.getelementptr %309[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %310, %308 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb47
   ^bb47:  // pred: ^bb46
-    %326 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %327 = llvm.load %326 : !llvm.ptr -> i64
-    %c31_i64_59 = arith.constant 31 : i64
-    %c32_i64_60 = arith.constant 32 : i64
-    %328 = arith.addi %324, %c31_i64_59 : i64
-    %329 = arith.divui %328, %c32_i64_60 : i64
-    %330 = arith.muli %329, %c32_i64_60 : i64
-    %331 = arith.cmpi ult, %327, %330 : i64
-    scf.if %331 {
-      %334 = func.call @dora_fn_extend_memory(%arg0, %330) : (!llvm.ptr, i64) -> !llvm.ptr
-      %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %336 = llvm.load %335 : !llvm.ptr -> !llvm.ptr
-      llvm.store %330, %326 : i64, !llvm.ptr
-      %337 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %336, %337 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %332 = call @dora_fn_return_data_copy(%arg0, %321, %322, %323) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    %c64_i256_55 = arith.constant 64 : i256
+    %311 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %312 = llvm.load %311 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_55, %312 : i256, !llvm.ptr
+    %313 = llvm.getelementptr %312[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %313, %311 : !llvm.ptr, !llvm.ptr
     cf.br ^bb48
   ^bb48:  // pred: ^bb47
-    %c0_i64_61 = arith.constant 0 : i64
+    %314 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %315 = llvm.load %314 : !llvm.ptr -> !llvm.ptr
+    %316 = llvm.getelementptr %315[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %317 = llvm.load %316 : !llvm.ptr -> i256
+    llvm.store %316, %314 : !llvm.ptr, !llvm.ptr
+    %318 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %319 = llvm.load %318 : !llvm.ptr -> !llvm.ptr
+    %320 = llvm.getelementptr %319[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %321 = llvm.load %320 : !llvm.ptr -> i256
+    llvm.store %320, %318 : !llvm.ptr, !llvm.ptr
+    %322 = arith.trunci %317 : i256 to i64
+    %c32_i64_56 = arith.constant 32 : i64
+    %323 = arith.addi %322, %c32_i64_56 : i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %324 = arith.cmpi slt, %323, %c0_i64_57 : i64
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %324, ^bb1(%c84_i8_58 : i8), ^bb49
+  ^bb49:  // pred: ^bb48
+    %c31_i64_59 = arith.constant 31 : i64
+    %c32_i64_60 = arith.constant 32 : i64
+    %325 = arith.addi %323, %c31_i64_59 : i64
+    %326 = arith.divui %325, %c32_i64_60 : i64
+    %327 = arith.muli %326, %c32_i64_60 : i64
+    %328 = call @dora_fn_extend_memory(%arg0, %327) : (!llvm.ptr, i64) -> !llvm.ptr
+    %329 = llvm.getelementptr %328[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %330 = llvm.load %329 : !llvm.ptr -> !llvm.ptr
+    %331 = llvm.getelementptr %328[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %332 = llvm.load %331 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %333 = arith.cmpi ne, %332, %c0_i8_61 : i8
+    cf.cond_br %333, ^bb1(%332 : i8), ^bb50
+  ^bb50:  // pred: ^bb49
+    %334 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %330, %334 : !llvm.ptr, !llvm.ptr
+    %335 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %327, %335 : i64, !llvm.ptr
+    %336 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %337 = llvm.load %336 : !llvm.ptr -> !llvm.ptr
+    %338 = llvm.getelementptr %337[%322] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %339 = llvm.intr.bswap(%321)  : (i256) -> i256
+    llvm.store %339, %338 {alignment = 1 : i64} : i256, !llvm.ptr
+    cf.br ^bb51
+  ^bb51:  // pred: ^bb50
+    %c32_i256_62 = arith.constant 32 : i256
+    %340 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %341 = llvm.load %340 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_62, %341 : i256, !llvm.ptr
+    %342 = llvm.getelementptr %341[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %342, %340 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb52
+  ^bb52:  // pred: ^bb51
+    %c0_i256_63 = arith.constant 0 : i256
+    %343 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %344 = llvm.load %343 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_63, %344 : i256, !llvm.ptr
+    %345 = llvm.getelementptr %344[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %345, %343 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb53
+  ^bb53:  // pred: ^bb52
+    %c0_i256_64 = arith.constant 0 : i256
+    %346 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %347 = llvm.load %346 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_64, %347 : i256, !llvm.ptr
+    %348 = llvm.getelementptr %347[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %348, %346 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb54
+  ^bb54:  // pred: ^bb53
+    %349 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %350 = llvm.load %349 : !llvm.ptr -> !llvm.ptr
+    %351 = llvm.getelementptr %350[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %352 = llvm.load %351 : !llvm.ptr -> i256
+    llvm.store %351, %349 : !llvm.ptr, !llvm.ptr
+    %353 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %354 = llvm.load %353 : !llvm.ptr -> !llvm.ptr
+    %355 = llvm.getelementptr %354[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %356 = llvm.load %355 : !llvm.ptr -> i256
+    llvm.store %355, %353 : !llvm.ptr, !llvm.ptr
+    %357 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %358 = llvm.load %357 : !llvm.ptr -> !llvm.ptr
+    %359 = llvm.getelementptr %358[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %360 = llvm.load %359 : !llvm.ptr -> i256
+    llvm.store %359, %357 : !llvm.ptr, !llvm.ptr
+    %361 = arith.trunci %352 : i256 to i64
+    %362 = arith.trunci %356 : i256 to i64
+    %363 = arith.trunci %360 : i256 to i64
+    %364 = arith.addi %361, %363 : i64
+    %c0_i64_65 = arith.constant 0 : i64
+    %365 = arith.cmpi slt, %364, %c0_i64_65 : i64
+    %c84_i8_66 = arith.constant 84 : i8
+    cf.cond_br %365, ^bb1(%c84_i8_66 : i8), ^bb55
+  ^bb55:  // pred: ^bb54
+    %c31_i64_67 = arith.constant 31 : i64
+    %c32_i64_68 = arith.constant 32 : i64
+    %366 = arith.addi %364, %c31_i64_67 : i64
+    %367 = arith.divui %366, %c32_i64_68 : i64
+    %368 = arith.muli %367, %c32_i64_68 : i64
+    %369 = call @dora_fn_extend_memory(%arg0, %368) : (!llvm.ptr, i64) -> !llvm.ptr
+    %370 = llvm.getelementptr %369[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %371 = llvm.load %370 : !llvm.ptr -> !llvm.ptr
+    %372 = llvm.getelementptr %369[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %373 = llvm.load %372 : !llvm.ptr -> i8
+    %c0_i8_69 = arith.constant 0 : i8
+    %374 = arith.cmpi ne, %373, %c0_i8_69 : i8
+    cf.cond_br %374, ^bb1(%373 : i8), ^bb56
+  ^bb56:  // pred: ^bb55
+    %375 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %371, %375 : !llvm.ptr, !llvm.ptr
+    %376 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %368, %376 : i64, !llvm.ptr
+    %377 = call @dora_fn_return_data_copy(%arg0, %361, %362, %363) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb57
+  ^bb57:  // pred: ^bb56
+    %c0_i64_70 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %333 = call @dora_fn_write_result(%arg0, %c0_i64_61, %c0_i64_61, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %378 = call @dora_fn_write_result(%arg0, %c0_i64_70, %c0_i64_70, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 7 preds: ^bb2, ^bb5, ^bb9, ^bb13, ^bb18, ^bb19, ^bb27
+  ^bb1(%10: i8):  // 12 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11, ^bb15, ^bb16, ^bb21, ^bb22, ^bb23, ^bb31, ^bb32
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,383 +120,388 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %219 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %222 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %221, %222 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256 = arith.constant -282693306169198560872784742741978202424711039104693490077813924759764729856 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c32_i256 = arith.constant 32 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256 = arith.constant -282693306169198560872784742741978202424711039104693490077813924759764729856 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %c32_i64_4 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c32_i64_4 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %56 = arith.cmpi slt, %55, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %56, ^bb1(%c84_i8_6 : i8), ^bb10
+    %c32_i256 = arith.constant 32 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %57 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %c32_i64_4 = arith.constant 32 : i64
+    %60 = arith.addi %59, %c32_i64_4 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_6 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %59 = arith.addi %55, %c31_i64_7 : i64
-    %60 = arith.divui %59, %c32_i64_8 : i64
-    %61 = arith.muli %60, %c32_i64_8 : i64
-    %62 = arith.cmpi ult, %58, %61 : i64
-    scf.if %62 {
-      %219 = func.call @dora_fn_extend_memory(%arg0, %61) : (!llvm.ptr, i64) -> !llvm.ptr
-      %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
-      llvm.store %61, %57 : i64, !llvm.ptr
-      %222 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %221, %222 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %63 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> !llvm.ptr
-    %65 = llvm.getelementptr %64[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %66 = llvm.intr.bswap(%53)  : (i256) -> i256
-    llvm.store %66, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c10123276409175967808859434475862811765392092841461775252157603250176_i256 = arith.constant 10123276409175967808859434475862811765392092841461775252157603250176 : i256
-    %67 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %68 : i256, !llvm.ptr
-    %69 = llvm.getelementptr %68[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %69, %67 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb12
+    %62 = arith.addi %60, %c31_i64_7 : i64
+    %63 = arith.divui %62, %c32_i64_8 : i64
+    %64 = arith.muli %63, %c32_i64_8 : i64
+    %65 = call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
+    %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_9 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_9 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c64_i256 = arith.constant 64 : i256
-    %70 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c64_i256, %71 : i256, !llvm.ptr
-    %72 = llvm.getelementptr %71[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %72, %70 : !llvm.ptr, !llvm.ptr
+    %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %67, %71 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %64, %72 : i64, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
+    %75 = llvm.getelementptr %74[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %76 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %76, %75 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %73 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> !llvm.ptr
-    %75 = llvm.getelementptr %74[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %76 = llvm.load %75 : !llvm.ptr -> i256
-    llvm.store %75, %73 : !llvm.ptr, !llvm.ptr
+    %c10123276409175967808859434475862811765392092841461775252157603250176_i256 = arith.constant 10123276409175967808859434475862811765392092841461775252157603250176 : i256
     %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
-    %79 = llvm.getelementptr %78[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %80 = llvm.load %79 : !llvm.ptr -> i256
+    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
-    %81 = arith.trunci %76 : i256 to i64
-    %c32_i64_9 = arith.constant 32 : i64
-    %82 = arith.addi %81, %c32_i64_9 : i64
-    %c0_i64_10 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_10 : i64
-    %c84_i8_11 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_11 : i8), ^bb14
+    cf.br ^bb14
   ^bb14:  // pred: ^bb13
-    %84 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> i64
-    %c31_i64_12 = arith.constant 31 : i64
-    %c32_i64_13 = arith.constant 32 : i64
-    %86 = arith.addi %82, %c31_i64_12 : i64
-    %87 = arith.divui %86, %c32_i64_13 : i64
-    %88 = arith.muli %87, %c32_i64_13 : i64
-    %89 = arith.cmpi ult, %85, %88 : i64
-    scf.if %89 {
-      %219 = func.call @dora_fn_extend_memory(%arg0, %88) : (!llvm.ptr, i64) -> !llvm.ptr
-      %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
-      llvm.store %88, %84 : i64, !llvm.ptr
-      %222 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %221, %222 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %90 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %91 = llvm.load %90 : !llvm.ptr -> !llvm.ptr
-    %92 = llvm.getelementptr %91[%81] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %93 = llvm.intr.bswap(%80)  : (i256) -> i256
-    llvm.store %93, %92 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c64_i256 = arith.constant 64 : i256
+    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %81 : i256, !llvm.ptr
+    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb15:  // pred: ^bb14
-    %c77_i256 = arith.constant 77 : i256
-    %94 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %95 = llvm.load %94 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c77_i256, %95 : i256, !llvm.ptr
-    %96 = llvm.getelementptr %95[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %96, %94 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb16
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    %85 = llvm.getelementptr %84[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %86 = llvm.load %85 : !llvm.ptr -> i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    %87 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %88 = llvm.load %87 : !llvm.ptr -> !llvm.ptr
+    %89 = llvm.getelementptr %88[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %90 = llvm.load %89 : !llvm.ptr -> i256
+    llvm.store %89, %87 : !llvm.ptr, !llvm.ptr
+    %91 = arith.trunci %86 : i256 to i64
+    %c32_i64_10 = arith.constant 32 : i64
+    %92 = arith.addi %91, %c32_i64_10 : i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_12 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %c0_i256_14 = arith.constant 0 : i256
-    %97 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %98 = llvm.load %97 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_14, %98 : i256, !llvm.ptr
-    %99 = llvm.getelementptr %98[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %99, %97 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb17
+    %c31_i64_13 = arith.constant 31 : i64
+    %c32_i64_14 = arith.constant 32 : i64
+    %94 = arith.addi %92, %c31_i64_13 : i64
+    %95 = arith.divui %94, %c32_i64_14 : i64
+    %96 = arith.muli %95, %c32_i64_14 : i64
+    %97 = call @dora_fn_extend_memory(%arg0, %96) : (!llvm.ptr, i64) -> !llvm.ptr
+    %98 = llvm.getelementptr %97[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %99 = llvm.load %98 : !llvm.ptr -> !llvm.ptr
+    %100 = llvm.getelementptr %97[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %101 = llvm.load %100 : !llvm.ptr -> i8
+    %c0_i8_15 = arith.constant 0 : i8
+    %102 = arith.cmpi ne, %101, %c0_i8_15 : i8
+    cf.cond_br %102, ^bb1(%101 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i256_15 = arith.constant 0 : i256
-    %100 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %101 = llvm.load %100 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_15, %101 : i256, !llvm.ptr
-    %102 = llvm.getelementptr %101[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %102, %100 : !llvm.ptr, !llvm.ptr
+    %103 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %99, %103 : !llvm.ptr, !llvm.ptr
+    %104 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %96, %104 : i64, !llvm.ptr
+    %105 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %106 = llvm.load %105 : !llvm.ptr -> !llvm.ptr
+    %107 = llvm.getelementptr %106[%91] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %108 = llvm.intr.bswap(%90)  : (i256) -> i256
+    llvm.store %108, %107 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %103 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %104 = llvm.load %103 : !llvm.ptr -> !llvm.ptr
-    %105 = llvm.getelementptr %104[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %106 = llvm.load %105 : !llvm.ptr -> i256
-    llvm.store %105, %103 : !llvm.ptr, !llvm.ptr
-    %107 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %108 = llvm.load %107 : !llvm.ptr -> !llvm.ptr
-    %109 = llvm.getelementptr %108[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %110 = llvm.load %109 : !llvm.ptr -> i256
-    llvm.store %109, %107 : !llvm.ptr, !llvm.ptr
-    %111 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %112 = llvm.load %111 : !llvm.ptr -> !llvm.ptr
-    %113 = llvm.getelementptr %112[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %114 = llvm.load %113 : !llvm.ptr -> i256
-    llvm.store %113, %111 : !llvm.ptr, !llvm.ptr
-    %115 = arith.trunci %110 : i256 to i64
-    %116 = arith.trunci %114 : i256 to i64
-    %117 = arith.addi %115, %116 : i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %118 = arith.cmpi slt, %117, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8_17 : i8), ^bb19
+    %c77_i256 = arith.constant 77 : i256
+    %109 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %110 = llvm.load %109 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c77_i256, %110 : i256, !llvm.ptr
+    %111 = llvm.getelementptr %110[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %111, %109 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %119 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %120 = llvm.load %119 : !llvm.ptr -> i64
-    %c31_i64_18 = arith.constant 31 : i64
-    %c32_i64_19 = arith.constant 32 : i64
-    %121 = arith.addi %117, %c31_i64_18 : i64
-    %122 = arith.divui %121, %c32_i64_19 : i64
-    %123 = arith.muli %122, %c32_i64_19 : i64
-    %124 = arith.cmpi ult, %120, %123 : i64
-    scf.if %124 {
-      %219 = func.call @dora_fn_extend_memory(%arg0, %123) : (!llvm.ptr, i64) -> !llvm.ptr
-      %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
-      llvm.store %123, %119 : i64, !llvm.ptr
-      %222 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %221, %222 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %125 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %106, %125 {alignment = 1 : i64} : i256, !llvm.ptr
-    %126 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %127 = llvm.load %126 : !llvm.ptr -> i64
-    %c1_i64 = arith.constant 1 : i64
-    %128 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
-    llvm.store %127, %128 {alignment = 1 : i64} : i64, !llvm.ptr
-    %129 = call @dora_fn_create(%arg0, %116, %115, %125, %128) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %130 = llvm.getelementptr %129[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %131 = llvm.load %130 : !llvm.ptr -> i8
-    %c0_i8 = arith.constant 0 : i8
-    %132 = arith.cmpi ne, %c0_i8, %131 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %132, ^bb1(%c94_i8 : i8), ^bb20
+    %c0_i256_16 = arith.constant 0 : i256
+    %112 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %113 = llvm.load %112 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_16, %113 : i256, !llvm.ptr
+    %114 = llvm.getelementptr %113[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %114, %112 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb20
   ^bb20:  // pred: ^bb19
-    %133 = llvm.load %125 : !llvm.ptr -> i256
-    %134 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %135 = llvm.load %134 : !llvm.ptr -> !llvm.ptr
-    llvm.store %133, %135 : i256, !llvm.ptr
-    %136 = llvm.getelementptr %135[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %136, %134 : !llvm.ptr, !llvm.ptr
+    %c0_i256_17 = arith.constant 0 : i256
+    %115 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %116 = llvm.load %115 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_17, %116 : i256, !llvm.ptr
+    %117 = llvm.getelementptr %116[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %117, %115 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_20 = arith.constant 0 : i256
-    %137 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %138 = llvm.load %137 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_20, %138 : i256, !llvm.ptr
-    %139 = llvm.getelementptr %138[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %139, %137 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb22
+    %118 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %119 = llvm.load %118 : !llvm.ptr -> !llvm.ptr
+    %120 = llvm.getelementptr %119[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %121 = llvm.load %120 : !llvm.ptr -> i256
+    llvm.store %120, %118 : !llvm.ptr, !llvm.ptr
+    %122 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %123 = llvm.load %122 : !llvm.ptr -> !llvm.ptr
+    %124 = llvm.getelementptr %123[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %125 = llvm.load %124 : !llvm.ptr -> i256
+    llvm.store %124, %122 : !llvm.ptr, !llvm.ptr
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %130 = arith.trunci %125 : i256 to i64
+    %131 = arith.trunci %129 : i256 to i64
+    %132 = arith.addi %130, %131 : i64
+    %c0_i64_18 = arith.constant 0 : i64
+    %133 = arith.cmpi slt, %132, %c0_i64_18 : i64
+    %c84_i8_19 = arith.constant 84 : i8
+    cf.cond_br %133, ^bb1(%c84_i8_19 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_21 = arith.constant 0 : i256
-    %140 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %141 = llvm.load %140 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_21, %141 : i256, !llvm.ptr
-    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %142, %140 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb23
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %134 = arith.addi %132, %c31_i64_20 : i64
+    %135 = arith.divui %134, %c32_i64_21 : i64
+    %136 = arith.muli %135, %c32_i64_21 : i64
+    %137 = call @dora_fn_extend_memory(%arg0, %136) : (!llvm.ptr, i64) -> !llvm.ptr
+    %138 = llvm.getelementptr %137[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    %140 = llvm.getelementptr %137[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %141 = llvm.load %140 : !llvm.ptr -> i8
+    %c0_i8_22 = arith.constant 0 : i8
+    %142 = arith.cmpi ne, %141, %c0_i8_22 : i8
+    cf.cond_br %142, ^bb1(%141 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_22 = arith.constant 0 : i256
-    %143 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %144 = llvm.load %143 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_22, %144 : i256, !llvm.ptr
-    %145 = llvm.getelementptr %144[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %145, %143 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb24
+    %143 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %139, %143 : !llvm.ptr, !llvm.ptr
+    %144 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %136, %144 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %145 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %121, %145 {alignment = 1 : i64} : i256, !llvm.ptr
+    %146 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %147 = llvm.load %146 : !llvm.ptr -> i64
+    %c1_i64 = arith.constant 1 : i64
+    %148 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    llvm.store %147, %148 {alignment = 1 : i64} : i64, !llvm.ptr
+    %149 = call @dora_fn_create(%arg0, %131, %130, %145, %148) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %150 = llvm.getelementptr %149[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %151 = llvm.load %150 : !llvm.ptr -> i8
+    %c0_i8_23 = arith.constant 0 : i8
+    %152 = arith.cmpi ne, %c0_i8_23, %151 : i8
+    %c94_i8 = arith.constant 94 : i8
+    cf.cond_br %152, ^bb1(%c94_i8 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c0_i256_23 = arith.constant 0 : i256
-    %146 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %147 = llvm.load %146 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_23, %147 : i256, !llvm.ptr
-    %148 = llvm.getelementptr %147[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %148, %146 : !llvm.ptr, !llvm.ptr
+    %153 = llvm.load %145 : !llvm.ptr -> i256
+    %154 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %155 = llvm.load %154 : !llvm.ptr -> !llvm.ptr
+    llvm.store %153, %155 : i256, !llvm.ptr
+    %156 = llvm.getelementptr %155[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %156, %154 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %149 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %150 = llvm.load %149 : !llvm.ptr -> !llvm.ptr
-    %151 = llvm.getelementptr %150[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %152 = llvm.load %151 : !llvm.ptr -> i256
-    %153 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
-    llvm.store %152, %154 : i256, !llvm.ptr
-    %155 = llvm.getelementptr %154[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %155, %153 : !llvm.ptr, !llvm.ptr
+    %c0_i256_24 = arith.constant 0 : i256
+    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_24, %158 : i256, !llvm.ptr
+    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb26:  // pred: ^bb25
-    %c4294967295_i256 = arith.constant 4294967295 : i256
-    %156 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %157 = llvm.load %156 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c4294967295_i256, %157 : i256, !llvm.ptr
-    %158 = llvm.getelementptr %157[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
+    %c0_i256_25 = arith.constant 0 : i256
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_25, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb27:  // pred: ^bb26
-    %159 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %160 = llvm.load %159 : !llvm.ptr -> !llvm.ptr
-    %161 = llvm.getelementptr %160[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %162 = llvm.load %161 : !llvm.ptr -> i256
-    llvm.store %161, %159 : !llvm.ptr, !llvm.ptr
+    %c0_i256_26 = arith.constant 0 : i256
     %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    %165 = llvm.getelementptr %164[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %166 = llvm.load %165 : !llvm.ptr -> i256
+    llvm.store %c0_i256_26, %164 : i256, !llvm.ptr
+    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
     llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    %167 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %168 = llvm.load %167 : !llvm.ptr -> !llvm.ptr
-    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %170 = llvm.load %169 : !llvm.ptr -> i256
-    llvm.store %169, %167 : !llvm.ptr, !llvm.ptr
-    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
-    %173 = llvm.getelementptr %172[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %174 = llvm.load %173 : !llvm.ptr -> i256
-    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
-    %175 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %176 = llvm.load %175 : !llvm.ptr -> !llvm.ptr
-    %177 = llvm.getelementptr %176[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %178 = llvm.load %177 : !llvm.ptr -> i256
-    llvm.store %177, %175 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb28
+  ^bb28:  // pred: ^bb27
+    %c0_i256_27 = arith.constant 0 : i256
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_27, %167 : i256, !llvm.ptr
+    %168 = llvm.getelementptr %167[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb29
+  ^bb29:  // pred: ^bb28
+    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
+    %171 = llvm.getelementptr %170[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %172 = llvm.load %171 : !llvm.ptr -> i256
+    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
+    llvm.store %172, %174 : i256, !llvm.ptr
+    %175 = llvm.getelementptr %174[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %175, %173 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb30
+  ^bb30:  // pred: ^bb29
+    %c4294967295_i256 = arith.constant 4294967295 : i256
+    %176 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %177 = llvm.load %176 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4294967295_i256, %177 : i256, !llvm.ptr
+    %178 = llvm.getelementptr %177[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %178, %176 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb31
+  ^bb31:  // pred: ^bb30
     %179 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
     %180 = llvm.load %179 : !llvm.ptr -> !llvm.ptr
     %181 = llvm.getelementptr %180[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %182 = llvm.load %181 : !llvm.ptr -> i256
     llvm.store %181, %179 : !llvm.ptr, !llvm.ptr
-    %c0_i256_24 = arith.constant 0 : i256
-    %183 = arith.trunci %162 : i256 to i64
-    %184 = arith.trunci %170 : i256 to i64
-    %185 = arith.trunci %174 : i256 to i64
-    %186 = arith.trunci %178 : i256 to i64
-    %187 = arith.trunci %182 : i256 to i64
-    %188 = arith.addi %184, %185 : i64
-    %189 = arith.addi %186, %187 : i64
-    %190 = arith.maxui %188, %189 : i64
-    %c0_i64_25 = arith.constant 0 : i64
-    %191 = arith.cmpi slt, %190, %c0_i64_25 : i64
-    %c84_i8_26 = arith.constant 84 : i8
-    cf.cond_br %191, ^bb1(%c84_i8_26 : i8), ^bb28
-  ^bb28:  // pred: ^bb27
-    %192 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %193 = llvm.load %192 : !llvm.ptr -> i64
-    %c31_i64_27 = arith.constant 31 : i64
-    %c32_i64_28 = arith.constant 32 : i64
-    %194 = arith.addi %190, %c31_i64_27 : i64
-    %195 = arith.divui %194, %c32_i64_28 : i64
-    %196 = arith.muli %195, %c32_i64_28 : i64
-    %197 = arith.cmpi ult, %193, %196 : i64
-    scf.if %197 {
-      %219 = func.call @dora_fn_extend_memory(%arg0, %196) : (!llvm.ptr, i64) -> !llvm.ptr
-      %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
-      llvm.store %196, %192 : i64, !llvm.ptr
-      %222 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %221, %222 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %198 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %199 = llvm.load %198 : !llvm.ptr -> i64
-    %c1_i256_29 = arith.constant 1 : i256
-    %200 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_24, %200 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_30 = arith.constant 1 : i256
-    %201 = llvm.alloca %c1_i256_30 x i256 : (i256) -> !llvm.ptr
-    llvm.store %166, %201 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_31 = arith.constant 1 : i64
-    %202 = llvm.alloca %c1_i64_31 x i64 : (i64) -> !llvm.ptr
-    %c0_i8_32 = arith.constant 0 : i8
-    %203 = call @dora_fn_call(%arg0, %183, %201, %200, %184, %185, %186, %187, %199, %202, %c0_i8_32) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %204 = llvm.getelementptr %203[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %205 = llvm.load %204 : !llvm.ptr -> i8
-    %206 = llvm.load %202 : !llvm.ptr -> i64
-    %207 = arith.extui %205 : i8 to i256
-    %208 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %209 = llvm.load %208 : !llvm.ptr -> !llvm.ptr
-    llvm.store %207, %209 : i256, !llvm.ptr
-    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %210, %208 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb29
-  ^bb29:  // pred: ^bb28
-    %211 = call @dora_fn_return_data_size(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %212 = llvm.getelementptr %211[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %213 = llvm.load %212 : !llvm.ptr -> i64
-    %214 = arith.extui %213 : i64 to i256
-    %215 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
-    llvm.store %214, %216 : i256, !llvm.ptr
-    %217 = llvm.getelementptr %216[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %217, %215 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb30
-  ^bb30:  // pred: ^bb29
-    %c0_i64_33 = arith.constant 0 : i64
+    %183 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %184 = llvm.load %183 : !llvm.ptr -> !llvm.ptr
+    %185 = llvm.getelementptr %184[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %186 = llvm.load %185 : !llvm.ptr -> i256
+    llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
+    %187 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %188 = llvm.load %187 : !llvm.ptr -> !llvm.ptr
+    %189 = llvm.getelementptr %188[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %190 = llvm.load %189 : !llvm.ptr -> i256
+    llvm.store %189, %187 : !llvm.ptr, !llvm.ptr
+    %191 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %192 = llvm.load %191 : !llvm.ptr -> !llvm.ptr
+    %193 = llvm.getelementptr %192[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %194 = llvm.load %193 : !llvm.ptr -> i256
+    llvm.store %193, %191 : !llvm.ptr, !llvm.ptr
+    %195 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %196 = llvm.load %195 : !llvm.ptr -> !llvm.ptr
+    %197 = llvm.getelementptr %196[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %198 = llvm.load %197 : !llvm.ptr -> i256
+    llvm.store %197, %195 : !llvm.ptr, !llvm.ptr
+    %199 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %200 = llvm.load %199 : !llvm.ptr -> !llvm.ptr
+    %201 = llvm.getelementptr %200[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %202 = llvm.load %201 : !llvm.ptr -> i256
+    llvm.store %201, %199 : !llvm.ptr, !llvm.ptr
+    %c0_i256_28 = arith.constant 0 : i256
+    %203 = arith.trunci %182 : i256 to i64
+    %204 = arith.trunci %190 : i256 to i64
+    %205 = arith.trunci %194 : i256 to i64
+    %206 = arith.trunci %198 : i256 to i64
+    %207 = arith.trunci %202 : i256 to i64
+    %208 = arith.addi %204, %205 : i64
+    %209 = arith.addi %206, %207 : i64
+    %210 = arith.maxui %208, %209 : i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %211 = arith.cmpi slt, %210, %c0_i64_29 : i64
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %211, ^bb1(%c84_i8_30 : i8), ^bb32
+  ^bb32:  // pred: ^bb31
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %212 = arith.addi %210, %c31_i64_31 : i64
+    %213 = arith.divui %212, %c32_i64_32 : i64
+    %214 = arith.muli %213, %c32_i64_32 : i64
+    %215 = call @dora_fn_extend_memory(%arg0, %214) : (!llvm.ptr, i64) -> !llvm.ptr
+    %216 = llvm.getelementptr %215[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
+    %218 = llvm.getelementptr %215[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %219 = llvm.load %218 : !llvm.ptr -> i8
+    %c0_i8_33 = arith.constant 0 : i8
+    %220 = arith.cmpi ne, %219, %c0_i8_33 : i8
+    cf.cond_br %220, ^bb1(%219 : i8), ^bb33
+  ^bb33:  // pred: ^bb32
+    %221 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %217, %221 : !llvm.ptr, !llvm.ptr
+    %222 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %214, %222 : i64, !llvm.ptr
+    %223 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %224 = llvm.load %223 : !llvm.ptr -> i64
+    %c1_i256_34 = arith.constant 1 : i256
+    %225 = llvm.alloca %c1_i256_34 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_28, %225 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_35 = arith.constant 1 : i256
+    %226 = llvm.alloca %c1_i256_35 x i256 : (i256) -> !llvm.ptr
+    llvm.store %186, %226 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_36 = arith.constant 1 : i64
+    %227 = llvm.alloca %c1_i64_36 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_37 = arith.constant 0 : i8
+    %228 = call @dora_fn_call(%arg0, %203, %226, %225, %204, %205, %206, %207, %224, %227, %c0_i8_37) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %229 = llvm.getelementptr %228[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %230 = llvm.load %229 : !llvm.ptr -> i8
+    %231 = llvm.load %227 : !llvm.ptr -> i64
+    %232 = arith.extui %230 : i8 to i256
+    %233 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %234 = llvm.load %233 : !llvm.ptr -> !llvm.ptr
+    llvm.store %232, %234 : i256, !llvm.ptr
+    %235 = llvm.getelementptr %234[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %235, %233 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb34
+  ^bb34:  // pred: ^bb33
+    %236 = call @dora_fn_return_data_size(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %237 = llvm.getelementptr %236[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %238 = llvm.load %237 : !llvm.ptr -> i64
+    %239 = arith.extui %238 : i64 to i256
+    %240 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %241 = llvm.load %240 : !llvm.ptr -> !llvm.ptr
+    llvm.store %239, %241 : i256, !llvm.ptr
+    %242 = llvm.getelementptr %241[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %242, %240 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb35
+  ^bb35:  // pred: ^bb34
+    %c0_i64_38 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %218 = call @dora_fn_write_result(%arg0, %c0_i64_33, %c0_i64_33, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %243 = call @dora_fn_write_result(%arg0, %c0_i64_38, %c0_i64_38, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_keccak256.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_keccak256.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb9
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,95 +120,97 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %71 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %72 = llvm.getelementptr %71[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %74 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %73, %74 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c4_i256 = arith.constant 4 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c4_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i256_4 = arith.constant 0 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c4_i256 = arith.constant 4 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %55 = arith.trunci %53 : i256 to i64
-    %56 = arith.addi %54, %55 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %57 = arith.cmpi slt, %56, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8_6 : i8), ^bb10
+    %c0_i256_4 = arith.constant 0 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %58 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %59 = llvm.load %58 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %60 = arith.trunci %58 : i256 to i64
+    %61 = arith.addi %59, %60 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %62 = arith.cmpi slt, %61, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %62, ^bb1(%c84_i8_6 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %60 = arith.addi %56, %c31_i64_7 : i64
-    %61 = arith.divui %60, %c32_i64_8 : i64
-    %62 = arith.muli %61, %c32_i64_8 : i64
-    %63 = arith.cmpi ult, %59, %62 : i64
-    scf.if %63 {
-      %71 = func.call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
-      %72 = llvm.getelementptr %71[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
-      llvm.store %62, %58 : i64, !llvm.ptr
-      %74 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %73, %74 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c1_i256 = arith.constant 1 : i256
-    %64 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    %65 = call @dora_fn_keccak256_hasher(%arg0, %54, %55, %64) : (!llvm.ptr, i64, i64, !llvm.ptr) -> !llvm.ptr
-    %66 = llvm.load %64 : !llvm.ptr -> i256
-    %67 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = arith.addi %61, %c31_i64_7 : i64
+    %64 = arith.divui %63, %c32_i64_8 : i64
+    %65 = arith.muli %64, %c32_i64_8 : i64
+    %66 = call @dora_fn_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+    %67 = llvm.getelementptr %66[16] : (!llvm.ptr) -> !llvm.ptr, i8
     %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
-    llvm.store %66, %68 : i256, !llvm.ptr
-    %69 = llvm.getelementptr %68[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %69, %67 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb11
-  ^bb11:  // pred: ^bb10
-    %c0_i64_9 = arith.constant 0 : i64
+    %69 = llvm.getelementptr %66[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = llvm.load %69 : !llvm.ptr -> i8
+    %c0_i8_9 = arith.constant 0 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8_9 : i8
+    cf.cond_br %71, ^bb1(%70 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
+    %72 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %68, %72 : !llvm.ptr, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %65, %73 : i64, !llvm.ptr
+    %c1_i256 = arith.constant 1 : i256
+    %74 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    %75 = call @dora_fn_keccak256_hasher(%arg0, %59, %60, %74) : (!llvm.ptr, i64, i64, !llvm.ptr) -> !llvm.ptr
+    %76 = llvm.load %74 : !llvm.ptr -> i256
+    %77 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
+    llvm.store %76, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %77 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb13
+  ^bb13:  // pred: ^bb12
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %70 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %80 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mcopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mcopy.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb10
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb11, ^bb12
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,107 +120,109 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %79 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %80 = llvm.getelementptr %79[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %82 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %81, %82 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c32_i256_4 = arith.constant 32 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c32_i256_5 = arith.constant 32 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_5, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c32_i256_4 = arith.constant 32 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i256 = arith.constant 0 : i256
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256, %47 : i256, !llvm.ptr
-    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
+    %c32_i256_5 = arith.constant 32 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_5, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %49 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> !llvm.ptr
-    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    llvm.store %51, %49 : !llvm.ptr, !llvm.ptr
-    %53 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> !llvm.ptr
-    %55 = llvm.getelementptr %54[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %56 = llvm.load %55 : !llvm.ptr -> i256
-    llvm.store %55, %53 : !llvm.ptr, !llvm.ptr
-    %57 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> !llvm.ptr
-    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %60 = llvm.load %59 : !llvm.ptr -> i256
-    llvm.store %59, %57 : !llvm.ptr, !llvm.ptr
-    %61 = arith.trunci %52 : i256 to i64
-    %62 = arith.trunci %56 : i256 to i64
-    %63 = arith.trunci %60 : i256 to i64
-    %64 = arith.addi %62, %63 : i64
-    %65 = arith.addi %61, %63 : i64
-    %66 = arith.maxui %64, %65 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %67 = arith.cmpi slt, %66, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %67, ^bb1(%c84_i8_7 : i8), ^bb11
+    %c0_i256 = arith.constant 0 : i256
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb11
   ^bb11:  // pred: ^bb10
-    %68 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %69 = llvm.load %68 : !llvm.ptr -> i64
+    %54 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %55 = llvm.load %54 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %54 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %59 = llvm.load %58 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %58 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %62 : !llvm.ptr, !llvm.ptr
+    %66 = arith.trunci %57 : i256 to i64
+    %67 = arith.trunci %61 : i256 to i64
+    %68 = arith.trunci %65 : i256 to i64
+    %69 = arith.addi %67, %68 : i64
+    %70 = arith.addi %66, %68 : i64
+    %71 = arith.maxui %69, %70 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %72 = arith.cmpi slt, %71, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_7 : i8), ^bb12
+  ^bb12:  // pred: ^bb11
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %70 = arith.addi %66, %c31_i64_8 : i64
-    %71 = arith.divui %70, %c32_i64_9 : i64
-    %72 = arith.muli %71, %c32_i64_9 : i64
-    %73 = arith.cmpi ult, %69, %72 : i64
-    scf.if %73 {
-      %79 = func.call @dora_fn_extend_memory(%arg0, %72) : (!llvm.ptr, i64) -> !llvm.ptr
-      %80 = llvm.getelementptr %79[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-      llvm.store %72, %68 : i64, !llvm.ptr
-      %82 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %81, %82 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %74 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %75 = llvm.load %74 : !llvm.ptr -> !llvm.ptr
-    %76 = llvm.getelementptr %75[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %77 = llvm.getelementptr %75[%61] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    "llvm.intr.memmove"(%77, %76, %63) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
-    cf.br ^bb12
-  ^bb12:  // pred: ^bb11
-    %c0_i64_10 = arith.constant 0 : i64
+    %73 = arith.addi %71, %c31_i64_8 : i64
+    %74 = arith.divui %73, %c32_i64_9 : i64
+    %75 = arith.muli %74, %c32_i64_9 : i64
+    %76 = call @dora_fn_extend_memory(%arg0, %75) : (!llvm.ptr, i64) -> !llvm.ptr
+    %77 = llvm.getelementptr %76[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %78 = llvm.load %77 : !llvm.ptr -> !llvm.ptr
+    %79 = llvm.getelementptr %76[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %80 = llvm.load %79 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %81 = arith.cmpi ne, %80, %c0_i8_10 : i8
+    cf.cond_br %81, ^bb1(%80 : i8), ^bb13
+  ^bb13:  // pred: ^bb12
+    %82 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %78, %82 : !llvm.ptr, !llvm.ptr
+    %83 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %75, %83 : i64, !llvm.ptr
+    %84 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %85 = llvm.load %84 : !llvm.ptr -> !llvm.ptr
+    %86 = llvm.getelementptr %85[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %87 = llvm.getelementptr %85[%66] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    "llvm.intr.memmove"(%87, %86, %68) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    cf.br ^bb14
+  ^bb14:  // pred: ^bb13
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %88 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mload.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb8
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,83 +120,85 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c0_i256_4 = arith.constant 0 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    %45 = llvm.getelementptr %44[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
-    %47 = arith.trunci %46 : i256 to i64
-    %c32_i64_5 = arith.constant 32 : i64
-    %48 = arith.addi %47, %c32_i64_5 : i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %49 = arith.cmpi slt, %48, %c0_i64_6 : i64
-    %c84_i8_7 = arith.constant 84 : i8
-    cf.cond_br %49, ^bb1(%c84_i8_7 : i8), ^bb9
+    %c0_i256_4 = arith.constant 0 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %50 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i64
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    %50 = llvm.getelementptr %49[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %51 = llvm.load %50 : !llvm.ptr -> i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    %52 = arith.trunci %51 : i256 to i64
+    %c32_i64_5 = arith.constant 32 : i64
+    %53 = arith.addi %52, %c32_i64_5 : i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %54 = arith.cmpi slt, %53, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %54, ^bb1(%c84_i8_7 : i8), ^bb10
+  ^bb10:  // pred: ^bb9
     %c31_i64_8 = arith.constant 31 : i64
     %c32_i64_9 = arith.constant 32 : i64
-    %52 = arith.addi %48, %c31_i64_8 : i64
-    %53 = arith.divui %52, %c32_i64_9 : i64
-    %54 = arith.muli %53, %c32_i64_9 : i64
-    %55 = arith.cmpi ult, %51, %54 : i64
-    scf.if %55 {
-      %65 = func.call @dora_fn_extend_memory(%arg0, %54) : (!llvm.ptr, i64) -> !llvm.ptr
-      %66 = llvm.getelementptr %65[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
-      llvm.store %54, %50 : i64, !llvm.ptr
-      %68 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %67, %68 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %56 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %57 = llvm.load %56 : !llvm.ptr -> !llvm.ptr
-    %58 = llvm.getelementptr %57[%47] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %59 = llvm.load %58 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %60 = llvm.intr.bswap(%59)  : (i256) -> i256
-    %61 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %62 = llvm.load %61 : !llvm.ptr -> !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
-    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %63, %61 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb10
-  ^bb10:  // pred: ^bb9
-    %c0_i64_10 = arith.constant 0 : i64
+    %55 = arith.addi %53, %c31_i64_8 : i64
+    %56 = arith.divui %55, %c32_i64_9 : i64
+    %57 = arith.muli %56, %c32_i64_9 : i64
+    %58 = call @dora_fn_extend_memory(%arg0, %57) : (!llvm.ptr, i64) -> !llvm.ptr
+    %59 = llvm.getelementptr %58[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %60 = llvm.load %59 : !llvm.ptr -> !llvm.ptr
+    %61 = llvm.getelementptr %58[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %62 = llvm.load %61 : !llvm.ptr -> i8
+    %c0_i8_10 = arith.constant 0 : i8
+    %63 = arith.cmpi ne, %62, %c0_i8_10 : i8
+    cf.cond_br %63, ^bb1(%62 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
+    %64 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %60, %64 : !llvm.ptr, !llvm.ptr
+    %65 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %57, %65 : i64, !llvm.ptr
+    %66 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %67 = llvm.load %66 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %69 = llvm.load %68 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %70 = llvm.intr.bswap(%69)  : (i256) -> i256
+    %71 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %72 = llvm.load %71 : !llvm.ptr -> !llvm.ptr
+    llvm.store %70, %72 : i256, !llvm.ptr
+    %73 = llvm.getelementptr %72[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %73, %71 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
+  ^bb12:  // pred: ^bb11
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %74 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_revert.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_revert.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb9
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,92 +120,94 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %68 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %70, %71 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c2_i256 = arith.constant 2 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c2_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i256_4 = arith.constant 0 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c2_i256 = arith.constant 2 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %55 = arith.trunci %53 : i256 to i64
-    %56 = arith.addi %54, %55 : i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %57 = arith.cmpi slt, %56, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8_6 : i8), ^bb10
+    %c0_i256_4 = arith.constant 0 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %58 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %59 = llvm.load %58 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %60 = arith.trunci %58 : i256 to i64
+    %61 = arith.addi %59, %60 : i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %62 = arith.cmpi slt, %61, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %62, ^bb1(%c84_i8_6 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %60 = arith.addi %56, %c31_i64_7 : i64
-    %61 = arith.divui %60, %c32_i64_8 : i64
-    %62 = arith.muli %61, %c32_i64_8 : i64
-    %63 = arith.cmpi ult, %59, %62 : i64
-    scf.if %63 {
-      %68 = func.call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
-      %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-      llvm.store %62, %58 : i64, !llvm.ptr
-      %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %70, %71 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %64 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i64
-    %c16_i8 = arith.constant 16 : i8
-    %66 = call @dora_fn_write_result(%arg0, %54, %55, %65, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
-    return %c16_i8 : i8
-  ^bb11:  // no predecessors
-    cf.br ^bb12
+    %63 = arith.addi %61, %c31_i64_7 : i64
+    %64 = arith.divui %63, %c32_i64_8 : i64
+    %65 = arith.muli %64, %c32_i64_8 : i64
+    %66 = call @dora_fn_extend_memory(%arg0, %65) : (!llvm.ptr, i64) -> !llvm.ptr
+    %67 = llvm.getelementptr %66[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %68 = llvm.load %67 : !llvm.ptr -> !llvm.ptr
+    %69 = llvm.getelementptr %66[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = llvm.load %69 : !llvm.ptr -> i8
+    %c0_i8_9 = arith.constant 0 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8_9 : i8
+    cf.cond_br %71, ^bb1(%70 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i64_9 = arith.constant 0 : i64
+    %72 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %68, %72 : !llvm.ptr, !llvm.ptr
+    %73 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %65, %73 : i64, !llvm.ptr
+    %74 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %75 = llvm.load %74 : !llvm.ptr -> i64
+    %c16_i8 = arith.constant 16 : i8
+    %76 = call @dora_fn_write_result(%arg0, %59, %60, %75, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    return %c16_i8 : i8
+  ^bb13:  // no predecessors
+    cf.br ^bb14
+  ^bb14:  // pred: ^bb13
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %67 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %77 = call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -122,32 +122,33 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %32, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %33 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %34 = llvm.load %33 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %35 = arith.addi %29, %c31_i64 : i64
-    %36 = arith.divui %35, %c32_i64 : i64
-    %37 = arith.muli %36, %c32_i64 : i64
-    %38 = arith.cmpi ult, %34, %37 : i64
-    scf.if %38 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %37) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %37, %33 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
+    %33 = arith.addi %29, %c31_i64 : i64
+    %34 = arith.divui %33, %c32_i64 : i64
+    %35 = arith.muli %34, %c32_i64 : i64
+    %36 = call @dora_fn_extend_memory(%arg0, %35) : (!llvm.ptr, i64) -> !llvm.ptr
+    %37 = llvm.getelementptr %36[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %38 = llvm.load %37 : !llvm.ptr -> !llvm.ptr
+    %39 = llvm.getelementptr %36[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %40 = llvm.load %39 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %39 = call @dora_fn_write_result(%arg0, %27, %28, %31, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
-    return %c0_i8 : i8
-  ^bb7:  // no predecessors
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
-    %c0_i64_3 = arith.constant 0 : i64
+    %41 = arith.cmpi ne, %40, %c0_i8 : i8
+    cf.cond_br %41, ^bb1(%40 : i8), ^bb7
+  ^bb7:  // pred: ^bb6
+    %42 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %38, %42 : !llvm.ptr, !llvm.ptr
+    %43 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %35, %43 : i64, !llvm.ptr
+    %c0_i8_3 = arith.constant 0 : i8
+    %44 = call @dora_fn_write_result(%arg0, %27, %28, %31, %c0_i8_3) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    return %c0_i8_3 : i8
+  ^bb8:  // no predecessors
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return_large_data.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return_large_data.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -122,32 +122,33 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %32, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %33 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %34 = llvm.load %33 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %35 = arith.addi %29, %c31_i64 : i64
-    %36 = arith.divui %35, %c32_i64 : i64
-    %37 = arith.muli %36, %c32_i64 : i64
-    %38 = arith.cmpi ult, %34, %37 : i64
-    scf.if %38 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %37) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %37, %33 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
+    %33 = arith.addi %29, %c31_i64 : i64
+    %34 = arith.divui %33, %c32_i64 : i64
+    %35 = arith.muli %34, %c32_i64 : i64
+    %36 = call @dora_fn_extend_memory(%arg0, %35) : (!llvm.ptr, i64) -> !llvm.ptr
+    %37 = llvm.getelementptr %36[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %38 = llvm.load %37 : !llvm.ptr -> !llvm.ptr
+    %39 = llvm.getelementptr %36[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %40 = llvm.load %39 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %39 = call @dora_fn_write_result(%arg0, %27, %28, %31, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
-    return %c0_i8 : i8
-  ^bb7:  // no predecessors
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
-    %c0_i64_3 = arith.constant 0 : i64
+    %41 = arith.cmpi ne, %40, %c0_i8 : i8
+    cf.cond_br %41, ^bb1(%40 : i8), ^bb7
+  ^bb7:  // pred: ^bb6
+    %42 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %38, %42 : !llvm.ptr, !llvm.ptr
+    %43 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %35, %43 : i64, !llvm.ptr
+    %c0_i8_3 = arith.constant 0 : i8
+    %44 = call @dora_fn_write_result(%arg0, %27, %28, %31, %c0_i8_3) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    return %c0_i8_3 : i8
+  ^bb8:  // no predecessors
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,34 +120,35 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %30, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %31 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %32 = llvm.load %31 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %33 = arith.addi %29, %c31_i64 : i64
-    %34 = arith.divui %33, %c32_i64 : i64
-    %35 = arith.muli %34, %c32_i64 : i64
-    %36 = arith.cmpi ult, %32, %35 : i64
-    scf.if %36 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %35) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %35, %31 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %37 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %38 = llvm.load %37 : !llvm.ptr -> i64
+    %31 = arith.addi %29, %c31_i64 : i64
+    %32 = arith.divui %31, %c32_i64 : i64
+    %33 = arith.muli %32, %c32_i64 : i64
+    %34 = call @dora_fn_extend_memory(%arg0, %33) : (!llvm.ptr, i64) -> !llvm.ptr
+    %35 = llvm.getelementptr %34[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %36 = llvm.load %35 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %34[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %38 = llvm.load %37 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %39 = arith.cmpi ne, %38, %c0_i8 : i8
+    cf.cond_br %39, ^bb1(%38 : i8), ^bb7
+  ^bb7:  // pred: ^bb6
+    %40 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %36, %40 : !llvm.ptr, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %33, %41 : i64, !llvm.ptr
+    %42 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %43 = llvm.load %42 : !llvm.ptr -> i64
     %c16_i8 = arith.constant 16 : i8
-    %39 = call @dora_fn_write_result(%arg0, %27, %28, %38, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %44 = call @dora_fn_write_result(%arg0, %27, %28, %43, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c16_i8 : i8
-  ^bb7:  // no predecessors
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
+  ^bb8:  // no predecessors
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert_large_data.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert_large_data.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb5
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb6
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,34 +120,35 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %30, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %31 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %32 = llvm.load %31 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %33 = arith.addi %29, %c31_i64 : i64
-    %34 = arith.divui %33, %c32_i64 : i64
-    %35 = arith.muli %34, %c32_i64 : i64
-    %36 = arith.cmpi ult, %32, %35 : i64
-    scf.if %36 {
-      %41 = func.call @dora_fn_extend_memory(%arg0, %35) : (!llvm.ptr, i64) -> !llvm.ptr
-      %42 = llvm.getelementptr %41[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %43 = llvm.load %42 : !llvm.ptr -> !llvm.ptr
-      llvm.store %35, %31 : i64, !llvm.ptr
-      %44 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %43, %44 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %37 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %38 = llvm.load %37 : !llvm.ptr -> i64
+    %31 = arith.addi %29, %c31_i64 : i64
+    %32 = arith.divui %31, %c32_i64 : i64
+    %33 = arith.muli %32, %c32_i64 : i64
+    %34 = call @dora_fn_extend_memory(%arg0, %33) : (!llvm.ptr, i64) -> !llvm.ptr
+    %35 = llvm.getelementptr %34[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %36 = llvm.load %35 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %34[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %38 = llvm.load %37 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %39 = arith.cmpi ne, %38, %c0_i8 : i8
+    cf.cond_br %39, ^bb1(%38 : i8), ^bb7
+  ^bb7:  // pred: ^bb6
+    %40 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %36, %40 : !llvm.ptr, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %33, %41 : i64, !llvm.ptr
+    %42 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %43 = llvm.load %42 : !llvm.ptr -> i64
     %c16_i8 = arith.constant 16 : i8
-    %39 = call @dora_fn_write_result(%arg0, %27, %28, %38, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %44 = call @dora_fn_write_result(%arg0, %27, %28, %43, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c16_i8 : i8
-  ^bb7:  // no predecessors
-    cf.br ^bb8
-  ^bb8:  // pred: ^bb7
+  ^bb8:  // no predecessors
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %45 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb9
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -178,49 +178,50 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %63, ^bb1(%c84_i8 : i8), ^bb10
   ^bb10:  // pred: ^bb9
-    %64 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %66 = arith.addi %62, %c31_i64 : i64
-    %67 = arith.divui %66, %c32_i64 : i64
-    %68 = arith.muli %67, %c32_i64 : i64
-    %69 = arith.cmpi ult, %65, %68 : i64
-    scf.if %69 {
-      %84 = func.call @dora_fn_extend_memory(%arg0, %68) : (!llvm.ptr, i64) -> !llvm.ptr
-      %85 = llvm.getelementptr %84[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
-      llvm.store %68, %64 : i64, !llvm.ptr
-      %87 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %86, %87 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %70 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> i64
-    %c1_i256 = arith.constant 1 : i256
-    %72 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256, %72 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_5 = arith.constant 1 : i256
-    %73 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
-    llvm.store %38, %73 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64 = arith.constant 1 : i64
-    %74 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %64 = arith.addi %62, %c31_i64 : i64
+    %65 = arith.divui %64, %c32_i64 : i64
+    %66 = arith.muli %65, %c32_i64 : i64
+    %67 = call @dora_fn_extend_memory(%arg0, %66) : (!llvm.ptr, i64) -> !llvm.ptr
+    %68 = llvm.getelementptr %67[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> !llvm.ptr
+    %70 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %71 = llvm.load %70 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %75 = call @dora_fn_call(%arg0, %55, %73, %72, %56, %57, %58, %59, %71, %74, %c0_i8) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %77 = llvm.load %76 : !llvm.ptr -> i8
-    %78 = llvm.load %74 : !llvm.ptr -> i64
-    %79 = arith.extui %77 : i8 to i256
-    %80 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
-    %82 = llvm.getelementptr %81[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %82, %80 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb11
+    %72 = arith.cmpi ne, %71, %c0_i8 : i8
+    cf.cond_br %72, ^bb1(%71 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i64_6 = arith.constant 0 : i64
+    %73 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %69, %73 : !llvm.ptr, !llvm.ptr
+    %74 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %66, %74 : i64, !llvm.ptr
+    %75 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %76 = llvm.load %75 : !llvm.ptr -> i64
+    %c1_i256 = arith.constant 1 : i256
+    %77 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256, %77 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_5 = arith.constant 1 : i256
+    %78 = llvm.alloca %c1_i256_5 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64 = arith.constant 1 : i64
+    %79 = llvm.alloca %c1_i64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_6 = arith.constant 0 : i8
+    %80 = call @dora_fn_call(%arg0, %55, %78, %77, %56, %57, %58, %59, %76, %79, %c0_i8_6) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %81 = llvm.getelementptr %80[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %82 = llvm.load %81 : !llvm.ptr -> i8
+    %83 = llvm.load %79 : !llvm.ptr -> i64
+    %84 = arith.extui %82 : i8 to i256
+    %85 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %86 = llvm.load %85 : !llvm.ptr -> !llvm.ptr
+    llvm.store %84, %86 : i256, !llvm.ptr
+    %87 = llvm.getelementptr %86[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %87, %85 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
+  ^bb12:  // pred: ^bb11
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %83 = call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %88 = call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_store_return.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_store_return.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb5, ^bb9
+  ^bb1(%10: i8):  // 5 preds: ^bb2, ^bb5, ^bb6, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -120,92 +120,94 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb6
   ^bb6:  // pred: ^bb5
-    %30 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %31 = llvm.load %30 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64_3 = arith.constant 32 : i64
-    %32 = arith.addi %28, %c31_i64 : i64
-    %33 = arith.divui %32, %c32_i64_3 : i64
-    %34 = arith.muli %33, %c32_i64_3 : i64
-    %35 = arith.cmpi ult, %31, %34 : i64
-    scf.if %35 {
-      %68 = func.call @dora_fn_extend_memory(%arg0, %34) : (!llvm.ptr, i64) -> !llvm.ptr
-      %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-      llvm.store %34, %30 : i64, !llvm.ptr
-      %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %70, %71 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %36 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> !llvm.ptr
-    %38 = llvm.getelementptr %37[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %39 = llvm.intr.bswap(%26)  : (i256) -> i256
-    llvm.store %39, %38 {alignment = 1 : i64} : i256, !llvm.ptr
-    cf.br ^bb7
+    %30 = arith.addi %28, %c31_i64 : i64
+    %31 = arith.divui %30, %c32_i64_3 : i64
+    %32 = arith.muli %31, %c32_i64_3 : i64
+    %33 = call @dora_fn_extend_memory(%arg0, %32) : (!llvm.ptr, i64) -> !llvm.ptr
+    %34 = llvm.getelementptr %33[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %35 = llvm.load %34 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %33[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
+    cf.cond_br %38, ^bb1(%37 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %c2_i256 = arith.constant 2 : i256
-    %40 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c2_i256, %41 : i256, !llvm.ptr
-    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %42, %40 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %35, %39 : !llvm.ptr, !llvm.ptr
+    %40 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %32, %40 : i64, !llvm.ptr
+    %41 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %42 = llvm.load %41 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %44 = llvm.intr.bswap(%26)  : (i256) -> i256
+    llvm.store %44, %43 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb8
   ^bb8:  // pred: ^bb7
-    %c0_i256_4 = arith.constant 0 : i256
-    %43 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_4, %44 : i256, !llvm.ptr
-    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %45, %43 : !llvm.ptr, !llvm.ptr
+    %c2_i256 = arith.constant 2 : i256
+    %45 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %46 = llvm.load %45 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %45 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb9:  // pred: ^bb8
-    %46 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %47 = llvm.load %46 : !llvm.ptr -> !llvm.ptr
-    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    llvm.store %48, %46 : !llvm.ptr, !llvm.ptr
-    %50 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> !llvm.ptr
-    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %53 = llvm.load %52 : !llvm.ptr -> i256
-    llvm.store %52, %50 : !llvm.ptr, !llvm.ptr
-    %54 = arith.trunci %49 : i256 to i64
-    %55 = arith.trunci %53 : i256 to i64
-    %56 = arith.addi %55, %54 : i64
-    %57 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %59 = arith.cmpi slt, %56, %c0_i64_5 : i64
-    %c84_i8_6 = arith.constant 84 : i8
-    cf.cond_br %59, ^bb1(%c84_i8_6 : i8), ^bb10
+    %c0_i256_4 = arith.constant 0 : i256
+    %48 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %49 : i256, !llvm.ptr
+    %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %50, %48 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb10
   ^bb10:  // pred: ^bb9
-    %60 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i64
+    %51 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %52 = llvm.load %51 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %51 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %56 = llvm.load %55 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %55 : !llvm.ptr, !llvm.ptr
+    %59 = arith.trunci %54 : i256 to i64
+    %60 = arith.trunci %58 : i256 to i64
+    %61 = arith.addi %60, %59 : i64
+    %62 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %63 = llvm.load %62 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %64 = arith.cmpi slt, %61, %c0_i64_5 : i64
+    %c84_i8_6 = arith.constant 84 : i8
+    cf.cond_br %64, ^bb1(%c84_i8_6 : i8), ^bb11
+  ^bb11:  // pred: ^bb10
     %c31_i64_7 = arith.constant 31 : i64
     %c32_i64_8 = arith.constant 32 : i64
-    %62 = arith.addi %56, %c31_i64_7 : i64
-    %63 = arith.divui %62, %c32_i64_8 : i64
-    %64 = arith.muli %63, %c32_i64_8 : i64
-    %65 = arith.cmpi ult, %61, %64 : i64
-    scf.if %65 {
-      %68 = func.call @dora_fn_extend_memory(%arg0, %64) : (!llvm.ptr, i64) -> !llvm.ptr
-      %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
-      llvm.store %64, %60 : i64, !llvm.ptr
-      %71 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %70, %71 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %c0_i8 = arith.constant 0 : i8
-    %66 = call @dora_fn_write_result(%arg0, %54, %55, %58, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
-    return %c0_i8 : i8
-  ^bb11:  // no predecessors
-    cf.br ^bb12
+    %65 = arith.addi %61, %c31_i64_7 : i64
+    %66 = arith.divui %65, %c32_i64_8 : i64
+    %67 = arith.muli %66, %c32_i64_8 : i64
+    %68 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
+    %69 = llvm.getelementptr %68[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = llvm.load %69 : !llvm.ptr -> !llvm.ptr
+    %71 = llvm.getelementptr %68[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %72 = llvm.load %71 : !llvm.ptr -> i8
+    %c0_i8_9 = arith.constant 0 : i8
+    %73 = arith.cmpi ne, %72, %c0_i8_9 : i8
+    cf.cond_br %73, ^bb1(%72 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i64_9 = arith.constant 0 : i64
+    %74 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %70, %74 : !llvm.ptr, !llvm.ptr
+    %75 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %67, %75 : i64, !llvm.ptr
+    %c0_i8_10 = arith.constant 0 : i8
+    %76 = call @dora_fn_write_result(%arg0, %59, %60, %63, %c0_i8_10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    return %c0_i8_10 : i8
+  ^bb13:  // no predecessors
+    cf.br ^bb14
+  ^bb14:  // pred: ^bb13
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %67 = call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %77 = call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_basic.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,29 +134,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %47 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %48 = llvm.getelementptr %47[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %49, %50 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = call @dora_fn_return_data_copy(%arg0, %34, %35, %36) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
   ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = call @dora_fn_return_data_copy(%arg0, %34, %35, %36) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %51 = call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_out_of_bounds.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,29 +134,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %47 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %48 = llvm.getelementptr %47[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %49, %50 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = call @dora_fn_return_data_copy(%arg0, %34, %35, %36) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
   ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = call @dora_fn_return_data_copy(%arg0, %34, %35, %36) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %51 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_partial.snap
@@ -76,7 +76,7 @@ module {
     %9 = llvm.mlir.addressof @dora_global_stack_length : !llvm.ptr
     %c1024_i64 = arith.constant 1024 : i64
     cf.br ^bb3
-  ^bb1(%10: i8):  // 2 preds: ^bb2, ^bb6
+  ^bb1(%10: i8):  // 3 preds: ^bb2, ^bb6, ^bb7
     %c0_i64_1 = arith.constant 0 : i64
     %11 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %10) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %10 : i8
@@ -134,29 +134,30 @@ module {
     %c84_i8 = arith.constant 84 : i8
     cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb7
   ^bb7:  // pred: ^bb6
-    %39 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    %40 = llvm.load %39 : !llvm.ptr -> i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %41 = arith.addi %37, %c31_i64 : i64
-    %42 = arith.divui %41, %c32_i64 : i64
-    %43 = arith.muli %42, %c32_i64 : i64
-    %44 = arith.cmpi ult, %40, %43 : i64
-    scf.if %44 {
-      %47 = func.call @dora_fn_extend_memory(%arg0, %43) : (!llvm.ptr, i64) -> !llvm.ptr
-      %48 = llvm.getelementptr %47[16] : (!llvm.ptr) -> !llvm.ptr, i8
-      %49 = llvm.load %48 : !llvm.ptr -> !llvm.ptr
-      llvm.store %43, %39 : i64, !llvm.ptr
-      %50 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-      llvm.store %49, %50 : !llvm.ptr, !llvm.ptr
-    } else {
-    }
-    %45 = call @dora_fn_return_data_copy(%arg0, %34, %35, %36) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb8
+    %39 = arith.addi %37, %c31_i64 : i64
+    %40 = arith.divui %39, %c32_i64 : i64
+    %41 = arith.muli %40, %c32_i64 : i64
+    %42 = call @dora_fn_extend_memory(%arg0, %41) : (!llvm.ptr, i64) -> !llvm.ptr
+    %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %44 = llvm.load %43 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %46 = llvm.load %45 : !llvm.ptr -> i8
+    %c0_i8 = arith.constant 0 : i8
+    %47 = arith.cmpi ne, %46, %c0_i8 : i8
+    cf.cond_br %47, ^bb1(%46 : i8), ^bb8
   ^bb8:  // pred: ^bb7
+    %48 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %44, %48 : !llvm.ptr, !llvm.ptr
+    %49 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %41, %49 : i64, !llvm.ptr
+    %50 = call @dora_fn_return_data_copy(%arg0, %34, %35, %36) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb9
+  ^bb9:  // pred: ^bb8
     %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %51 = call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }


### PR DESCRIPTION
In the resizing memory process of compiler, we have added a check for runtime memory allocation failures. When memory allocation fails, users will receive a `HaltReason::MemorylimitOOG` error code.

Refs #40 