### PR TITLE
refactor: make opcode not found as runtime halt error

### DIFF
--- a/crates/dora-compiler/src/evm/instructions/control.rs
+++ b/crates/dora-compiler/src/evm/instructions/control.rs
@@ -90,9 +90,18 @@ impl<'c> EVMCompiler<'c> {
         Ok((start_block, empty_block))
     }
 
+    #[inline]
     pub(crate) fn invalid<'r>(
         ctx: &mut CtxType<'c>,
         region: &'r Region<'c>,
+    ) -> Result<(BlockRef<'r, 'c>, BlockRef<'r, 'c>)> {
+        Self::invalid_with_error_code(ctx, region, ExitStatusCode::InvalidFEOpcode)
+    }
+
+    pub(crate) fn invalid_with_error_code<'r>(
+        ctx: &mut CtxType<'c>,
+        region: &'r Region<'c>,
+        error_code: ExitStatusCode,
     ) -> Result<(BlockRef<'r, 'c>, BlockRef<'r, 'c>)> {
         let start_block = region.append_block(Block::new(&[]));
         let empty_block = region.append_block(Block::new(&[]));
@@ -100,7 +109,7 @@ impl<'c> EVMCompiler<'c> {
         builder.invalid();
         start_block.append_operation(cf::br(
             &builder.ctx.revert_block,
-            &[builder.make(builder.iconst_8(ExitStatusCode::InvalidFEOpcode as i8))?],
+            &[builder.make(builder.iconst_8(error_code as i8))?],
             builder.location(),
         ));
         Ok((start_block, empty_block))

--- a/crates/dora-tools/bins/ethertest/main.rs
+++ b/crates/dora-tools/bins/ethertest/main.rs
@@ -374,6 +374,8 @@ fn should_skip(path: &Path) -> bool {
         // JSON big int issue cases: https://github.com/ethereum/tests/issues/971
         "ValueOverflow.json" |
         "ValueOverflowParis.json" |
+        // https://github.com/dp-labs/dora/issues/77
+        "all_opcodes.json" |
         // Attack cases
         "run_until_out_of_gas.json" |
         "ContractCreationSpam.json" |
@@ -398,6 +400,7 @@ fn should_skip(path: &Path) -> bool {
         "createNameRegistratorOutOfMemoryBonds0.json"
     ) || path_str.contains("stEOF")
         || path_str.contains("stBugs")
+        // https://github.com/dp-labs/dora/issues/77
         || path_str.contains("stBadOpcode")
         || path_str.contains("stMemory")
         || path_str.contains("stRandom")

--- a/crates/dora/src/tests/operations.rs
+++ b/crates/dora/src/tests/operations.rs
@@ -1523,6 +1523,24 @@ fn returndatasize() {
 }
 
 #[test]
+fn returndataload() {
+    let operations = vec![
+        Operation::Push((1_u8, BigUint::from(0_u8))),
+        // Note that RETURNDATALOAD is not found in the CANCUN spec.
+        Operation::ReturnDataLoad,
+        // Return result
+        Operation::Push0,
+        Operation::Mstore,
+        Operation::Push((1, 32_u8.into())),
+        Operation::Push0,
+        Operation::Return,
+    ];
+    let (env, mut db) = default_env_and_db_setup(operations);
+    let result = run_evm(env, db, SpecId::CANCUN).unwrap().result;
+    assert!(result.is_halt());
+}
+
+#[test]
 fn returndatacopy() {
     let operations = vec![
         // size


### PR DESCRIPTION
+ refactor: make opcode not found as runtime halt error

Attempting to deploy a contract on the Ethereum network that contains an illegal EVM OPCODE will result in the failure of the contract deployment.  There are specific opcodes that are marked as _invalid_ in different specs. If we try to use these illegal opcodes in a contract, the transaction that deploys the contract will be reverted, and no new contract instance will be created.

Therefore, if we try to deploy a contract that includes these illegal opcodes, the EVM will recognize them and refuse to execute, causing the contract creation transaction to fail while consuming the gas specified in the transaction. This typically results in a loss of funds, as the Ether (ETH) used to deploy the contract is consumed with the failure of the transaction.