### PR TITLE
refactor: record contract create error to the runtime context error

### DIFF
--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 36 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36
+  ^bb1(%13: i8):  // 35 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -361,214 +361,207 @@ module {
     %150 = llvm.alloca %c1_i64_43 x i64 : (i64) -> !llvm.ptr
     llvm.store %149, %150 {alignment = 1 : i64} : i64, !llvm.ptr
     %151 = call @dora_fn_create(%arg0, %132, %130, %147, %150) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %152 = llvm.getelementptr %151[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %152 = llvm.getelementptr %151[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %153 = llvm.load %152 : !llvm.ptr -> i8
-    %154 = llvm.getelementptr %151[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %155 = llvm.load %154 : !llvm.ptr -> i8
     %c0_i8_44 = arith.constant 0 : i8
-    %156 = arith.cmpi ne, %155, %c0_i8_44 : i8
-    cf.cond_br %156, ^bb1(%155 : i8), ^bb23
+    %154 = arith.cmpi ne, %153, %c0_i8_44 : i8
+    cf.cond_br %154, ^bb1(%153 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i8_45 = arith.constant 0 : i8
-    %157 = arith.cmpi ne, %c0_i8_45, %153 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %157, ^bb1(%c94_i8 : i8), ^bb24
+    %155 = llvm.load %147 : !llvm.ptr -> i256
+    %156 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %157 = llvm.load %156 : !llvm.ptr -> !llvm.ptr
+    llvm.store %155, %157 : i256, !llvm.ptr
+    %158 = llvm.getelementptr %157[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
+    %159 = llvm.load %9 : !llvm.ptr -> i64
+    %c0_i64_45 = arith.constant 0 : i64
+    %160 = arith.addi %159, %c0_i64_45 : i64
+    llvm.store %160, %9 : i64, !llvm.ptr
+    %c1_i64_46 = arith.constant 1 : i64
+    %161 = arith.cmpi ult, %159, %c1_i64_46 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %161, ^bb1(%c91_i8_47 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %158 = llvm.load %147 : !llvm.ptr -> i256
-    %159 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %160 = llvm.load %159 : !llvm.ptr -> !llvm.ptr
-    llvm.store %158, %160 : i256, !llvm.ptr
-    %161 = llvm.getelementptr %160[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %161, %159 : !llvm.ptr, !llvm.ptr
-    %162 = llvm.load %9 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
-    %163 = arith.addi %162, %c0_i64_46 : i64
-    llvm.store %163, %9 : i64, !llvm.ptr
-    %c1_i64_47 = arith.constant 1 : i64
-    %164 = arith.cmpi ult, %162, %c1_i64_47 : i64
-    %c91_i8_48 = arith.constant 91 : i8
-    cf.cond_br %164, ^bb1(%c91_i8_48 : i8), ^bb25
+    %162 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %163 = llvm.load %162 : !llvm.ptr -> !llvm.ptr
+    %164 = llvm.getelementptr %163[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %165 = llvm.load %164 : !llvm.ptr -> i256
+    llvm.store %164, %162 : !llvm.ptr, !llvm.ptr
+    %c1_i256_48 = arith.constant 1 : i256
+    %166 = llvm.alloca %c1_i256_48 x i256 : (i256) -> !llvm.ptr
+    llvm.store %165, %166 {alignment = 1 : i64} : i256, !llvm.ptr
+    %167 = call @dora_fn_extcodesize(%arg0, %166) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %168 = llvm.getelementptr %167[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %169 = llvm.load %168 : !llvm.ptr -> i64
+    %170 = arith.extui %169 : i64 to i256
+    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
+    llvm.store %170, %172 : i256, !llvm.ptr
+    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_49 = arith.constant 1 : i64
+    %175 = arith.addi %174, %c1_i64_49 : i64
+    llvm.store %175, %9 : i64, !llvm.ptr
+    %176 = arith.cmpi ult, %c1024_i64, %175 : i64
+    %c92_i8_50 = arith.constant 92 : i8
+    cf.cond_br %176, ^bb1(%c92_i8_50 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %165 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> !llvm.ptr
-    %167 = llvm.getelementptr %166[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %168 = llvm.load %167 : !llvm.ptr -> i256
-    llvm.store %167, %165 : !llvm.ptr, !llvm.ptr
-    %c1_i256_49 = arith.constant 1 : i256
-    %169 = llvm.alloca %c1_i256_49 x i256 : (i256) -> !llvm.ptr
-    llvm.store %168, %169 {alignment = 1 : i64} : i256, !llvm.ptr
-    %170 = call @dora_fn_extcodesize(%arg0, %169) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %171 = llvm.getelementptr %170[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %172 = llvm.load %171 : !llvm.ptr -> i64
-    %173 = arith.extui %172 : i64 to i256
-    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
-    llvm.store %173, %175 : i256, !llvm.ptr
-    %176 = llvm.getelementptr %175[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
-    %177 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_50 = arith.constant 1 : i64
-    %178 = arith.addi %177, %c1_i64_50 : i64
-    llvm.store %178, %9 : i64, !llvm.ptr
-    %179 = arith.cmpi ult, %c1024_i64, %178 : i64
-    %c92_i8_51 = arith.constant 92 : i8
-    cf.cond_br %179, ^bb1(%c92_i8_51 : i8), ^bb26
+    %c0_i256_51 = arith.constant 0 : i256
+    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_51, %178 : i256, !llvm.ptr
+    %179 = llvm.getelementptr %178[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
+    %180 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_52 = arith.constant -2 : i64
+    %181 = arith.addi %180, %c-2_i64_52 : i64
+    llvm.store %181, %9 : i64, !llvm.ptr
+    %c2_i64_53 = arith.constant 2 : i64
+    %182 = arith.cmpi ult, %180, %c2_i64_53 : i64
+    %c91_i8_54 = arith.constant 91 : i8
+    cf.cond_br %182, ^bb1(%c91_i8_54 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i256_52 = arith.constant 0 : i256
-    %180 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %181 = llvm.load %180 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_52, %181 : i256, !llvm.ptr
-    %182 = llvm.getelementptr %181[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %182, %180 : !llvm.ptr, !llvm.ptr
-    %183 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_53 = arith.constant -2 : i64
-    %184 = arith.addi %183, %c-2_i64_53 : i64
-    llvm.store %184, %9 : i64, !llvm.ptr
-    %c2_i64_54 = arith.constant 2 : i64
-    %185 = arith.cmpi ult, %183, %c2_i64_54 : i64
-    %c91_i8_55 = arith.constant 91 : i8
-    cf.cond_br %185, ^bb1(%c91_i8_55 : i8), ^bb27
+    %183 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %184 = llvm.load %183 : !llvm.ptr -> !llvm.ptr
+    %185 = llvm.getelementptr %184[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %186 = llvm.load %185 : !llvm.ptr -> i256
+    llvm.store %185, %183 : !llvm.ptr, !llvm.ptr
+    %187 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %188 = llvm.load %187 : !llvm.ptr -> !llvm.ptr
+    %189 = llvm.getelementptr %188[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %190 = llvm.load %189 : !llvm.ptr -> i256
+    llvm.store %189, %187 : !llvm.ptr, !llvm.ptr
+    %191 = arith.trunci %186 : i256 to i64
+    %c0_i64_55 = arith.constant 0 : i64
+    %192 = arith.cmpi slt, %191, %c0_i64_55 : i64
+    %c84_i8_56 = arith.constant 84 : i8
+    cf.cond_br %192, ^bb1(%c84_i8_56 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
-    %188 = llvm.getelementptr %187[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %189 = llvm.load %188 : !llvm.ptr -> i256
-    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
-    %190 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
-    %192 = llvm.getelementptr %191[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %193 = llvm.load %192 : !llvm.ptr -> i256
-    llvm.store %192, %190 : !llvm.ptr, !llvm.ptr
-    %194 = arith.trunci %189 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %195 = arith.cmpi slt, %194, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %195, ^bb1(%c84_i8_57 : i8), ^bb28
+    %c32_i64_57 = arith.constant 32 : i64
+    %193 = arith.addi %191, %c32_i64_57 : i64
+    %c0_i64_58 = arith.constant 0 : i64
+    %194 = arith.cmpi slt, %193, %c0_i64_58 : i64
+    %c84_i8_59 = arith.constant 84 : i8
+    cf.cond_br %194, ^bb1(%c84_i8_59 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %c32_i64_58 = arith.constant 32 : i64
-    %196 = arith.addi %194, %c32_i64_58 : i64
-    %c0_i64_59 = arith.constant 0 : i64
-    %197 = arith.cmpi slt, %196, %c0_i64_59 : i64
-    %c84_i8_60 = arith.constant 84 : i8
-    cf.cond_br %197, ^bb1(%c84_i8_60 : i8), ^bb29
+    %c31_i64_60 = arith.constant 31 : i64
+    %c32_i64_61 = arith.constant 32 : i64
+    %195 = arith.addi %193, %c31_i64_60 : i64
+    %196 = arith.divui %195, %c32_i64_61 : i64
+    %197 = arith.muli %196, %c32_i64_61 : i64
+    %198 = call @dora_fn_extend_memory(%arg0, %197) : (!llvm.ptr, i64) -> !llvm.ptr
+    %199 = llvm.getelementptr %198[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %200 = llvm.load %199 : !llvm.ptr -> !llvm.ptr
+    %201 = llvm.getelementptr %198[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %202 = llvm.load %201 : !llvm.ptr -> i8
+    %c0_i8_62 = arith.constant 0 : i8
+    %203 = arith.cmpi ne, %202, %c0_i8_62 : i8
+    cf.cond_br %203, ^bb1(%202 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c31_i64_61 = arith.constant 31 : i64
-    %c32_i64_62 = arith.constant 32 : i64
-    %198 = arith.addi %196, %c31_i64_61 : i64
-    %199 = arith.divui %198, %c32_i64_62 : i64
-    %200 = arith.muli %199, %c32_i64_62 : i64
-    %201 = call @dora_fn_extend_memory(%arg0, %200) : (!llvm.ptr, i64) -> !llvm.ptr
-    %202 = llvm.getelementptr %201[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %203 = llvm.load %202 : !llvm.ptr -> !llvm.ptr
-    %204 = llvm.getelementptr %201[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %205 = llvm.load %204 : !llvm.ptr -> i8
-    %c0_i8_63 = arith.constant 0 : i8
-    %206 = arith.cmpi ne, %205, %c0_i8_63 : i8
-    cf.cond_br %206, ^bb1(%205 : i8), ^bb30
+    %204 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %200, %204 : !llvm.ptr, !llvm.ptr
+    %205 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %197, %205 : i64, !llvm.ptr
+    %206 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %207 = llvm.load %206 : !llvm.ptr -> !llvm.ptr
+    %208 = llvm.getelementptr %207[%191] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %209 = llvm.intr.bswap(%190)  : (i256) -> i256
+    llvm.store %209, %208 {alignment = 1 : i64} : i256, !llvm.ptr
+    %210 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_63 = arith.constant 1 : i64
+    %211 = arith.addi %210, %c1_i64_63 : i64
+    llvm.store %211, %9 : i64, !llvm.ptr
+    %212 = arith.cmpi ult, %c1024_i64, %211 : i64
+    %c92_i8_64 = arith.constant 92 : i8
+    cf.cond_br %212, ^bb1(%c92_i8_64 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %207 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %203, %207 : !llvm.ptr, !llvm.ptr
-    %208 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %200, %208 : i64, !llvm.ptr
-    %209 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %210 = llvm.load %209 : !llvm.ptr -> !llvm.ptr
-    %211 = llvm.getelementptr %210[%194] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %212 = llvm.intr.bswap(%193)  : (i256) -> i256
-    llvm.store %212, %211 {alignment = 1 : i64} : i256, !llvm.ptr
-    %213 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_64 = arith.constant 1 : i64
-    %214 = arith.addi %213, %c1_i64_64 : i64
-    llvm.store %214, %9 : i64, !llvm.ptr
-    %215 = arith.cmpi ult, %c1024_i64, %214 : i64
-    %c92_i8_65 = arith.constant 92 : i8
-    cf.cond_br %215, ^bb1(%c92_i8_65 : i8), ^bb31
+    %c32_i256_65 = arith.constant 32 : i256
+    %213 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %214 = llvm.load %213 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_65, %214 : i256, !llvm.ptr
+    %215 = llvm.getelementptr %214[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %215, %213 : !llvm.ptr, !llvm.ptr
+    %216 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_66 = arith.constant 1 : i64
+    %217 = arith.addi %216, %c1_i64_66 : i64
+    llvm.store %217, %9 : i64, !llvm.ptr
+    %218 = arith.cmpi ult, %c1024_i64, %217 : i64
+    %c92_i8_67 = arith.constant 92 : i8
+    cf.cond_br %218, ^bb1(%c92_i8_67 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c32_i256_66 = arith.constant 32 : i256
-    %216 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_66, %217 : i256, !llvm.ptr
-    %218 = llvm.getelementptr %217[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %218, %216 : !llvm.ptr, !llvm.ptr
-    %219 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_67 = arith.constant 1 : i64
-    %220 = arith.addi %219, %c1_i64_67 : i64
-    llvm.store %220, %9 : i64, !llvm.ptr
-    %221 = arith.cmpi ult, %c1024_i64, %220 : i64
-    %c92_i8_68 = arith.constant 92 : i8
-    cf.cond_br %221, ^bb1(%c92_i8_68 : i8), ^bb32
+    %c0_i256_68 = arith.constant 0 : i256
+    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_68, %220 : i256, !llvm.ptr
+    %221 = llvm.getelementptr %220[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
+    %222 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_69 = arith.constant -2 : i64
+    %223 = arith.addi %222, %c-2_i64_69 : i64
+    llvm.store %223, %9 : i64, !llvm.ptr
+    %c2_i64_70 = arith.constant 2 : i64
+    %224 = arith.cmpi ult, %222, %c2_i64_70 : i64
+    %c91_i8_71 = arith.constant 91 : i8
+    cf.cond_br %224, ^bb1(%c91_i8_71 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i256_69 = arith.constant 0 : i256
-    %222 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %223 = llvm.load %222 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_69, %223 : i256, !llvm.ptr
-    %224 = llvm.getelementptr %223[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %224, %222 : !llvm.ptr, !llvm.ptr
-    %225 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_70 = arith.constant -2 : i64
-    %226 = arith.addi %225, %c-2_i64_70 : i64
-    llvm.store %226, %9 : i64, !llvm.ptr
-    %c2_i64_71 = arith.constant 2 : i64
-    %227 = arith.cmpi ult, %225, %c2_i64_71 : i64
-    %c91_i8_72 = arith.constant 91 : i8
-    cf.cond_br %227, ^bb1(%c91_i8_72 : i8), ^bb33
+    %225 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %226 = llvm.load %225 : !llvm.ptr -> !llvm.ptr
+    %227 = llvm.getelementptr %226[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %228 = llvm.load %227 : !llvm.ptr -> i256
+    llvm.store %227, %225 : !llvm.ptr, !llvm.ptr
+    %229 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %230 = llvm.load %229 : !llvm.ptr -> !llvm.ptr
+    %231 = llvm.getelementptr %230[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %232 = llvm.load %231 : !llvm.ptr -> i256
+    llvm.store %231, %229 : !llvm.ptr, !llvm.ptr
+    %233 = arith.trunci %228 : i256 to i64
+    %c0_i64_72 = arith.constant 0 : i64
+    %234 = arith.cmpi slt, %233, %c0_i64_72 : i64
+    %c84_i8_73 = arith.constant 84 : i8
+    cf.cond_br %234, ^bb1(%c84_i8_73 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %228 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %229 = llvm.load %228 : !llvm.ptr -> !llvm.ptr
-    %230 = llvm.getelementptr %229[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %231 = llvm.load %230 : !llvm.ptr -> i256
-    llvm.store %230, %228 : !llvm.ptr, !llvm.ptr
-    %232 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %233 = llvm.load %232 : !llvm.ptr -> !llvm.ptr
-    %234 = llvm.getelementptr %233[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %235 = llvm.load %234 : !llvm.ptr -> i256
-    llvm.store %234, %232 : !llvm.ptr, !llvm.ptr
-    %236 = arith.trunci %231 : i256 to i64
-    %c0_i64_73 = arith.constant 0 : i64
-    %237 = arith.cmpi slt, %236, %c0_i64_73 : i64
-    %c84_i8_74 = arith.constant 84 : i8
-    cf.cond_br %237, ^bb1(%c84_i8_74 : i8), ^bb34
+    %235 = arith.trunci %232 : i256 to i64
+    %c0_i64_74 = arith.constant 0 : i64
+    %236 = arith.cmpi slt, %235, %c0_i64_74 : i64
+    %c84_i8_75 = arith.constant 84 : i8
+    cf.cond_br %236, ^bb1(%c84_i8_75 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %238 = arith.trunci %235 : i256 to i64
-    %c0_i64_75 = arith.constant 0 : i64
-    %239 = arith.cmpi slt, %238, %c0_i64_75 : i64
-    %c84_i8_76 = arith.constant 84 : i8
-    cf.cond_br %239, ^bb1(%c84_i8_76 : i8), ^bb35
+    %237 = arith.addi %235, %233 : i64
+    %238 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %239 = llvm.load %238 : !llvm.ptr -> i64
+    %c0_i64_76 = arith.constant 0 : i64
+    %240 = arith.cmpi slt, %237, %c0_i64_76 : i64
+    %c84_i8_77 = arith.constant 84 : i8
+    cf.cond_br %240, ^bb1(%c84_i8_77 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %240 = arith.addi %238, %236 : i64
-    %241 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %242 = llvm.load %241 : !llvm.ptr -> i64
-    %c0_i64_77 = arith.constant 0 : i64
-    %243 = arith.cmpi slt, %240, %c0_i64_77 : i64
-    %c84_i8_78 = arith.constant 84 : i8
-    cf.cond_br %243, ^bb1(%c84_i8_78 : i8), ^bb36
+    %c31_i64_78 = arith.constant 31 : i64
+    %c32_i64_79 = arith.constant 32 : i64
+    %241 = arith.addi %237, %c31_i64_78 : i64
+    %242 = arith.divui %241, %c32_i64_79 : i64
+    %243 = arith.muli %242, %c32_i64_79 : i64
+    %244 = call @dora_fn_extend_memory(%arg0, %243) : (!llvm.ptr, i64) -> !llvm.ptr
+    %245 = llvm.getelementptr %244[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %246 = llvm.load %245 : !llvm.ptr -> !llvm.ptr
+    %247 = llvm.getelementptr %244[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %248 = llvm.load %247 : !llvm.ptr -> i8
+    %c0_i8_80 = arith.constant 0 : i8
+    %249 = arith.cmpi ne, %248, %c0_i8_80 : i8
+    cf.cond_br %249, ^bb1(%248 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %c31_i64_79 = arith.constant 31 : i64
-    %c32_i64_80 = arith.constant 32 : i64
-    %244 = arith.addi %240, %c31_i64_79 : i64
-    %245 = arith.divui %244, %c32_i64_80 : i64
-    %246 = arith.muli %245, %c32_i64_80 : i64
-    %247 = call @dora_fn_extend_memory(%arg0, %246) : (!llvm.ptr, i64) -> !llvm.ptr
-    %248 = llvm.getelementptr %247[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %249 = llvm.load %248 : !llvm.ptr -> !llvm.ptr
-    %250 = llvm.getelementptr %247[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %251 = llvm.load %250 : !llvm.ptr -> i8
+    %250 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %246, %250 : !llvm.ptr, !llvm.ptr
+    %251 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %243, %251 : i64, !llvm.ptr
     %c0_i8_81 = arith.constant 0 : i8
-    %252 = arith.cmpi ne, %251, %c0_i8_81 : i8
-    cf.cond_br %252, ^bb1(%251 : i8), ^bb37
-  ^bb37:  // pred: ^bb36
-    %253 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %249, %253 : !llvm.ptr, !llvm.ptr
-    %254 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %246, %254 : i64, !llvm.ptr
-    %c0_i8_82 = arith.constant 0 : i8
-    %255 = call @dora_fn_write_result(%arg0, %236, %238, %242, %c0_i8_82) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
-    return %c0_i8_82 : i8
-  ^bb38:  // no predecessors
-    cf.br ^bb39
-  ^bb39:  // pred: ^bb38
-    %c0_i64_83 = arith.constant 0 : i64
+    %252 = call @dora_fn_write_result(%arg0, %233, %235, %239, %c0_i8_81) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    return %c0_i8_81 : i8
+  ^bb37:  // no predecessors
+    cf.br ^bb38
+  ^bb38:  // pred: ^bb37
+    %c0_i64_82 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %256 = call @dora_fn_write_result(%arg0, %c0_i64_83, %c0_i64_83, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %253 = call @dora_fn_write_result(%arg0, %c0_i64_82, %c0_i64_82, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 11 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11
+  ^bb1(%13: i8):  // 10 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -195,30 +195,23 @@ module {
     %66 = llvm.alloca %c1_i64_11 x i64 : (i64) -> !llvm.ptr
     llvm.store %65, %66 {alignment = 1 : i64} : i64, !llvm.ptr
     %67 = call @dora_fn_create(%arg0, %48, %46, %63, %66) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %68 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %69 = llvm.load %68 : !llvm.ptr -> i8
-    %70 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %71 = llvm.load %70 : !llvm.ptr -> i8
     %c0_i8_12 = arith.constant 0 : i8
-    %72 = arith.cmpi ne, %71, %c0_i8_12 : i8
-    cf.cond_br %72, ^bb1(%71 : i8), ^bb11
+    %70 = arith.cmpi ne, %69, %c0_i8_12 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i8_13 = arith.constant 0 : i8
-    %73 = arith.cmpi ne, %c0_i8_13, %69 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %73, ^bb1(%c94_i8 : i8), ^bb12
+    %71 = llvm.load %63 : !llvm.ptr -> i256
+    %72 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
+    llvm.store %71, %73 : i256, !llvm.ptr
+    %74 = llvm.getelementptr %73[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %74, %72 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %74 = llvm.load %63 : !llvm.ptr -> i256
-    %75 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> !llvm.ptr
-    llvm.store %74, %76 : i256, !llvm.ptr
-    %77 = llvm.getelementptr %76[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %77, %75 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
-  ^bb13:  // pred: ^bb12
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_13 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %75 = call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 12 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12
+  ^bb1(%13: i8):  // 11 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -217,30 +217,23 @@ module {
     %77 = llvm.alloca %c1_i256_14 x i256 : (i256) -> !llvm.ptr
     llvm.store %55, %77 {alignment = 1 : i64} : i256, !llvm.ptr
     %78 = call @dora_fn_create2(%arg0, %58, %56, %73, %76, %77) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %79 = llvm.getelementptr %78[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %79 = llvm.getelementptr %78[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %80 = llvm.load %79 : !llvm.ptr -> i8
-    %81 = llvm.getelementptr %78[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %82 = llvm.load %81 : !llvm.ptr -> i8
     %c0_i8_15 = arith.constant 0 : i8
-    %83 = arith.cmpi ne, %82, %c0_i8_15 : i8
-    cf.cond_br %83, ^bb1(%82 : i8), ^bb12
+    %81 = arith.cmpi ne, %80, %c0_i8_15 : i8
+    cf.cond_br %81, ^bb1(%80 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i8_16 = arith.constant 0 : i8
-    %84 = arith.cmpi ne, %c0_i8_16, %80 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %84, ^bb1(%c94_i8 : i8), ^bb13
+    %82 = llvm.load %73 : !llvm.ptr -> i256
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    llvm.store %82, %84 : i256, !llvm.ptr
+    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %85 = llvm.load %73 : !llvm.ptr -> i256
-    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
-    llvm.store %85, %87 : i256, !llvm.ptr
-    %88 = llvm.getelementptr %87[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
-  ^bb14:  // pred: ^bb13
-    %c0_i64_17 = arith.constant 0 : i64
+    %c0_i64_16 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %89 = call @dora_fn_write_result(%arg0, %c0_i64_17, %c0_i64_17, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %86 = call @dora_fn_write_result(%arg0, %c0_i64_16, %c0_i64_16, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 12 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12
+  ^bb1(%13: i8):  // 11 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -217,30 +217,23 @@ module {
     %77 = llvm.alloca %c1_i256_14 x i256 : (i256) -> !llvm.ptr
     llvm.store %55, %77 {alignment = 1 : i64} : i256, !llvm.ptr
     %78 = call @dora_fn_create2(%arg0, %58, %56, %73, %76, %77) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %79 = llvm.getelementptr %78[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %79 = llvm.getelementptr %78[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %80 = llvm.load %79 : !llvm.ptr -> i8
-    %81 = llvm.getelementptr %78[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %82 = llvm.load %81 : !llvm.ptr -> i8
     %c0_i8_15 = arith.constant 0 : i8
-    %83 = arith.cmpi ne, %82, %c0_i8_15 : i8
-    cf.cond_br %83, ^bb1(%82 : i8), ^bb12
+    %81 = arith.cmpi ne, %80, %c0_i8_15 : i8
+    cf.cond_br %81, ^bb1(%80 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c0_i8_16 = arith.constant 0 : i8
-    %84 = arith.cmpi ne, %c0_i8_16, %80 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %84, ^bb1(%c94_i8 : i8), ^bb13
+    %82 = llvm.load %73 : !llvm.ptr -> i256
+    %83 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %84 = llvm.load %83 : !llvm.ptr -> !llvm.ptr
+    llvm.store %82, %84 : i256, !llvm.ptr
+    %85 = llvm.getelementptr %84[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %85, %83 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb13
   ^bb13:  // pred: ^bb12
-    %85 = llvm.load %73 : !llvm.ptr -> i256
-    %86 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %87 = llvm.load %86 : !llvm.ptr -> !llvm.ptr
-    llvm.store %85, %87 : i256, !llvm.ptr
-    %88 = llvm.getelementptr %87[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %88, %86 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb14
-  ^bb14:  // pred: ^bb13
-    %c0_i64_17 = arith.constant 0 : i64
+    %c0_i64_16 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %89 = call @dora_fn_write_result(%arg0, %c0_i64_17, %c0_i64_17, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %86 = call @dora_fn_write_result(%arg0, %c0_i64_16, %c0_i64_16, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 11 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11
+  ^bb1(%13: i8):  // 10 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -195,30 +195,23 @@ module {
     %66 = llvm.alloca %c1_i64_13 x i64 : (i64) -> !llvm.ptr
     llvm.store %65, %66 {alignment = 1 : i64} : i64, !llvm.ptr
     %67 = call @dora_fn_create(%arg0, %48, %46, %63, %66) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %68 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %69 = llvm.load %68 : !llvm.ptr -> i8
-    %70 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %71 = llvm.load %70 : !llvm.ptr -> i8
     %c0_i8_14 = arith.constant 0 : i8
-    %72 = arith.cmpi ne, %71, %c0_i8_14 : i8
-    cf.cond_br %72, ^bb1(%71 : i8), ^bb11
+    %70 = arith.cmpi ne, %69, %c0_i8_14 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i8_15 = arith.constant 0 : i8
-    %73 = arith.cmpi ne, %c0_i8_15, %69 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %73, ^bb1(%c94_i8 : i8), ^bb12
+    %71 = llvm.load %63 : !llvm.ptr -> i256
+    %72 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
+    llvm.store %71, %73 : i256, !llvm.ptr
+    %74 = llvm.getelementptr %73[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %74, %72 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %74 = llvm.load %63 : !llvm.ptr -> i256
-    %75 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> !llvm.ptr
-    llvm.store %74, %76 : i256, !llvm.ptr
-    %77 = llvm.getelementptr %76[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %77, %75 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
-  ^bb13:  // pred: ^bb12
-    %c0_i64_16 = arith.constant 0 : i64
+    %c0_i64_15 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = call @dora_fn_write_result(%arg0, %c0_i64_16, %c0_i64_16, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %75 = call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 11 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11
+  ^bb1(%13: i8):  // 10 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -195,30 +195,23 @@ module {
     %66 = llvm.alloca %c1_i64_12 x i64 : (i64) -> !llvm.ptr
     llvm.store %65, %66 {alignment = 1 : i64} : i64, !llvm.ptr
     %67 = call @dora_fn_create(%arg0, %48, %46, %63, %66) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %68 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %69 = llvm.load %68 : !llvm.ptr -> i8
-    %70 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %71 = llvm.load %70 : !llvm.ptr -> i8
     %c0_i8_13 = arith.constant 0 : i8
-    %72 = arith.cmpi ne, %71, %c0_i8_13 : i8
-    cf.cond_br %72, ^bb1(%71 : i8), ^bb11
+    %70 = arith.cmpi ne, %69, %c0_i8_13 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i8_14 = arith.constant 0 : i8
-    %73 = arith.cmpi ne, %c0_i8_14, %69 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %73, ^bb1(%c94_i8 : i8), ^bb12
+    %71 = llvm.load %63 : !llvm.ptr -> i256
+    %72 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
+    llvm.store %71, %73 : i256, !llvm.ptr
+    %74 = llvm.getelementptr %73[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %74, %72 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %74 = llvm.load %63 : !llvm.ptr -> i256
-    %75 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> !llvm.ptr
-    llvm.store %74, %76 : i256, !llvm.ptr
-    %77 = llvm.getelementptr %76[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %77, %75 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
-  ^bb13:  // pred: ^bb12
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_14 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %75 = call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 17 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17
+  ^bb1(%13: i8):  // 16 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -278,30 +278,23 @@ module {
     %108 = llvm.alloca %c1_i64_26 x i64 : (i64) -> !llvm.ptr
     llvm.store %107, %108 {alignment = 1 : i64} : i64, !llvm.ptr
     %109 = call @dora_fn_create(%arg0, %90, %88, %105, %108) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %110 = llvm.getelementptr %109[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %110 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %111 = llvm.load %110 : !llvm.ptr -> i8
-    %112 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %113 = llvm.load %112 : !llvm.ptr -> i8
     %c0_i8_27 = arith.constant 0 : i8
-    %114 = arith.cmpi ne, %113, %c0_i8_27 : i8
-    cf.cond_br %114, ^bb1(%113 : i8), ^bb17
+    %112 = arith.cmpi ne, %111, %c0_i8_27 : i8
+    cf.cond_br %112, ^bb1(%111 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i8_28 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %c0_i8_28, %111 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %115, ^bb1(%c94_i8 : i8), ^bb18
+    %113 = llvm.load %105 : !llvm.ptr -> i256
+    %114 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> !llvm.ptr
+    llvm.store %113, %115 : i256, !llvm.ptr
+    %116 = llvm.getelementptr %115[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %116, %114 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb18
   ^bb18:  // pred: ^bb17
-    %116 = llvm.load %105 : !llvm.ptr -> i256
-    %117 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %118 = llvm.load %117 : !llvm.ptr -> !llvm.ptr
-    llvm.store %116, %118 : i256, !llvm.ptr
-    %119 = llvm.getelementptr %118[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %119, %117 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb19
-  ^bb19:  // pred: ^bb18
-    %c0_i64_29 = arith.constant 0 : i64
+    %c0_i64_28 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %120 = call @dora_fn_write_result(%arg0, %c0_i64_29, %c0_i64_29, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %117 = call @dora_fn_write_result(%arg0, %c0_i64_28, %c0_i64_28, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 11 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11
+  ^bb1(%13: i8):  // 10 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -195,30 +195,23 @@ module {
     %66 = llvm.alloca %c1_i64_11 x i64 : (i64) -> !llvm.ptr
     llvm.store %65, %66 {alignment = 1 : i64} : i64, !llvm.ptr
     %67 = call @dora_fn_create(%arg0, %48, %46, %63, %66) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %68 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %69 = llvm.load %68 : !llvm.ptr -> i8
-    %70 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %71 = llvm.load %70 : !llvm.ptr -> i8
     %c0_i8_12 = arith.constant 0 : i8
-    %72 = arith.cmpi ne, %71, %c0_i8_12 : i8
-    cf.cond_br %72, ^bb1(%71 : i8), ^bb11
+    %70 = arith.cmpi ne, %69, %c0_i8_12 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %c0_i8_13 = arith.constant 0 : i8
-    %73 = arith.cmpi ne, %c0_i8_13, %69 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %73, ^bb1(%c94_i8 : i8), ^bb12
+    %71 = llvm.load %63 : !llvm.ptr -> i256
+    %72 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %73 = llvm.load %72 : !llvm.ptr -> !llvm.ptr
+    llvm.store %71, %73 : i256, !llvm.ptr
+    %74 = llvm.getelementptr %73[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %74, %72 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb12
   ^bb12:  // pred: ^bb11
-    %74 = llvm.load %63 : !llvm.ptr -> i256
-    %75 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> !llvm.ptr
-    llvm.store %74, %76 : i256, !llvm.ptr
-    %77 = llvm.getelementptr %76[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %77, %75 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb13
-  ^bb13:  // pred: ^bb12
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_13 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %75 = call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 33 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33
+  ^bb1(%13: i8):  // 32 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -278,261 +278,254 @@ module {
     %108 = llvm.alloca %c1_i64_26 x i64 : (i64) -> !llvm.ptr
     llvm.store %107, %108 {alignment = 1 : i64} : i64, !llvm.ptr
     %109 = call @dora_fn_create(%arg0, %90, %88, %105, %108) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %110 = llvm.getelementptr %109[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %110 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %111 = llvm.load %110 : !llvm.ptr -> i8
-    %112 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %113 = llvm.load %112 : !llvm.ptr -> i8
     %c0_i8_27 = arith.constant 0 : i8
-    %114 = arith.cmpi ne, %113, %c0_i8_27 : i8
-    cf.cond_br %114, ^bb1(%113 : i8), ^bb17
+    %112 = arith.cmpi ne, %111, %c0_i8_27 : i8
+    cf.cond_br %112, ^bb1(%111 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i8_28 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %c0_i8_28, %111 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %115, ^bb1(%c94_i8 : i8), ^bb18
+    %113 = llvm.load %105 : !llvm.ptr -> i256
+    %114 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> !llvm.ptr
+    llvm.store %113, %115 : i256, !llvm.ptr
+    %116 = llvm.getelementptr %115[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %116, %114 : !llvm.ptr, !llvm.ptr
+    %117 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_28 = arith.constant 1 : i64
+    %118 = arith.addi %117, %c1_i64_28 : i64
+    llvm.store %118, %9 : i64, !llvm.ptr
+    %119 = arith.cmpi ult, %c1024_i64, %118 : i64
+    %c92_i8_29 = arith.constant 92 : i8
+    cf.cond_br %119, ^bb1(%c92_i8_29 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %116 = llvm.load %105 : !llvm.ptr -> i256
-    %117 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %118 = llvm.load %117 : !llvm.ptr -> !llvm.ptr
-    llvm.store %116, %118 : i256, !llvm.ptr
-    %119 = llvm.getelementptr %118[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %119, %117 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_29 : i64
-    llvm.store %121, %9 : i64, !llvm.ptr
-    %122 = arith.cmpi ult, %c1024_i64, %121 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_30 : i8), ^bb19
+    %c0_i256_30 = arith.constant 0 : i256
+    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_30, %121 : i256, !llvm.ptr
+    %122 = llvm.getelementptr %121[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
+    %123 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_31 = arith.constant 1 : i64
+    %124 = arith.addi %123, %c1_i64_31 : i64
+    llvm.store %124, %9 : i64, !llvm.ptr
+    %125 = arith.cmpi ult, %c1024_i64, %124 : i64
+    %c92_i8_32 = arith.constant 92 : i8
+    cf.cond_br %125, ^bb1(%c92_i8_32 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %c0_i256_31 = arith.constant 0 : i256
-    %123 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %124 = llvm.load %123 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_31, %124 : i256, !llvm.ptr
-    %125 = llvm.getelementptr %124[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %125, %123 : !llvm.ptr, !llvm.ptr
-    %126 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %127 = arith.addi %126, %c1_i64_32 : i64
-    llvm.store %127, %9 : i64, !llvm.ptr
-    %128 = arith.cmpi ult, %c1024_i64, %127 : i64
-    %c92_i8_33 = arith.constant 92 : i8
-    cf.cond_br %128, ^bb1(%c92_i8_33 : i8), ^bb20
+    %c0_i256_33 = arith.constant 0 : i256
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_33, %127 : i256, !llvm.ptr
+    %128 = llvm.getelementptr %127[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %129 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %130 = arith.addi %129, %c1_i64_34 : i64
+    llvm.store %130, %9 : i64, !llvm.ptr
+    %131 = arith.cmpi ult, %c1024_i64, %130 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %131, ^bb1(%c92_i8_35 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %c0_i256_34 = arith.constant 0 : i256
-    %129 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %130 = llvm.load %129 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_34, %130 : i256, !llvm.ptr
-    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %131, %129 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %133 = arith.addi %132, %c1_i64_35 : i64
-    llvm.store %133, %9 : i64, !llvm.ptr
-    %134 = arith.cmpi ult, %c1024_i64, %133 : i64
-    %c92_i8_36 = arith.constant 92 : i8
-    cf.cond_br %134, ^bb1(%c92_i8_36 : i8), ^bb21
+    %c0_i256_36 = arith.constant 0 : i256
+    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_36, %133 : i256, !llvm.ptr
+    %134 = llvm.getelementptr %133[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
+    %135 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_37 = arith.constant 1 : i64
+    %136 = arith.addi %135, %c1_i64_37 : i64
+    llvm.store %136, %9 : i64, !llvm.ptr
+    %137 = arith.cmpi ult, %c1024_i64, %136 : i64
+    %c92_i8_38 = arith.constant 92 : i8
+    cf.cond_br %137, ^bb1(%c92_i8_38 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_37 = arith.constant 0 : i256
-    %135 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %136 = llvm.load %135 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_37, %136 : i256, !llvm.ptr
-    %137 = llvm.getelementptr %136[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %137, %135 : !llvm.ptr, !llvm.ptr
-    %138 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_38 : i64
-    llvm.store %139, %9 : i64, !llvm.ptr
-    %140 = arith.cmpi ult, %c1024_i64, %139 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_39 : i8), ^bb22
+    %c0_i256_39 = arith.constant 0 : i256
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_39, %139 : i256, !llvm.ptr
+    %140 = llvm.getelementptr %139[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %141 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %142 = arith.addi %141, %c1_i64_40 : i64
+    llvm.store %142, %9 : i64, !llvm.ptr
+    %143 = arith.cmpi ult, %c1024_i64, %142 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %143, ^bb1(%c92_i8_41 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_40 = arith.constant 0 : i256
-    %141 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %142 = llvm.load %141 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_40, %142 : i256, !llvm.ptr
-    %143 = llvm.getelementptr %142[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %143, %141 : !llvm.ptr, !llvm.ptr
-    %144 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_41 = arith.constant 1 : i64
-    %145 = arith.addi %144, %c1_i64_41 : i64
-    llvm.store %145, %9 : i64, !llvm.ptr
-    %146 = arith.cmpi ult, %c1024_i64, %145 : i64
-    %c92_i8_42 = arith.constant 92 : i8
-    cf.cond_br %146, ^bb1(%c92_i8_42 : i8), ^bb23
+    %c0_i256_42 = arith.constant 0 : i256
+    %144 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %145 = llvm.load %144 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_42, %145 : i256, !llvm.ptr
+    %146 = llvm.getelementptr %145[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %146, %144 : !llvm.ptr, !llvm.ptr
+    %147 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_43 = arith.constant 1 : i64
+    %148 = arith.addi %147, %c1_i64_43 : i64
+    llvm.store %148, %9 : i64, !llvm.ptr
+    %149 = arith.cmpi ult, %c1024_i64, %148 : i64
+    %c92_i8_44 = arith.constant 92 : i8
+    cf.cond_br %149, ^bb1(%c92_i8_44 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_43 = arith.constant 0 : i256
-    %147 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_43, %148 : i256, !llvm.ptr
-    %149 = llvm.getelementptr %148[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %149, %147 : !llvm.ptr, !llvm.ptr
-    %150 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %151 = arith.addi %150, %c1_i64_44 : i64
-    llvm.store %151, %9 : i64, !llvm.ptr
-    %152 = arith.cmpi ult, %c1024_i64, %151 : i64
-    %c92_i8_45 = arith.constant 92 : i8
-    cf.cond_br %152, ^bb1(%c92_i8_45 : i8), ^bb24
+    %150 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %151 = llvm.load %150 : !llvm.ptr -> !llvm.ptr
+    %152 = llvm.getelementptr %151[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %153 = llvm.load %152 : !llvm.ptr -> i256
+    %154 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %155 = llvm.load %154 : !llvm.ptr -> !llvm.ptr
+    llvm.store %153, %155 : i256, !llvm.ptr
+    %156 = llvm.getelementptr %155[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %156, %154 : !llvm.ptr, !llvm.ptr
+    %157 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_45 = arith.constant 1 : i64
+    %158 = arith.addi %157, %c1_i64_45 : i64
+    llvm.store %158, %9 : i64, !llvm.ptr
+    %159 = arith.cmpi ult, %c1024_i64, %158 : i64
+    %c92_i8_46 = arith.constant 92 : i8
+    cf.cond_br %159, ^bb1(%c92_i8_46 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %153 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
-    %155 = llvm.getelementptr %154[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
-    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
-    %160 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_46 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_46 : i64
-    llvm.store %161, %9 : i64, !llvm.ptr
-    %162 = arith.cmpi ult, %c1024_i64, %161 : i64
-    %c92_i8_47 = arith.constant 92 : i8
-    cf.cond_br %162, ^bb1(%c92_i8_47 : i8), ^bb25
-  ^bb25:  // pred: ^bb24
     %c65535_i256 = arith.constant 65535 : i256
-    %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %164 : i256, !llvm.ptr
-    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    %166 = llvm.load %9 : !llvm.ptr -> i64
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
+    %163 = llvm.load %9 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %167 = arith.addi %166, %c-6_i64 : i64
-    llvm.store %167, %9 : i64, !llvm.ptr
+    %164 = arith.addi %163, %c-6_i64 : i64
+    llvm.store %164, %9 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %168 = arith.cmpi ult, %166, %c7_i64 : i64
-    %c91_i8_48 = arith.constant 91 : i8
-    cf.cond_br %168, ^bb1(%c91_i8_48 : i8), ^bb26
-  ^bb26:  // pred: ^bb25
-    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
-    %171 = llvm.getelementptr %170[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %172 = llvm.load %171 : !llvm.ptr -> i256
-    llvm.store %171, %169 : !llvm.ptr, !llvm.ptr
-    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
-    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %176 = llvm.load %175 : !llvm.ptr -> i256
-    llvm.store %175, %173 : !llvm.ptr, !llvm.ptr
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    %179 = llvm.getelementptr %178[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    %181 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %182 = llvm.load %181 : !llvm.ptr -> !llvm.ptr
-    %183 = llvm.getelementptr %182[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    llvm.store %183, %181 : !llvm.ptr, !llvm.ptr
-    %185 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
-    %187 = llvm.getelementptr %186[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    llvm.store %187, %185 : !llvm.ptr, !llvm.ptr
-    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
-    %191 = llvm.getelementptr %190[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
-    %193 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
-    %195 = llvm.getelementptr %194[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    llvm.store %195, %193 : !llvm.ptr, !llvm.ptr
-    %197 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %198 = llvm.load %197 : !llvm.ptr -> i1
-    %c0_i256_49 = arith.constant 0 : i256
-    %199 = arith.cmpi ne, %180, %c0_i256_49 : i256
-    %200 = arith.andi %198, %199 : i1
+    %165 = arith.cmpi ult, %163, %c7_i64 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %165, ^bb1(%c91_i8_47 : i8), ^bb25
+  ^bb25:  // pred: ^bb24
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    %168 = llvm.getelementptr %167[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %169 = llvm.load %168 : !llvm.ptr -> i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %170 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
+    %176 = llvm.getelementptr %175[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %177 = llvm.load %176 : !llvm.ptr -> i256
+    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
+    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    %180 = llvm.getelementptr %179[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %181 = llvm.load %180 : !llvm.ptr -> i256
+    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
+    %182 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %183 = llvm.load %182 : !llvm.ptr -> !llvm.ptr
+    %184 = llvm.getelementptr %183[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %185 = llvm.load %184 : !llvm.ptr -> i256
+    llvm.store %184, %182 : !llvm.ptr, !llvm.ptr
+    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
+    %188 = llvm.getelementptr %187[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %189 = llvm.load %188 : !llvm.ptr -> i256
+    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
+    %190 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
+    %192 = llvm.getelementptr %191[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %193 = llvm.load %192 : !llvm.ptr -> i256
+    llvm.store %192, %190 : !llvm.ptr, !llvm.ptr
+    %194 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %195 = llvm.load %194 : !llvm.ptr -> i1
+    %c0_i256_48 = arith.constant 0 : i256
+    %196 = arith.cmpi ne, %177, %c0_i256_48 : i256
+    %197 = arith.andi %195, %196 : i1
     %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %200, ^bb1(%c86_i8 : i8), ^bb27
+    cf.cond_br %197, ^bb1(%c86_i8 : i8), ^bb26
+  ^bb26:  // pred: ^bb25
+    %198 = arith.trunci %169 : i256 to i64
+    %199 = arith.trunci %181 : i256 to i64
+    %c0_i64_49 = arith.constant 0 : i64
+    %200 = arith.cmpi slt, %199, %c0_i64_49 : i64
+    %c84_i8_50 = arith.constant 84 : i8
+    cf.cond_br %200, ^bb1(%c84_i8_50 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %201 = arith.trunci %172 : i256 to i64
-    %202 = arith.trunci %184 : i256 to i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %203 = arith.cmpi slt, %202, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %203, ^bb1(%c84_i8_51 : i8), ^bb28
+    %201 = arith.trunci %185 : i256 to i64
+    %c0_i64_51 = arith.constant 0 : i64
+    %202 = arith.cmpi slt, %201, %c0_i64_51 : i64
+    %c84_i8_52 = arith.constant 84 : i8
+    cf.cond_br %202, ^bb1(%c84_i8_52 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %204 = arith.trunci %188 : i256 to i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %205 = arith.cmpi slt, %204, %c0_i64_52 : i64
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %205, ^bb1(%c84_i8_53 : i8), ^bb29
+    %203 = arith.trunci %189 : i256 to i64
+    %c0_i64_53 = arith.constant 0 : i64
+    %204 = arith.cmpi slt, %203, %c0_i64_53 : i64
+    %c84_i8_54 = arith.constant 84 : i8
+    cf.cond_br %204, ^bb1(%c84_i8_54 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %206 = arith.trunci %192 : i256 to i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %207 = arith.cmpi slt, %206, %c0_i64_54 : i64
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %207, ^bb1(%c84_i8_55 : i8), ^bb30
+    %205 = arith.trunci %193 : i256 to i64
+    %c0_i64_55 = arith.constant 0 : i64
+    %206 = arith.cmpi slt, %205, %c0_i64_55 : i64
+    %c84_i8_56 = arith.constant 84 : i8
+    cf.cond_br %206, ^bb1(%c84_i8_56 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %208 = arith.trunci %196 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %209 = arith.cmpi slt, %208, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %209, ^bb1(%c84_i8_57 : i8), ^bb31
+    %207 = arith.addi %199, %201 : i64
+    %208 = arith.addi %203, %205 : i64
+    %209 = arith.maxui %207, %208 : i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %210 = arith.cmpi slt, %209, %c0_i64_57 : i64
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %210, ^bb1(%c84_i8_58 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %210 = arith.addi %202, %204 : i64
-    %211 = arith.addi %206, %208 : i64
-    %212 = arith.maxui %210, %211 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %213 = arith.cmpi slt, %212, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %213, ^bb1(%c84_i8_59 : i8), ^bb32
+    %c31_i64_59 = arith.constant 31 : i64
+    %c32_i64_60 = arith.constant 32 : i64
+    %211 = arith.addi %209, %c31_i64_59 : i64
+    %212 = arith.divui %211, %c32_i64_60 : i64
+    %213 = arith.muli %212, %c32_i64_60 : i64
+    %214 = call @dora_fn_extend_memory(%arg0, %213) : (!llvm.ptr, i64) -> !llvm.ptr
+    %215 = llvm.getelementptr %214[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
+    %217 = llvm.getelementptr %214[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %218 = llvm.load %217 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %219 = arith.cmpi ne, %218, %c0_i8_61 : i8
+    cf.cond_br %219, ^bb1(%218 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_60 = arith.constant 31 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %214 = arith.addi %212, %c31_i64_60 : i64
-    %215 = arith.divui %214, %c32_i64_61 : i64
-    %216 = arith.muli %215, %c32_i64_61 : i64
-    %217 = call @dora_fn_extend_memory(%arg0, %216) : (!llvm.ptr, i64) -> !llvm.ptr
-    %218 = llvm.getelementptr %217[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %219 = llvm.load %218 : !llvm.ptr -> !llvm.ptr
-    %220 = llvm.getelementptr %217[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %221 = llvm.load %220 : !llvm.ptr -> i8
-    %c0_i8_62 = arith.constant 0 : i8
-    %222 = arith.cmpi ne, %221, %c0_i8_62 : i8
-    cf.cond_br %222, ^bb1(%221 : i8), ^bb33
-  ^bb33:  // pred: ^bb32
-    %223 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %219, %223 : !llvm.ptr, !llvm.ptr
-    %224 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %216, %224 : i64, !llvm.ptr
-    %225 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %226 = llvm.load %225 : !llvm.ptr -> i64
+    %220 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %216, %220 : !llvm.ptr, !llvm.ptr
+    %221 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %213, %221 : i64, !llvm.ptr
+    %222 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %223 = llvm.load %222 : !llvm.ptr -> i64
+    %c1_i256_62 = arith.constant 1 : i256
+    %224 = llvm.alloca %c1_i256_62 x i256 : (i256) -> !llvm.ptr
+    llvm.store %177, %224 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_63 = arith.constant 1 : i256
-    %227 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %227 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_64 = arith.constant 1 : i256
-    %228 = llvm.alloca %c1_i256_64 x i256 : (i256) -> !llvm.ptr
-    llvm.store %176, %228 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_65 = arith.constant 1 : i64
-    %229 = llvm.alloca %c1_i64_65 x i64 : (i64) -> !llvm.ptr
+    %225 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
+    llvm.store %173, %225 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_64 = arith.constant 1 : i64
+    %226 = llvm.alloca %c1_i64_64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_65 = arith.constant 0 : i8
+    %227 = call @dora_fn_call(%arg0, %198, %225, %224, %199, %201, %203, %205, %223, %226, %c0_i8_65) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %228 = llvm.getelementptr %227[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %229 = llvm.load %228 : !llvm.ptr -> i8
+    %230 = llvm.getelementptr %227[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %231 = llvm.load %230 : !llvm.ptr -> i8
     %c0_i8_66 = arith.constant 0 : i8
-    %230 = call @dora_fn_call(%arg0, %201, %228, %227, %202, %204, %206, %208, %226, %229, %c0_i8_66) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %231 = llvm.getelementptr %230[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %232 = llvm.load %231 : !llvm.ptr -> i8
-    %233 = llvm.getelementptr %230[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %234 = llvm.load %233 : !llvm.ptr -> i8
-    %c0_i8_67 = arith.constant 0 : i8
-    %235 = arith.cmpi ne, %234, %c0_i8_67 : i8
-    cf.cond_br %235, ^bb1(%234 : i8), ^bb34
+    %232 = arith.cmpi ne, %231, %c0_i8_66 : i8
+    cf.cond_br %232, ^bb1(%231 : i8), ^bb33
+  ^bb33:  // pred: ^bb32
+    %233 = llvm.load %226 : !llvm.ptr -> i64
+    %234 = arith.extui %229 : i8 to i256
+    %235 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %236 = llvm.load %235 : !llvm.ptr -> !llvm.ptr
+    llvm.store %234, %236 : i256, !llvm.ptr
+    %237 = llvm.getelementptr %236[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %237, %235 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb34
   ^bb34:  // pred: ^bb33
-    %236 = llvm.load %229 : !llvm.ptr -> i64
-    %237 = arith.extui %232 : i8 to i256
-    %238 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %239 = llvm.load %238 : !llvm.ptr -> !llvm.ptr
-    llvm.store %237, %239 : i256, !llvm.ptr
-    %240 = llvm.getelementptr %239[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %240, %238 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb35
-  ^bb35:  // pred: ^bb34
-    %c0_i64_68 = arith.constant 0 : i64
+    %c0_i64_67 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %241 = call @dora_fn_write_result(%arg0, %c0_i64_68, %c0_i64_68, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %238 = call @dora_fn_write_result(%arg0, %c0_i64_67, %c0_i64_67, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 49 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49
+  ^bb1(%13: i8):  // 48 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -278,492 +278,485 @@ module {
     %108 = llvm.alloca %c1_i64_26 x i64 : (i64) -> !llvm.ptr
     llvm.store %107, %108 {alignment = 1 : i64} : i64, !llvm.ptr
     %109 = call @dora_fn_create(%arg0, %90, %88, %105, %108) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %110 = llvm.getelementptr %109[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %110 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %111 = llvm.load %110 : !llvm.ptr -> i8
-    %112 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %113 = llvm.load %112 : !llvm.ptr -> i8
     %c0_i8_27 = arith.constant 0 : i8
-    %114 = arith.cmpi ne, %113, %c0_i8_27 : i8
-    cf.cond_br %114, ^bb1(%113 : i8), ^bb17
+    %112 = arith.cmpi ne, %111, %c0_i8_27 : i8
+    cf.cond_br %112, ^bb1(%111 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i8_28 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %c0_i8_28, %111 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %115, ^bb1(%c94_i8 : i8), ^bb18
+    %113 = llvm.load %105 : !llvm.ptr -> i256
+    %114 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> !llvm.ptr
+    llvm.store %113, %115 : i256, !llvm.ptr
+    %116 = llvm.getelementptr %115[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %116, %114 : !llvm.ptr, !llvm.ptr
+    %117 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_28 = arith.constant 1 : i64
+    %118 = arith.addi %117, %c1_i64_28 : i64
+    llvm.store %118, %9 : i64, !llvm.ptr
+    %119 = arith.cmpi ult, %c1024_i64, %118 : i64
+    %c92_i8_29 = arith.constant 92 : i8
+    cf.cond_br %119, ^bb1(%c92_i8_29 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %116 = llvm.load %105 : !llvm.ptr -> i256
-    %117 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %118 = llvm.load %117 : !llvm.ptr -> !llvm.ptr
-    llvm.store %116, %118 : i256, !llvm.ptr
-    %119 = llvm.getelementptr %118[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %119, %117 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_29 : i64
-    llvm.store %121, %9 : i64, !llvm.ptr
-    %122 = arith.cmpi ult, %c1024_i64, %121 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_30 : i8), ^bb19
+    %c0_i256_30 = arith.constant 0 : i256
+    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_30, %121 : i256, !llvm.ptr
+    %122 = llvm.getelementptr %121[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
+    %123 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_31 = arith.constant 1 : i64
+    %124 = arith.addi %123, %c1_i64_31 : i64
+    llvm.store %124, %9 : i64, !llvm.ptr
+    %125 = arith.cmpi ult, %c1024_i64, %124 : i64
+    %c92_i8_32 = arith.constant 92 : i8
+    cf.cond_br %125, ^bb1(%c92_i8_32 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %c0_i256_31 = arith.constant 0 : i256
-    %123 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %124 = llvm.load %123 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_31, %124 : i256, !llvm.ptr
-    %125 = llvm.getelementptr %124[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %125, %123 : !llvm.ptr, !llvm.ptr
-    %126 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %127 = arith.addi %126, %c1_i64_32 : i64
-    llvm.store %127, %9 : i64, !llvm.ptr
-    %128 = arith.cmpi ult, %c1024_i64, %127 : i64
-    %c92_i8_33 = arith.constant 92 : i8
-    cf.cond_br %128, ^bb1(%c92_i8_33 : i8), ^bb20
+    %c0_i256_33 = arith.constant 0 : i256
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_33, %127 : i256, !llvm.ptr
+    %128 = llvm.getelementptr %127[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %129 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %130 = arith.addi %129, %c1_i64_34 : i64
+    llvm.store %130, %9 : i64, !llvm.ptr
+    %131 = arith.cmpi ult, %c1024_i64, %130 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %131, ^bb1(%c92_i8_35 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %c0_i256_34 = arith.constant 0 : i256
-    %129 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %130 = llvm.load %129 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_34, %130 : i256, !llvm.ptr
-    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %131, %129 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %133 = arith.addi %132, %c1_i64_35 : i64
-    llvm.store %133, %9 : i64, !llvm.ptr
-    %134 = arith.cmpi ult, %c1024_i64, %133 : i64
-    %c92_i8_36 = arith.constant 92 : i8
-    cf.cond_br %134, ^bb1(%c92_i8_36 : i8), ^bb21
+    %c0_i256_36 = arith.constant 0 : i256
+    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_36, %133 : i256, !llvm.ptr
+    %134 = llvm.getelementptr %133[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
+    %135 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_37 = arith.constant 1 : i64
+    %136 = arith.addi %135, %c1_i64_37 : i64
+    llvm.store %136, %9 : i64, !llvm.ptr
+    %137 = arith.cmpi ult, %c1024_i64, %136 : i64
+    %c92_i8_38 = arith.constant 92 : i8
+    cf.cond_br %137, ^bb1(%c92_i8_38 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_37 = arith.constant 0 : i256
-    %135 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %136 = llvm.load %135 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_37, %136 : i256, !llvm.ptr
-    %137 = llvm.getelementptr %136[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %137, %135 : !llvm.ptr, !llvm.ptr
-    %138 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_38 : i64
-    llvm.store %139, %9 : i64, !llvm.ptr
-    %140 = arith.cmpi ult, %c1024_i64, %139 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_39 : i8), ^bb22
+    %c0_i256_39 = arith.constant 0 : i256
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_39, %139 : i256, !llvm.ptr
+    %140 = llvm.getelementptr %139[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %141 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %142 = arith.addi %141, %c1_i64_40 : i64
+    llvm.store %142, %9 : i64, !llvm.ptr
+    %143 = arith.cmpi ult, %c1024_i64, %142 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %143, ^bb1(%c92_i8_41 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_40 = arith.constant 0 : i256
-    %141 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %142 = llvm.load %141 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_40, %142 : i256, !llvm.ptr
-    %143 = llvm.getelementptr %142[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %143, %141 : !llvm.ptr, !llvm.ptr
-    %144 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_41 = arith.constant 1 : i64
-    %145 = arith.addi %144, %c1_i64_41 : i64
-    llvm.store %145, %9 : i64, !llvm.ptr
-    %146 = arith.cmpi ult, %c1024_i64, %145 : i64
-    %c92_i8_42 = arith.constant 92 : i8
-    cf.cond_br %146, ^bb1(%c92_i8_42 : i8), ^bb23
+    %c0_i256_42 = arith.constant 0 : i256
+    %144 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %145 = llvm.load %144 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_42, %145 : i256, !llvm.ptr
+    %146 = llvm.getelementptr %145[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %146, %144 : !llvm.ptr, !llvm.ptr
+    %147 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_43 = arith.constant 1 : i64
+    %148 = arith.addi %147, %c1_i64_43 : i64
+    llvm.store %148, %9 : i64, !llvm.ptr
+    %149 = arith.cmpi ult, %c1024_i64, %148 : i64
+    %c92_i8_44 = arith.constant 92 : i8
+    cf.cond_br %149, ^bb1(%c92_i8_44 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_43 = arith.constant 0 : i256
-    %147 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_43, %148 : i256, !llvm.ptr
-    %149 = llvm.getelementptr %148[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %149, %147 : !llvm.ptr, !llvm.ptr
-    %150 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %151 = arith.addi %150, %c1_i64_44 : i64
-    llvm.store %151, %9 : i64, !llvm.ptr
-    %152 = arith.cmpi ult, %c1024_i64, %151 : i64
-    %c92_i8_45 = arith.constant 92 : i8
-    cf.cond_br %152, ^bb1(%c92_i8_45 : i8), ^bb24
+    %150 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %151 = llvm.load %150 : !llvm.ptr -> !llvm.ptr
+    %152 = llvm.getelementptr %151[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %153 = llvm.load %152 : !llvm.ptr -> i256
+    %154 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %155 = llvm.load %154 : !llvm.ptr -> !llvm.ptr
+    llvm.store %153, %155 : i256, !llvm.ptr
+    %156 = llvm.getelementptr %155[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %156, %154 : !llvm.ptr, !llvm.ptr
+    %157 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_45 = arith.constant 1 : i64
+    %158 = arith.addi %157, %c1_i64_45 : i64
+    llvm.store %158, %9 : i64, !llvm.ptr
+    %159 = arith.cmpi ult, %c1024_i64, %158 : i64
+    %c92_i8_46 = arith.constant 92 : i8
+    cf.cond_br %159, ^bb1(%c92_i8_46 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %153 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
-    %155 = llvm.getelementptr %154[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
-    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
-    %160 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_46 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_46 : i64
-    llvm.store %161, %9 : i64, !llvm.ptr
-    %162 = arith.cmpi ult, %c1024_i64, %161 : i64
-    %c92_i8_47 = arith.constant 92 : i8
-    cf.cond_br %162, ^bb1(%c92_i8_47 : i8), ^bb25
-  ^bb25:  // pred: ^bb24
     %c65535_i256 = arith.constant 65535 : i256
-    %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %164 : i256, !llvm.ptr
-    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    %166 = llvm.load %9 : !llvm.ptr -> i64
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
+    %163 = llvm.load %9 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %167 = arith.addi %166, %c-6_i64 : i64
-    llvm.store %167, %9 : i64, !llvm.ptr
+    %164 = arith.addi %163, %c-6_i64 : i64
+    llvm.store %164, %9 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %168 = arith.cmpi ult, %166, %c7_i64 : i64
-    %c91_i8_48 = arith.constant 91 : i8
-    cf.cond_br %168, ^bb1(%c91_i8_48 : i8), ^bb26
-  ^bb26:  // pred: ^bb25
-    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
-    %171 = llvm.getelementptr %170[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %172 = llvm.load %171 : !llvm.ptr -> i256
-    llvm.store %171, %169 : !llvm.ptr, !llvm.ptr
-    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
-    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %176 = llvm.load %175 : !llvm.ptr -> i256
-    llvm.store %175, %173 : !llvm.ptr, !llvm.ptr
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    %179 = llvm.getelementptr %178[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    %181 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %182 = llvm.load %181 : !llvm.ptr -> !llvm.ptr
-    %183 = llvm.getelementptr %182[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    llvm.store %183, %181 : !llvm.ptr, !llvm.ptr
-    %185 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
-    %187 = llvm.getelementptr %186[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    llvm.store %187, %185 : !llvm.ptr, !llvm.ptr
-    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
-    %191 = llvm.getelementptr %190[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
-    %193 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
-    %195 = llvm.getelementptr %194[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    llvm.store %195, %193 : !llvm.ptr, !llvm.ptr
-    %197 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %198 = llvm.load %197 : !llvm.ptr -> i1
-    %c0_i256_49 = arith.constant 0 : i256
-    %199 = arith.cmpi ne, %180, %c0_i256_49 : i256
-    %200 = arith.andi %198, %199 : i1
+    %165 = arith.cmpi ult, %163, %c7_i64 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %165, ^bb1(%c91_i8_47 : i8), ^bb25
+  ^bb25:  // pred: ^bb24
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    %168 = llvm.getelementptr %167[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %169 = llvm.load %168 : !llvm.ptr -> i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %170 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
+    %176 = llvm.getelementptr %175[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %177 = llvm.load %176 : !llvm.ptr -> i256
+    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
+    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    %180 = llvm.getelementptr %179[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %181 = llvm.load %180 : !llvm.ptr -> i256
+    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
+    %182 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %183 = llvm.load %182 : !llvm.ptr -> !llvm.ptr
+    %184 = llvm.getelementptr %183[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %185 = llvm.load %184 : !llvm.ptr -> i256
+    llvm.store %184, %182 : !llvm.ptr, !llvm.ptr
+    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
+    %188 = llvm.getelementptr %187[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %189 = llvm.load %188 : !llvm.ptr -> i256
+    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
+    %190 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
+    %192 = llvm.getelementptr %191[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %193 = llvm.load %192 : !llvm.ptr -> i256
+    llvm.store %192, %190 : !llvm.ptr, !llvm.ptr
+    %194 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %195 = llvm.load %194 : !llvm.ptr -> i1
+    %c0_i256_48 = arith.constant 0 : i256
+    %196 = arith.cmpi ne, %177, %c0_i256_48 : i256
+    %197 = arith.andi %195, %196 : i1
     %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %200, ^bb1(%c86_i8 : i8), ^bb27
+    cf.cond_br %197, ^bb1(%c86_i8 : i8), ^bb26
+  ^bb26:  // pred: ^bb25
+    %198 = arith.trunci %169 : i256 to i64
+    %199 = arith.trunci %181 : i256 to i64
+    %c0_i64_49 = arith.constant 0 : i64
+    %200 = arith.cmpi slt, %199, %c0_i64_49 : i64
+    %c84_i8_50 = arith.constant 84 : i8
+    cf.cond_br %200, ^bb1(%c84_i8_50 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %201 = arith.trunci %172 : i256 to i64
-    %202 = arith.trunci %184 : i256 to i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %203 = arith.cmpi slt, %202, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %203, ^bb1(%c84_i8_51 : i8), ^bb28
+    %201 = arith.trunci %185 : i256 to i64
+    %c0_i64_51 = arith.constant 0 : i64
+    %202 = arith.cmpi slt, %201, %c0_i64_51 : i64
+    %c84_i8_52 = arith.constant 84 : i8
+    cf.cond_br %202, ^bb1(%c84_i8_52 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %204 = arith.trunci %188 : i256 to i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %205 = arith.cmpi slt, %204, %c0_i64_52 : i64
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %205, ^bb1(%c84_i8_53 : i8), ^bb29
+    %203 = arith.trunci %189 : i256 to i64
+    %c0_i64_53 = arith.constant 0 : i64
+    %204 = arith.cmpi slt, %203, %c0_i64_53 : i64
+    %c84_i8_54 = arith.constant 84 : i8
+    cf.cond_br %204, ^bb1(%c84_i8_54 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %206 = arith.trunci %192 : i256 to i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %207 = arith.cmpi slt, %206, %c0_i64_54 : i64
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %207, ^bb1(%c84_i8_55 : i8), ^bb30
+    %205 = arith.trunci %193 : i256 to i64
+    %c0_i64_55 = arith.constant 0 : i64
+    %206 = arith.cmpi slt, %205, %c0_i64_55 : i64
+    %c84_i8_56 = arith.constant 84 : i8
+    cf.cond_br %206, ^bb1(%c84_i8_56 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %208 = arith.trunci %196 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %209 = arith.cmpi slt, %208, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %209, ^bb1(%c84_i8_57 : i8), ^bb31
+    %207 = arith.addi %199, %201 : i64
+    %208 = arith.addi %203, %205 : i64
+    %209 = arith.maxui %207, %208 : i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %210 = arith.cmpi slt, %209, %c0_i64_57 : i64
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %210, ^bb1(%c84_i8_58 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %210 = arith.addi %202, %204 : i64
-    %211 = arith.addi %206, %208 : i64
-    %212 = arith.maxui %210, %211 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %213 = arith.cmpi slt, %212, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %213, ^bb1(%c84_i8_59 : i8), ^bb32
+    %c31_i64_59 = arith.constant 31 : i64
+    %c32_i64_60 = arith.constant 32 : i64
+    %211 = arith.addi %209, %c31_i64_59 : i64
+    %212 = arith.divui %211, %c32_i64_60 : i64
+    %213 = arith.muli %212, %c32_i64_60 : i64
+    %214 = call @dora_fn_extend_memory(%arg0, %213) : (!llvm.ptr, i64) -> !llvm.ptr
+    %215 = llvm.getelementptr %214[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
+    %217 = llvm.getelementptr %214[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %218 = llvm.load %217 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %219 = arith.cmpi ne, %218, %c0_i8_61 : i8
+    cf.cond_br %219, ^bb1(%218 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_60 = arith.constant 31 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %214 = arith.addi %212, %c31_i64_60 : i64
-    %215 = arith.divui %214, %c32_i64_61 : i64
-    %216 = arith.muli %215, %c32_i64_61 : i64
-    %217 = call @dora_fn_extend_memory(%arg0, %216) : (!llvm.ptr, i64) -> !llvm.ptr
-    %218 = llvm.getelementptr %217[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %219 = llvm.load %218 : !llvm.ptr -> !llvm.ptr
-    %220 = llvm.getelementptr %217[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %221 = llvm.load %220 : !llvm.ptr -> i8
-    %c0_i8_62 = arith.constant 0 : i8
-    %222 = arith.cmpi ne, %221, %c0_i8_62 : i8
-    cf.cond_br %222, ^bb1(%221 : i8), ^bb33
-  ^bb33:  // pred: ^bb32
-    %223 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %219, %223 : !llvm.ptr, !llvm.ptr
-    %224 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %216, %224 : i64, !llvm.ptr
-    %225 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %226 = llvm.load %225 : !llvm.ptr -> i64
+    %220 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %216, %220 : !llvm.ptr, !llvm.ptr
+    %221 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %213, %221 : i64, !llvm.ptr
+    %222 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %223 = llvm.load %222 : !llvm.ptr -> i64
+    %c1_i256_62 = arith.constant 1 : i256
+    %224 = llvm.alloca %c1_i256_62 x i256 : (i256) -> !llvm.ptr
+    llvm.store %177, %224 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_63 = arith.constant 1 : i256
-    %227 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %227 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_64 = arith.constant 1 : i256
-    %228 = llvm.alloca %c1_i256_64 x i256 : (i256) -> !llvm.ptr
-    llvm.store %176, %228 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_65 = arith.constant 1 : i64
-    %229 = llvm.alloca %c1_i64_65 x i64 : (i64) -> !llvm.ptr
+    %225 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
+    llvm.store %173, %225 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_64 = arith.constant 1 : i64
+    %226 = llvm.alloca %c1_i64_64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_65 = arith.constant 0 : i8
+    %227 = call @dora_fn_call(%arg0, %198, %225, %224, %199, %201, %203, %205, %223, %226, %c0_i8_65) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %228 = llvm.getelementptr %227[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %229 = llvm.load %228 : !llvm.ptr -> i8
+    %230 = llvm.getelementptr %227[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %231 = llvm.load %230 : !llvm.ptr -> i8
     %c0_i8_66 = arith.constant 0 : i8
-    %230 = call @dora_fn_call(%arg0, %201, %228, %227, %202, %204, %206, %208, %226, %229, %c0_i8_66) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %231 = llvm.getelementptr %230[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %232 = llvm.load %231 : !llvm.ptr -> i8
-    %233 = llvm.getelementptr %230[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %234 = llvm.load %233 : !llvm.ptr -> i8
-    %c0_i8_67 = arith.constant 0 : i8
-    %235 = arith.cmpi ne, %234, %c0_i8_67 : i8
-    cf.cond_br %235, ^bb1(%234 : i8), ^bb34
+    %232 = arith.cmpi ne, %231, %c0_i8_66 : i8
+    cf.cond_br %232, ^bb1(%231 : i8), ^bb33
+  ^bb33:  // pred: ^bb32
+    %233 = llvm.load %226 : !llvm.ptr -> i64
+    %234 = arith.extui %229 : i8 to i256
+    %235 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %236 = llvm.load %235 : !llvm.ptr -> !llvm.ptr
+    llvm.store %234, %236 : i256, !llvm.ptr
+    %237 = llvm.getelementptr %236[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %237, %235 : !llvm.ptr, !llvm.ptr
+    %238 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_67 = arith.constant 1 : i64
+    %239 = arith.addi %238, %c1_i64_67 : i64
+    llvm.store %239, %9 : i64, !llvm.ptr
+    %240 = arith.cmpi ult, %c1024_i64, %239 : i64
+    %c92_i8_68 = arith.constant 92 : i8
+    cf.cond_br %240, ^bb1(%c92_i8_68 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %236 = llvm.load %229 : !llvm.ptr -> i64
-    %237 = arith.extui %232 : i8 to i256
-    %238 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %239 = llvm.load %238 : !llvm.ptr -> !llvm.ptr
-    llvm.store %237, %239 : i256, !llvm.ptr
-    %240 = llvm.getelementptr %239[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %240, %238 : !llvm.ptr, !llvm.ptr
-    %241 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_68 = arith.constant 1 : i64
-    %242 = arith.addi %241, %c1_i64_68 : i64
-    llvm.store %242, %9 : i64, !llvm.ptr
-    %243 = arith.cmpi ult, %c1024_i64, %242 : i64
-    %c92_i8_69 = arith.constant 92 : i8
-    cf.cond_br %243, ^bb1(%c92_i8_69 : i8), ^bb35
+    %c0_i256_69 = arith.constant 0 : i256
+    %241 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %242 = llvm.load %241 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_69, %242 : i256, !llvm.ptr
+    %243 = llvm.getelementptr %242[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %243, %241 : !llvm.ptr, !llvm.ptr
+    %244 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_70 = arith.constant 1 : i64
+    %245 = arith.addi %244, %c1_i64_70 : i64
+    llvm.store %245, %9 : i64, !llvm.ptr
+    %246 = arith.cmpi ult, %c1024_i64, %245 : i64
+    %c92_i8_71 = arith.constant 92 : i8
+    cf.cond_br %246, ^bb1(%c92_i8_71 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %c0_i256_70 = arith.constant 0 : i256
-    %244 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %245 = llvm.load %244 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_70, %245 : i256, !llvm.ptr
-    %246 = llvm.getelementptr %245[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %246, %244 : !llvm.ptr, !llvm.ptr
-    %247 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_71 = arith.constant 1 : i64
-    %248 = arith.addi %247, %c1_i64_71 : i64
-    llvm.store %248, %9 : i64, !llvm.ptr
-    %249 = arith.cmpi ult, %c1024_i64, %248 : i64
-    %c92_i8_72 = arith.constant 92 : i8
-    cf.cond_br %249, ^bb1(%c92_i8_72 : i8), ^bb36
+    %c0_i256_72 = arith.constant 0 : i256
+    %247 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %248 = llvm.load %247 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_72, %248 : i256, !llvm.ptr
+    %249 = llvm.getelementptr %248[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %249, %247 : !llvm.ptr, !llvm.ptr
+    %250 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_73 = arith.constant 1 : i64
+    %251 = arith.addi %250, %c1_i64_73 : i64
+    llvm.store %251, %9 : i64, !llvm.ptr
+    %252 = arith.cmpi ult, %c1024_i64, %251 : i64
+    %c92_i8_74 = arith.constant 92 : i8
+    cf.cond_br %252, ^bb1(%c92_i8_74 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %c0_i256_73 = arith.constant 0 : i256
-    %250 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %251 = llvm.load %250 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_73, %251 : i256, !llvm.ptr
-    %252 = llvm.getelementptr %251[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %252, %250 : !llvm.ptr, !llvm.ptr
-    %253 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_74 = arith.constant 1 : i64
-    %254 = arith.addi %253, %c1_i64_74 : i64
-    llvm.store %254, %9 : i64, !llvm.ptr
-    %255 = arith.cmpi ult, %c1024_i64, %254 : i64
-    %c92_i8_75 = arith.constant 92 : i8
-    cf.cond_br %255, ^bb1(%c92_i8_75 : i8), ^bb37
-  ^bb37:  // pred: ^bb36
     %c32_i256 = arith.constant 32 : i256
-    %256 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %257 = llvm.load %256 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %257 : i256, !llvm.ptr
-    %258 = llvm.getelementptr %257[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %258, %256 : !llvm.ptr, !llvm.ptr
-    %259 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_76 = arith.constant 1 : i64
-    %260 = arith.addi %259, %c1_i64_76 : i64
-    llvm.store %260, %9 : i64, !llvm.ptr
-    %261 = arith.cmpi ult, %c1024_i64, %260 : i64
-    %c92_i8_77 = arith.constant 92 : i8
-    cf.cond_br %261, ^bb1(%c92_i8_77 : i8), ^bb38
+    %253 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %254 : i256, !llvm.ptr
+    %255 = llvm.getelementptr %254[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %255, %253 : !llvm.ptr, !llvm.ptr
+    %256 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_75 = arith.constant 1 : i64
+    %257 = arith.addi %256, %c1_i64_75 : i64
+    llvm.store %257, %9 : i64, !llvm.ptr
+    %258 = arith.cmpi ult, %c1024_i64, %257 : i64
+    %c92_i8_76 = arith.constant 92 : i8
+    cf.cond_br %258, ^bb1(%c92_i8_76 : i8), ^bb37
+  ^bb37:  // pred: ^bb36
+    %c0_i256_77 = arith.constant 0 : i256
+    %259 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %260 = llvm.load %259 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_77, %260 : i256, !llvm.ptr
+    %261 = llvm.getelementptr %260[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %261, %259 : !llvm.ptr, !llvm.ptr
+    %262 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_78 = arith.constant 1 : i64
+    %263 = arith.addi %262, %c1_i64_78 : i64
+    llvm.store %263, %9 : i64, !llvm.ptr
+    %264 = arith.cmpi ult, %c1024_i64, %263 : i64
+    %c92_i8_79 = arith.constant 92 : i8
+    cf.cond_br %264, ^bb1(%c92_i8_79 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %c0_i256_78 = arith.constant 0 : i256
-    %262 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %263 = llvm.load %262 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_78, %263 : i256, !llvm.ptr
-    %264 = llvm.getelementptr %263[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %264, %262 : !llvm.ptr, !llvm.ptr
-    %265 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %266 = arith.addi %265, %c1_i64_79 : i64
-    llvm.store %266, %9 : i64, !llvm.ptr
-    %267 = arith.cmpi ult, %c1024_i64, %266 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %267, ^bb1(%c92_i8_80 : i8), ^bb39
+    %c0_i256_80 = arith.constant 0 : i256
+    %265 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %266 = llvm.load %265 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_80, %266 : i256, !llvm.ptr
+    %267 = llvm.getelementptr %266[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %267, %265 : !llvm.ptr, !llvm.ptr
+    %268 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_81 = arith.constant 1 : i64
+    %269 = arith.addi %268, %c1_i64_81 : i64
+    llvm.store %269, %9 : i64, !llvm.ptr
+    %270 = arith.cmpi ult, %c1024_i64, %269 : i64
+    %c92_i8_82 = arith.constant 92 : i8
+    cf.cond_br %270, ^bb1(%c92_i8_82 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %c0_i256_81 = arith.constant 0 : i256
-    %268 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %269 = llvm.load %268 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_81, %269 : i256, !llvm.ptr
-    %270 = llvm.getelementptr %269[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %270, %268 : !llvm.ptr, !llvm.ptr
-    %271 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_82 = arith.constant 1 : i64
-    %272 = arith.addi %271, %c1_i64_82 : i64
-    llvm.store %272, %9 : i64, !llvm.ptr
-    %273 = arith.cmpi ult, %c1024_i64, %272 : i64
-    %c92_i8_83 = arith.constant 92 : i8
-    cf.cond_br %273, ^bb1(%c92_i8_83 : i8), ^bb40
+    %271 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %272 = llvm.load %271 : !llvm.ptr -> !llvm.ptr
+    %273 = llvm.getelementptr %272[-7] : (!llvm.ptr) -> !llvm.ptr, i256
+    %274 = llvm.load %273 : !llvm.ptr -> i256
+    %275 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %276 = llvm.load %275 : !llvm.ptr -> !llvm.ptr
+    llvm.store %274, %276 : i256, !llvm.ptr
+    %277 = llvm.getelementptr %276[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %277, %275 : !llvm.ptr, !llvm.ptr
+    %278 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_83 = arith.constant 1 : i64
+    %279 = arith.addi %278, %c1_i64_83 : i64
+    llvm.store %279, %9 : i64, !llvm.ptr
+    %280 = arith.cmpi ult, %c1024_i64, %279 : i64
+    %c92_i8_84 = arith.constant 92 : i8
+    cf.cond_br %280, ^bb1(%c92_i8_84 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %274 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %275 = llvm.load %274 : !llvm.ptr -> !llvm.ptr
-    %276 = llvm.getelementptr %275[-7] : (!llvm.ptr) -> !llvm.ptr, i256
-    %277 = llvm.load %276 : !llvm.ptr -> i256
-    %278 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %279 = llvm.load %278 : !llvm.ptr -> !llvm.ptr
-    llvm.store %277, %279 : i256, !llvm.ptr
-    %280 = llvm.getelementptr %279[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %280, %278 : !llvm.ptr, !llvm.ptr
-    %281 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_84 = arith.constant 1 : i64
-    %282 = arith.addi %281, %c1_i64_84 : i64
-    llvm.store %282, %9 : i64, !llvm.ptr
-    %283 = arith.cmpi ult, %c1024_i64, %282 : i64
-    %c92_i8_85 = arith.constant 92 : i8
-    cf.cond_br %283, ^bb1(%c92_i8_85 : i8), ^bb41
+    %c65535_i256_85 = arith.constant 65535 : i256
+    %281 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %282 = llvm.load %281 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_85, %282 : i256, !llvm.ptr
+    %283 = llvm.getelementptr %282[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %283, %281 : !llvm.ptr, !llvm.ptr
+    %284 = llvm.load %9 : !llvm.ptr -> i64
+    %c-6_i64_86 = arith.constant -6 : i64
+    %285 = arith.addi %284, %c-6_i64_86 : i64
+    llvm.store %285, %9 : i64, !llvm.ptr
+    %c7_i64_87 = arith.constant 7 : i64
+    %286 = arith.cmpi ult, %284, %c7_i64_87 : i64
+    %c91_i8_88 = arith.constant 91 : i8
+    cf.cond_br %286, ^bb1(%c91_i8_88 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %c65535_i256_86 = arith.constant 65535 : i256
-    %284 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %285 = llvm.load %284 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256_86, %285 : i256, !llvm.ptr
-    %286 = llvm.getelementptr %285[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %286, %284 : !llvm.ptr, !llvm.ptr
-    %287 = llvm.load %9 : !llvm.ptr -> i64
-    %c-6_i64_87 = arith.constant -6 : i64
-    %288 = arith.addi %287, %c-6_i64_87 : i64
-    llvm.store %288, %9 : i64, !llvm.ptr
-    %c7_i64_88 = arith.constant 7 : i64
-    %289 = arith.cmpi ult, %287, %c7_i64_88 : i64
-    %c91_i8_89 = arith.constant 91 : i8
-    cf.cond_br %289, ^bb1(%c91_i8_89 : i8), ^bb42
+    %287 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %288 = llvm.load %287 : !llvm.ptr -> !llvm.ptr
+    %289 = llvm.getelementptr %288[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %290 = llvm.load %289 : !llvm.ptr -> i256
+    llvm.store %289, %287 : !llvm.ptr, !llvm.ptr
+    %291 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %292 = llvm.load %291 : !llvm.ptr -> !llvm.ptr
+    %293 = llvm.getelementptr %292[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %294 = llvm.load %293 : !llvm.ptr -> i256
+    llvm.store %293, %291 : !llvm.ptr, !llvm.ptr
+    %295 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %296 = llvm.load %295 : !llvm.ptr -> !llvm.ptr
+    %297 = llvm.getelementptr %296[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %298 = llvm.load %297 : !llvm.ptr -> i256
+    llvm.store %297, %295 : !llvm.ptr, !llvm.ptr
+    %299 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %300 = llvm.load %299 : !llvm.ptr -> !llvm.ptr
+    %301 = llvm.getelementptr %300[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %302 = llvm.load %301 : !llvm.ptr -> i256
+    llvm.store %301, %299 : !llvm.ptr, !llvm.ptr
+    %303 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %304 = llvm.load %303 : !llvm.ptr -> !llvm.ptr
+    %305 = llvm.getelementptr %304[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %306 = llvm.load %305 : !llvm.ptr -> i256
+    llvm.store %305, %303 : !llvm.ptr, !llvm.ptr
+    %307 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %308 = llvm.load %307 : !llvm.ptr -> !llvm.ptr
+    %309 = llvm.getelementptr %308[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %310 = llvm.load %309 : !llvm.ptr -> i256
+    llvm.store %309, %307 : !llvm.ptr, !llvm.ptr
+    %311 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %312 = llvm.load %311 : !llvm.ptr -> !llvm.ptr
+    %313 = llvm.getelementptr %312[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %314 = llvm.load %313 : !llvm.ptr -> i256
+    llvm.store %313, %311 : !llvm.ptr, !llvm.ptr
+    %315 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %316 = llvm.load %315 : !llvm.ptr -> i1
+    %c0_i256_89 = arith.constant 0 : i256
+    %317 = arith.cmpi ne, %298, %c0_i256_89 : i256
+    %318 = arith.andi %316, %317 : i1
+    %c86_i8_90 = arith.constant 86 : i8
+    cf.cond_br %318, ^bb1(%c86_i8_90 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %290 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %291 = llvm.load %290 : !llvm.ptr -> !llvm.ptr
-    %292 = llvm.getelementptr %291[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %293 = llvm.load %292 : !llvm.ptr -> i256
-    llvm.store %292, %290 : !llvm.ptr, !llvm.ptr
-    %294 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %295 = llvm.load %294 : !llvm.ptr -> !llvm.ptr
-    %296 = llvm.getelementptr %295[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %297 = llvm.load %296 : !llvm.ptr -> i256
-    llvm.store %296, %294 : !llvm.ptr, !llvm.ptr
-    %298 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %299 = llvm.load %298 : !llvm.ptr -> !llvm.ptr
-    %300 = llvm.getelementptr %299[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %301 = llvm.load %300 : !llvm.ptr -> i256
-    llvm.store %300, %298 : !llvm.ptr, !llvm.ptr
-    %302 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %303 = llvm.load %302 : !llvm.ptr -> !llvm.ptr
-    %304 = llvm.getelementptr %303[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %305 = llvm.load %304 : !llvm.ptr -> i256
-    llvm.store %304, %302 : !llvm.ptr, !llvm.ptr
-    %306 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %307 = llvm.load %306 : !llvm.ptr -> !llvm.ptr
-    %308 = llvm.getelementptr %307[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %309 = llvm.load %308 : !llvm.ptr -> i256
-    llvm.store %308, %306 : !llvm.ptr, !llvm.ptr
-    %310 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %311 = llvm.load %310 : !llvm.ptr -> !llvm.ptr
-    %312 = llvm.getelementptr %311[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %313 = llvm.load %312 : !llvm.ptr -> i256
-    llvm.store %312, %310 : !llvm.ptr, !llvm.ptr
-    %314 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %315 = llvm.load %314 : !llvm.ptr -> !llvm.ptr
-    %316 = llvm.getelementptr %315[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %317 = llvm.load %316 : !llvm.ptr -> i256
-    llvm.store %316, %314 : !llvm.ptr, !llvm.ptr
-    %318 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %319 = llvm.load %318 : !llvm.ptr -> i1
-    %c0_i256_90 = arith.constant 0 : i256
-    %320 = arith.cmpi ne, %301, %c0_i256_90 : i256
-    %321 = arith.andi %319, %320 : i1
-    %c86_i8_91 = arith.constant 86 : i8
-    cf.cond_br %321, ^bb1(%c86_i8_91 : i8), ^bb43
+    %319 = arith.trunci %290 : i256 to i64
+    %320 = arith.trunci %302 : i256 to i64
+    %c0_i64_91 = arith.constant 0 : i64
+    %321 = arith.cmpi slt, %320, %c0_i64_91 : i64
+    %c84_i8_92 = arith.constant 84 : i8
+    cf.cond_br %321, ^bb1(%c84_i8_92 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %322 = arith.trunci %293 : i256 to i64
-    %323 = arith.trunci %305 : i256 to i64
-    %c0_i64_92 = arith.constant 0 : i64
-    %324 = arith.cmpi slt, %323, %c0_i64_92 : i64
-    %c84_i8_93 = arith.constant 84 : i8
-    cf.cond_br %324, ^bb1(%c84_i8_93 : i8), ^bb44
+    %322 = arith.trunci %306 : i256 to i64
+    %c0_i64_93 = arith.constant 0 : i64
+    %323 = arith.cmpi slt, %322, %c0_i64_93 : i64
+    %c84_i8_94 = arith.constant 84 : i8
+    cf.cond_br %323, ^bb1(%c84_i8_94 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %325 = arith.trunci %309 : i256 to i64
-    %c0_i64_94 = arith.constant 0 : i64
-    %326 = arith.cmpi slt, %325, %c0_i64_94 : i64
-    %c84_i8_95 = arith.constant 84 : i8
-    cf.cond_br %326, ^bb1(%c84_i8_95 : i8), ^bb45
+    %324 = arith.trunci %310 : i256 to i64
+    %c0_i64_95 = arith.constant 0 : i64
+    %325 = arith.cmpi slt, %324, %c0_i64_95 : i64
+    %c84_i8_96 = arith.constant 84 : i8
+    cf.cond_br %325, ^bb1(%c84_i8_96 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %327 = arith.trunci %313 : i256 to i64
-    %c0_i64_96 = arith.constant 0 : i64
-    %328 = arith.cmpi slt, %327, %c0_i64_96 : i64
-    %c84_i8_97 = arith.constant 84 : i8
-    cf.cond_br %328, ^bb1(%c84_i8_97 : i8), ^bb46
+    %326 = arith.trunci %314 : i256 to i64
+    %c0_i64_97 = arith.constant 0 : i64
+    %327 = arith.cmpi slt, %326, %c0_i64_97 : i64
+    %c84_i8_98 = arith.constant 84 : i8
+    cf.cond_br %327, ^bb1(%c84_i8_98 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %329 = arith.trunci %317 : i256 to i64
-    %c0_i64_98 = arith.constant 0 : i64
-    %330 = arith.cmpi slt, %329, %c0_i64_98 : i64
-    %c84_i8_99 = arith.constant 84 : i8
-    cf.cond_br %330, ^bb1(%c84_i8_99 : i8), ^bb47
+    %328 = arith.addi %320, %322 : i64
+    %329 = arith.addi %324, %326 : i64
+    %330 = arith.maxui %328, %329 : i64
+    %c0_i64_99 = arith.constant 0 : i64
+    %331 = arith.cmpi slt, %330, %c0_i64_99 : i64
+    %c84_i8_100 = arith.constant 84 : i8
+    cf.cond_br %331, ^bb1(%c84_i8_100 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %331 = arith.addi %323, %325 : i64
-    %332 = arith.addi %327, %329 : i64
-    %333 = arith.maxui %331, %332 : i64
-    %c0_i64_100 = arith.constant 0 : i64
-    %334 = arith.cmpi slt, %333, %c0_i64_100 : i64
-    %c84_i8_101 = arith.constant 84 : i8
-    cf.cond_br %334, ^bb1(%c84_i8_101 : i8), ^bb48
+    %c31_i64_101 = arith.constant 31 : i64
+    %c32_i64_102 = arith.constant 32 : i64
+    %332 = arith.addi %330, %c31_i64_101 : i64
+    %333 = arith.divui %332, %c32_i64_102 : i64
+    %334 = arith.muli %333, %c32_i64_102 : i64
+    %335 = call @dora_fn_extend_memory(%arg0, %334) : (!llvm.ptr, i64) -> !llvm.ptr
+    %336 = llvm.getelementptr %335[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %337 = llvm.load %336 : !llvm.ptr -> !llvm.ptr
+    %338 = llvm.getelementptr %335[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %339 = llvm.load %338 : !llvm.ptr -> i8
+    %c0_i8_103 = arith.constant 0 : i8
+    %340 = arith.cmpi ne, %339, %c0_i8_103 : i8
+    cf.cond_br %340, ^bb1(%339 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %c31_i64_102 = arith.constant 31 : i64
-    %c32_i64_103 = arith.constant 32 : i64
-    %335 = arith.addi %333, %c31_i64_102 : i64
-    %336 = arith.divui %335, %c32_i64_103 : i64
-    %337 = arith.muli %336, %c32_i64_103 : i64
-    %338 = call @dora_fn_extend_memory(%arg0, %337) : (!llvm.ptr, i64) -> !llvm.ptr
-    %339 = llvm.getelementptr %338[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %340 = llvm.load %339 : !llvm.ptr -> !llvm.ptr
-    %341 = llvm.getelementptr %338[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %342 = llvm.load %341 : !llvm.ptr -> i8
-    %c0_i8_104 = arith.constant 0 : i8
-    %343 = arith.cmpi ne, %342, %c0_i8_104 : i8
-    cf.cond_br %343, ^bb1(%342 : i8), ^bb49
-  ^bb49:  // pred: ^bb48
-    %344 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %340, %344 : !llvm.ptr, !llvm.ptr
-    %345 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %337, %345 : i64, !llvm.ptr
-    %346 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %347 = llvm.load %346 : !llvm.ptr -> i64
+    %341 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %337, %341 : !llvm.ptr, !llvm.ptr
+    %342 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %334, %342 : i64, !llvm.ptr
+    %343 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %344 = llvm.load %343 : !llvm.ptr -> i64
+    %c1_i256_104 = arith.constant 1 : i256
+    %345 = llvm.alloca %c1_i256_104 x i256 : (i256) -> !llvm.ptr
+    llvm.store %298, %345 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_105 = arith.constant 1 : i256
-    %348 = llvm.alloca %c1_i256_105 x i256 : (i256) -> !llvm.ptr
-    llvm.store %301, %348 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_106 = arith.constant 1 : i256
-    %349 = llvm.alloca %c1_i256_106 x i256 : (i256) -> !llvm.ptr
-    llvm.store %297, %349 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_107 = arith.constant 1 : i64
-    %350 = llvm.alloca %c1_i64_107 x i64 : (i64) -> !llvm.ptr
+    %346 = llvm.alloca %c1_i256_105 x i256 : (i256) -> !llvm.ptr
+    llvm.store %294, %346 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_106 = arith.constant 1 : i64
+    %347 = llvm.alloca %c1_i64_106 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_107 = arith.constant 0 : i8
+    %348 = call @dora_fn_call(%arg0, %319, %346, %345, %320, %322, %324, %326, %344, %347, %c0_i8_107) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %349 = llvm.getelementptr %348[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %350 = llvm.load %349 : !llvm.ptr -> i8
+    %351 = llvm.getelementptr %348[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %352 = llvm.load %351 : !llvm.ptr -> i8
     %c0_i8_108 = arith.constant 0 : i8
-    %351 = call @dora_fn_call(%arg0, %322, %349, %348, %323, %325, %327, %329, %347, %350, %c0_i8_108) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %352 = llvm.getelementptr %351[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %353 = llvm.load %352 : !llvm.ptr -> i8
-    %354 = llvm.getelementptr %351[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %355 = llvm.load %354 : !llvm.ptr -> i8
-    %c0_i8_109 = arith.constant 0 : i8
-    %356 = arith.cmpi ne, %355, %c0_i8_109 : i8
-    cf.cond_br %356, ^bb1(%355 : i8), ^bb50
+    %353 = arith.cmpi ne, %352, %c0_i8_108 : i8
+    cf.cond_br %353, ^bb1(%352 : i8), ^bb49
+  ^bb49:  // pred: ^bb48
+    %354 = llvm.load %347 : !llvm.ptr -> i64
+    %355 = arith.extui %350 : i8 to i256
+    %356 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %357 = llvm.load %356 : !llvm.ptr -> !llvm.ptr
+    llvm.store %355, %357 : i256, !llvm.ptr
+    %358 = llvm.getelementptr %357[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %358, %356 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb50
   ^bb50:  // pred: ^bb49
-    %357 = llvm.load %350 : !llvm.ptr -> i64
-    %358 = arith.extui %353 : i8 to i256
-    %359 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %360 = llvm.load %359 : !llvm.ptr -> !llvm.ptr
-    llvm.store %358, %360 : i256, !llvm.ptr
-    %361 = llvm.getelementptr %360[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %361, %359 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb51
-  ^bb51:  // pred: ^bb50
-    %c0_i64_110 = arith.constant 0 : i64
+    %c0_i64_109 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %362 = call @dora_fn_write_result(%arg0, %c0_i64_110, %c0_i64_110, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %359 = call @dora_fn_write_result(%arg0, %c0_i64_109, %c0_i64_109, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 52 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49, ^bb50, ^bb51, ^bb52
+  ^bb1(%13: i8):  // 51 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49, ^bb50, ^bb51
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -278,546 +278,539 @@ module {
     %108 = llvm.alloca %c1_i64_26 x i64 : (i64) -> !llvm.ptr
     llvm.store %107, %108 {alignment = 1 : i64} : i64, !llvm.ptr
     %109 = call @dora_fn_create(%arg0, %90, %88, %105, %108) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %110 = llvm.getelementptr %109[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %110 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %111 = llvm.load %110 : !llvm.ptr -> i8
-    %112 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %113 = llvm.load %112 : !llvm.ptr -> i8
     %c0_i8_27 = arith.constant 0 : i8
-    %114 = arith.cmpi ne, %113, %c0_i8_27 : i8
-    cf.cond_br %114, ^bb1(%113 : i8), ^bb17
+    %112 = arith.cmpi ne, %111, %c0_i8_27 : i8
+    cf.cond_br %112, ^bb1(%111 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i8_28 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %c0_i8_28, %111 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %115, ^bb1(%c94_i8 : i8), ^bb18
+    %113 = llvm.load %105 : !llvm.ptr -> i256
+    %114 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> !llvm.ptr
+    llvm.store %113, %115 : i256, !llvm.ptr
+    %116 = llvm.getelementptr %115[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %116, %114 : !llvm.ptr, !llvm.ptr
+    %117 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_28 = arith.constant 1 : i64
+    %118 = arith.addi %117, %c1_i64_28 : i64
+    llvm.store %118, %9 : i64, !llvm.ptr
+    %119 = arith.cmpi ult, %c1024_i64, %118 : i64
+    %c92_i8_29 = arith.constant 92 : i8
+    cf.cond_br %119, ^bb1(%c92_i8_29 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %116 = llvm.load %105 : !llvm.ptr -> i256
-    %117 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %118 = llvm.load %117 : !llvm.ptr -> !llvm.ptr
-    llvm.store %116, %118 : i256, !llvm.ptr
-    %119 = llvm.getelementptr %118[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %119, %117 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_29 : i64
-    llvm.store %121, %9 : i64, !llvm.ptr
-    %122 = arith.cmpi ult, %c1024_i64, %121 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_30 : i8), ^bb19
+    %c0_i256_30 = arith.constant 0 : i256
+    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_30, %121 : i256, !llvm.ptr
+    %122 = llvm.getelementptr %121[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
+    %123 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_31 = arith.constant 1 : i64
+    %124 = arith.addi %123, %c1_i64_31 : i64
+    llvm.store %124, %9 : i64, !llvm.ptr
+    %125 = arith.cmpi ult, %c1024_i64, %124 : i64
+    %c92_i8_32 = arith.constant 92 : i8
+    cf.cond_br %125, ^bb1(%c92_i8_32 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %c0_i256_31 = arith.constant 0 : i256
-    %123 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %124 = llvm.load %123 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_31, %124 : i256, !llvm.ptr
-    %125 = llvm.getelementptr %124[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %125, %123 : !llvm.ptr, !llvm.ptr
-    %126 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %127 = arith.addi %126, %c1_i64_32 : i64
-    llvm.store %127, %9 : i64, !llvm.ptr
-    %128 = arith.cmpi ult, %c1024_i64, %127 : i64
-    %c92_i8_33 = arith.constant 92 : i8
-    cf.cond_br %128, ^bb1(%c92_i8_33 : i8), ^bb20
+    %c0_i256_33 = arith.constant 0 : i256
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_33, %127 : i256, !llvm.ptr
+    %128 = llvm.getelementptr %127[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %129 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %130 = arith.addi %129, %c1_i64_34 : i64
+    llvm.store %130, %9 : i64, !llvm.ptr
+    %131 = arith.cmpi ult, %c1024_i64, %130 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %131, ^bb1(%c92_i8_35 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %c0_i256_34 = arith.constant 0 : i256
-    %129 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %130 = llvm.load %129 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_34, %130 : i256, !llvm.ptr
-    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %131, %129 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %133 = arith.addi %132, %c1_i64_35 : i64
-    llvm.store %133, %9 : i64, !llvm.ptr
-    %134 = arith.cmpi ult, %c1024_i64, %133 : i64
-    %c92_i8_36 = arith.constant 92 : i8
-    cf.cond_br %134, ^bb1(%c92_i8_36 : i8), ^bb21
+    %c0_i256_36 = arith.constant 0 : i256
+    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_36, %133 : i256, !llvm.ptr
+    %134 = llvm.getelementptr %133[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
+    %135 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_37 = arith.constant 1 : i64
+    %136 = arith.addi %135, %c1_i64_37 : i64
+    llvm.store %136, %9 : i64, !llvm.ptr
+    %137 = arith.cmpi ult, %c1024_i64, %136 : i64
+    %c92_i8_38 = arith.constant 92 : i8
+    cf.cond_br %137, ^bb1(%c92_i8_38 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_37 = arith.constant 0 : i256
-    %135 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %136 = llvm.load %135 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_37, %136 : i256, !llvm.ptr
-    %137 = llvm.getelementptr %136[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %137, %135 : !llvm.ptr, !llvm.ptr
-    %138 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_38 : i64
-    llvm.store %139, %9 : i64, !llvm.ptr
-    %140 = arith.cmpi ult, %c1024_i64, %139 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_39 : i8), ^bb22
+    %c0_i256_39 = arith.constant 0 : i256
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_39, %139 : i256, !llvm.ptr
+    %140 = llvm.getelementptr %139[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %141 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %142 = arith.addi %141, %c1_i64_40 : i64
+    llvm.store %142, %9 : i64, !llvm.ptr
+    %143 = arith.cmpi ult, %c1024_i64, %142 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %143, ^bb1(%c92_i8_41 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_40 = arith.constant 0 : i256
-    %141 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %142 = llvm.load %141 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_40, %142 : i256, !llvm.ptr
-    %143 = llvm.getelementptr %142[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %143, %141 : !llvm.ptr, !llvm.ptr
-    %144 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_41 = arith.constant 1 : i64
-    %145 = arith.addi %144, %c1_i64_41 : i64
-    llvm.store %145, %9 : i64, !llvm.ptr
-    %146 = arith.cmpi ult, %c1024_i64, %145 : i64
-    %c92_i8_42 = arith.constant 92 : i8
-    cf.cond_br %146, ^bb1(%c92_i8_42 : i8), ^bb23
+    %c0_i256_42 = arith.constant 0 : i256
+    %144 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %145 = llvm.load %144 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_42, %145 : i256, !llvm.ptr
+    %146 = llvm.getelementptr %145[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %146, %144 : !llvm.ptr, !llvm.ptr
+    %147 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_43 = arith.constant 1 : i64
+    %148 = arith.addi %147, %c1_i64_43 : i64
+    llvm.store %148, %9 : i64, !llvm.ptr
+    %149 = arith.cmpi ult, %c1024_i64, %148 : i64
+    %c92_i8_44 = arith.constant 92 : i8
+    cf.cond_br %149, ^bb1(%c92_i8_44 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_43 = arith.constant 0 : i256
-    %147 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_43, %148 : i256, !llvm.ptr
-    %149 = llvm.getelementptr %148[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %149, %147 : !llvm.ptr, !llvm.ptr
-    %150 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %151 = arith.addi %150, %c1_i64_44 : i64
-    llvm.store %151, %9 : i64, !llvm.ptr
-    %152 = arith.cmpi ult, %c1024_i64, %151 : i64
-    %c92_i8_45 = arith.constant 92 : i8
-    cf.cond_br %152, ^bb1(%c92_i8_45 : i8), ^bb24
+    %150 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %151 = llvm.load %150 : !llvm.ptr -> !llvm.ptr
+    %152 = llvm.getelementptr %151[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %153 = llvm.load %152 : !llvm.ptr -> i256
+    %154 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %155 = llvm.load %154 : !llvm.ptr -> !llvm.ptr
+    llvm.store %153, %155 : i256, !llvm.ptr
+    %156 = llvm.getelementptr %155[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %156, %154 : !llvm.ptr, !llvm.ptr
+    %157 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_45 = arith.constant 1 : i64
+    %158 = arith.addi %157, %c1_i64_45 : i64
+    llvm.store %158, %9 : i64, !llvm.ptr
+    %159 = arith.cmpi ult, %c1024_i64, %158 : i64
+    %c92_i8_46 = arith.constant 92 : i8
+    cf.cond_br %159, ^bb1(%c92_i8_46 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %153 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
-    %155 = llvm.getelementptr %154[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
-    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
-    %160 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_46 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_46 : i64
-    llvm.store %161, %9 : i64, !llvm.ptr
-    %162 = arith.cmpi ult, %c1024_i64, %161 : i64
-    %c92_i8_47 = arith.constant 92 : i8
-    cf.cond_br %162, ^bb1(%c92_i8_47 : i8), ^bb25
-  ^bb25:  // pred: ^bb24
     %c65535_i256 = arith.constant 65535 : i256
-    %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %164 : i256, !llvm.ptr
-    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    %166 = llvm.load %9 : !llvm.ptr -> i64
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
+    %163 = llvm.load %9 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %167 = arith.addi %166, %c-6_i64 : i64
-    llvm.store %167, %9 : i64, !llvm.ptr
+    %164 = arith.addi %163, %c-6_i64 : i64
+    llvm.store %164, %9 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %168 = arith.cmpi ult, %166, %c7_i64 : i64
-    %c91_i8_48 = arith.constant 91 : i8
-    cf.cond_br %168, ^bb1(%c91_i8_48 : i8), ^bb26
-  ^bb26:  // pred: ^bb25
-    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
-    %171 = llvm.getelementptr %170[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %172 = llvm.load %171 : !llvm.ptr -> i256
-    llvm.store %171, %169 : !llvm.ptr, !llvm.ptr
-    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
-    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %176 = llvm.load %175 : !llvm.ptr -> i256
-    llvm.store %175, %173 : !llvm.ptr, !llvm.ptr
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    %179 = llvm.getelementptr %178[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    %181 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %182 = llvm.load %181 : !llvm.ptr -> !llvm.ptr
-    %183 = llvm.getelementptr %182[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    llvm.store %183, %181 : !llvm.ptr, !llvm.ptr
-    %185 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
-    %187 = llvm.getelementptr %186[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    llvm.store %187, %185 : !llvm.ptr, !llvm.ptr
-    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
-    %191 = llvm.getelementptr %190[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
-    %193 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
-    %195 = llvm.getelementptr %194[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    llvm.store %195, %193 : !llvm.ptr, !llvm.ptr
-    %197 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %198 = llvm.load %197 : !llvm.ptr -> i1
-    %c0_i256_49 = arith.constant 0 : i256
-    %199 = arith.cmpi ne, %180, %c0_i256_49 : i256
-    %200 = arith.andi %198, %199 : i1
+    %165 = arith.cmpi ult, %163, %c7_i64 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %165, ^bb1(%c91_i8_47 : i8), ^bb25
+  ^bb25:  // pred: ^bb24
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    %168 = llvm.getelementptr %167[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %169 = llvm.load %168 : !llvm.ptr -> i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %170 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
+    %176 = llvm.getelementptr %175[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %177 = llvm.load %176 : !llvm.ptr -> i256
+    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
+    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    %180 = llvm.getelementptr %179[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %181 = llvm.load %180 : !llvm.ptr -> i256
+    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
+    %182 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %183 = llvm.load %182 : !llvm.ptr -> !llvm.ptr
+    %184 = llvm.getelementptr %183[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %185 = llvm.load %184 : !llvm.ptr -> i256
+    llvm.store %184, %182 : !llvm.ptr, !llvm.ptr
+    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
+    %188 = llvm.getelementptr %187[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %189 = llvm.load %188 : !llvm.ptr -> i256
+    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
+    %190 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
+    %192 = llvm.getelementptr %191[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %193 = llvm.load %192 : !llvm.ptr -> i256
+    llvm.store %192, %190 : !llvm.ptr, !llvm.ptr
+    %194 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %195 = llvm.load %194 : !llvm.ptr -> i1
+    %c0_i256_48 = arith.constant 0 : i256
+    %196 = arith.cmpi ne, %177, %c0_i256_48 : i256
+    %197 = arith.andi %195, %196 : i1
     %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %200, ^bb1(%c86_i8 : i8), ^bb27
+    cf.cond_br %197, ^bb1(%c86_i8 : i8), ^bb26
+  ^bb26:  // pred: ^bb25
+    %198 = arith.trunci %169 : i256 to i64
+    %199 = arith.trunci %181 : i256 to i64
+    %c0_i64_49 = arith.constant 0 : i64
+    %200 = arith.cmpi slt, %199, %c0_i64_49 : i64
+    %c84_i8_50 = arith.constant 84 : i8
+    cf.cond_br %200, ^bb1(%c84_i8_50 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %201 = arith.trunci %172 : i256 to i64
-    %202 = arith.trunci %184 : i256 to i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %203 = arith.cmpi slt, %202, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %203, ^bb1(%c84_i8_51 : i8), ^bb28
+    %201 = arith.trunci %185 : i256 to i64
+    %c0_i64_51 = arith.constant 0 : i64
+    %202 = arith.cmpi slt, %201, %c0_i64_51 : i64
+    %c84_i8_52 = arith.constant 84 : i8
+    cf.cond_br %202, ^bb1(%c84_i8_52 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %204 = arith.trunci %188 : i256 to i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %205 = arith.cmpi slt, %204, %c0_i64_52 : i64
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %205, ^bb1(%c84_i8_53 : i8), ^bb29
+    %203 = arith.trunci %189 : i256 to i64
+    %c0_i64_53 = arith.constant 0 : i64
+    %204 = arith.cmpi slt, %203, %c0_i64_53 : i64
+    %c84_i8_54 = arith.constant 84 : i8
+    cf.cond_br %204, ^bb1(%c84_i8_54 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %206 = arith.trunci %192 : i256 to i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %207 = arith.cmpi slt, %206, %c0_i64_54 : i64
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %207, ^bb1(%c84_i8_55 : i8), ^bb30
+    %205 = arith.trunci %193 : i256 to i64
+    %c0_i64_55 = arith.constant 0 : i64
+    %206 = arith.cmpi slt, %205, %c0_i64_55 : i64
+    %c84_i8_56 = arith.constant 84 : i8
+    cf.cond_br %206, ^bb1(%c84_i8_56 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %208 = arith.trunci %196 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %209 = arith.cmpi slt, %208, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %209, ^bb1(%c84_i8_57 : i8), ^bb31
+    %207 = arith.addi %199, %201 : i64
+    %208 = arith.addi %203, %205 : i64
+    %209 = arith.maxui %207, %208 : i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %210 = arith.cmpi slt, %209, %c0_i64_57 : i64
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %210, ^bb1(%c84_i8_58 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %210 = arith.addi %202, %204 : i64
-    %211 = arith.addi %206, %208 : i64
-    %212 = arith.maxui %210, %211 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %213 = arith.cmpi slt, %212, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %213, ^bb1(%c84_i8_59 : i8), ^bb32
+    %c31_i64_59 = arith.constant 31 : i64
+    %c32_i64_60 = arith.constant 32 : i64
+    %211 = arith.addi %209, %c31_i64_59 : i64
+    %212 = arith.divui %211, %c32_i64_60 : i64
+    %213 = arith.muli %212, %c32_i64_60 : i64
+    %214 = call @dora_fn_extend_memory(%arg0, %213) : (!llvm.ptr, i64) -> !llvm.ptr
+    %215 = llvm.getelementptr %214[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %216 = llvm.load %215 : !llvm.ptr -> !llvm.ptr
+    %217 = llvm.getelementptr %214[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %218 = llvm.load %217 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %219 = arith.cmpi ne, %218, %c0_i8_61 : i8
+    cf.cond_br %219, ^bb1(%218 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_60 = arith.constant 31 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %214 = arith.addi %212, %c31_i64_60 : i64
-    %215 = arith.divui %214, %c32_i64_61 : i64
-    %216 = arith.muli %215, %c32_i64_61 : i64
-    %217 = call @dora_fn_extend_memory(%arg0, %216) : (!llvm.ptr, i64) -> !llvm.ptr
-    %218 = llvm.getelementptr %217[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %219 = llvm.load %218 : !llvm.ptr -> !llvm.ptr
-    %220 = llvm.getelementptr %217[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %221 = llvm.load %220 : !llvm.ptr -> i8
-    %c0_i8_62 = arith.constant 0 : i8
-    %222 = arith.cmpi ne, %221, %c0_i8_62 : i8
-    cf.cond_br %222, ^bb1(%221 : i8), ^bb33
-  ^bb33:  // pred: ^bb32
-    %223 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %219, %223 : !llvm.ptr, !llvm.ptr
-    %224 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %216, %224 : i64, !llvm.ptr
-    %225 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %226 = llvm.load %225 : !llvm.ptr -> i64
+    %220 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %216, %220 : !llvm.ptr, !llvm.ptr
+    %221 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %213, %221 : i64, !llvm.ptr
+    %222 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %223 = llvm.load %222 : !llvm.ptr -> i64
+    %c1_i256_62 = arith.constant 1 : i256
+    %224 = llvm.alloca %c1_i256_62 x i256 : (i256) -> !llvm.ptr
+    llvm.store %177, %224 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_63 = arith.constant 1 : i256
-    %227 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %227 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_64 = arith.constant 1 : i256
-    %228 = llvm.alloca %c1_i256_64 x i256 : (i256) -> !llvm.ptr
-    llvm.store %176, %228 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_65 = arith.constant 1 : i64
-    %229 = llvm.alloca %c1_i64_65 x i64 : (i64) -> !llvm.ptr
+    %225 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
+    llvm.store %173, %225 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_64 = arith.constant 1 : i64
+    %226 = llvm.alloca %c1_i64_64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_65 = arith.constant 0 : i8
+    %227 = call @dora_fn_call(%arg0, %198, %225, %224, %199, %201, %203, %205, %223, %226, %c0_i8_65) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %228 = llvm.getelementptr %227[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %229 = llvm.load %228 : !llvm.ptr -> i8
+    %230 = llvm.getelementptr %227[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %231 = llvm.load %230 : !llvm.ptr -> i8
     %c0_i8_66 = arith.constant 0 : i8
-    %230 = call @dora_fn_call(%arg0, %201, %228, %227, %202, %204, %206, %208, %226, %229, %c0_i8_66) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %231 = llvm.getelementptr %230[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %232 = llvm.load %231 : !llvm.ptr -> i8
-    %233 = llvm.getelementptr %230[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %234 = llvm.load %233 : !llvm.ptr -> i8
-    %c0_i8_67 = arith.constant 0 : i8
-    %235 = arith.cmpi ne, %234, %c0_i8_67 : i8
-    cf.cond_br %235, ^bb1(%234 : i8), ^bb34
+    %232 = arith.cmpi ne, %231, %c0_i8_66 : i8
+    cf.cond_br %232, ^bb1(%231 : i8), ^bb33
+  ^bb33:  // pred: ^bb32
+    %233 = llvm.load %226 : !llvm.ptr -> i64
+    %234 = arith.extui %229 : i8 to i256
+    %235 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %236 = llvm.load %235 : !llvm.ptr -> !llvm.ptr
+    llvm.store %234, %236 : i256, !llvm.ptr
+    %237 = llvm.getelementptr %236[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %237, %235 : !llvm.ptr, !llvm.ptr
+    %238 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_67 = arith.constant 1 : i64
+    %239 = arith.addi %238, %c1_i64_67 : i64
+    llvm.store %239, %9 : i64, !llvm.ptr
+    %240 = arith.cmpi ult, %c1024_i64, %239 : i64
+    %c92_i8_68 = arith.constant 92 : i8
+    cf.cond_br %240, ^bb1(%c92_i8_68 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %236 = llvm.load %229 : !llvm.ptr -> i64
-    %237 = arith.extui %232 : i8 to i256
-    %238 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %239 = llvm.load %238 : !llvm.ptr -> !llvm.ptr
-    llvm.store %237, %239 : i256, !llvm.ptr
-    %240 = llvm.getelementptr %239[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %240, %238 : !llvm.ptr, !llvm.ptr
-    %241 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_68 = arith.constant 1 : i64
-    %242 = arith.addi %241, %c1_i64_68 : i64
-    llvm.store %242, %9 : i64, !llvm.ptr
-    %243 = arith.cmpi ult, %c1024_i64, %242 : i64
-    %c92_i8_69 = arith.constant 92 : i8
-    cf.cond_br %243, ^bb1(%c92_i8_69 : i8), ^bb35
+    %c1_i256_69 = arith.constant 1 : i256
+    %241 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %242 = llvm.load %241 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_69, %242 : i256, !llvm.ptr
+    %243 = llvm.getelementptr %242[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %243, %241 : !llvm.ptr, !llvm.ptr
+    %244 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_70 = arith.constant 1 : i64
+    %245 = arith.addi %244, %c1_i64_70 : i64
+    llvm.store %245, %9 : i64, !llvm.ptr
+    %246 = arith.cmpi ult, %c1024_i64, %245 : i64
+    %c92_i8_71 = arith.constant 92 : i8
+    cf.cond_br %246, ^bb1(%c92_i8_71 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %c1_i256_70 = arith.constant 1 : i256
-    %244 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %245 = llvm.load %244 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c1_i256_70, %245 : i256, !llvm.ptr
-    %246 = llvm.getelementptr %245[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %246, %244 : !llvm.ptr, !llvm.ptr
-    %247 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_71 = arith.constant 1 : i64
-    %248 = arith.addi %247, %c1_i64_71 : i64
-    llvm.store %248, %9 : i64, !llvm.ptr
-    %249 = arith.cmpi ult, %c1024_i64, %248 : i64
-    %c92_i8_72 = arith.constant 92 : i8
-    cf.cond_br %249, ^bb1(%c92_i8_72 : i8), ^bb36
+    %c0_i256_72 = arith.constant 0 : i256
+    %247 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %248 = llvm.load %247 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_72, %248 : i256, !llvm.ptr
+    %249 = llvm.getelementptr %248[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %249, %247 : !llvm.ptr, !llvm.ptr
+    %250 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_73 = arith.constant -2 : i64
+    %251 = arith.addi %250, %c-2_i64_73 : i64
+    llvm.store %251, %9 : i64, !llvm.ptr
+    %c2_i64_74 = arith.constant 2 : i64
+    %252 = arith.cmpi ult, %250, %c2_i64_74 : i64
+    %c91_i8_75 = arith.constant 91 : i8
+    cf.cond_br %252, ^bb1(%c91_i8_75 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %c0_i256_73 = arith.constant 0 : i256
-    %250 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %251 = llvm.load %250 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_73, %251 : i256, !llvm.ptr
-    %252 = llvm.getelementptr %251[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %252, %250 : !llvm.ptr, !llvm.ptr
-    %253 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_74 = arith.constant -2 : i64
-    %254 = arith.addi %253, %c-2_i64_74 : i64
-    llvm.store %254, %9 : i64, !llvm.ptr
-    %c2_i64_75 = arith.constant 2 : i64
-    %255 = arith.cmpi ult, %253, %c2_i64_75 : i64
-    %c91_i8_76 = arith.constant 91 : i8
-    cf.cond_br %255, ^bb1(%c91_i8_76 : i8), ^bb37
-  ^bb37:  // pred: ^bb36
-    %256 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %257 = llvm.load %256 : !llvm.ptr -> !llvm.ptr
-    %258 = llvm.getelementptr %257[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %259 = llvm.load %258 : !llvm.ptr -> i256
-    llvm.store %258, %256 : !llvm.ptr, !llvm.ptr
-    %260 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %261 = llvm.load %260 : !llvm.ptr -> !llvm.ptr
-    %262 = llvm.getelementptr %261[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %263 = llvm.load %262 : !llvm.ptr -> i256
-    llvm.store %262, %260 : !llvm.ptr, !llvm.ptr
+    %253 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %254 = llvm.load %253 : !llvm.ptr -> !llvm.ptr
+    %255 = llvm.getelementptr %254[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %256 = llvm.load %255 : !llvm.ptr -> i256
+    llvm.store %255, %253 : !llvm.ptr, !llvm.ptr
+    %257 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %258 = llvm.load %257 : !llvm.ptr -> !llvm.ptr
+    %259 = llvm.getelementptr %258[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %260 = llvm.load %259 : !llvm.ptr -> i256
+    llvm.store %259, %257 : !llvm.ptr, !llvm.ptr
+    %c1_i256_76 = arith.constant 1 : i256
+    %261 = llvm.alloca %c1_i256_76 x i256 : (i256) -> !llvm.ptr
+    llvm.store %256, %261 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_77 = arith.constant 1 : i256
-    %264 = llvm.alloca %c1_i256_77 x i256 : (i256) -> !llvm.ptr
-    llvm.store %259, %264 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_78 = arith.constant 1 : i256
-    %265 = llvm.alloca %c1_i256_78 x i256 : (i256) -> !llvm.ptr
-    llvm.store %263, %265 {alignment = 1 : i64} : i256, !llvm.ptr
-    %266 = call @dora_fn_sstore(%arg0, %264, %265) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %267 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %268 = arith.addi %267, %c1_i64_79 : i64
-    llvm.store %268, %9 : i64, !llvm.ptr
-    %269 = arith.cmpi ult, %c1024_i64, %268 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %269, ^bb1(%c92_i8_80 : i8), ^bb38
+    %262 = llvm.alloca %c1_i256_77 x i256 : (i256) -> !llvm.ptr
+    llvm.store %260, %262 {alignment = 1 : i64} : i256, !llvm.ptr
+    %263 = call @dora_fn_sstore(%arg0, %261, %262) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %264 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_78 = arith.constant 1 : i64
+    %265 = arith.addi %264, %c1_i64_78 : i64
+    llvm.store %265, %9 : i64, !llvm.ptr
+    %266 = arith.cmpi ult, %c1024_i64, %265 : i64
+    %c92_i8_79 = arith.constant 92 : i8
+    cf.cond_br %266, ^bb1(%c92_i8_79 : i8), ^bb37
+  ^bb37:  // pred: ^bb36
+    %c0_i256_80 = arith.constant 0 : i256
+    %267 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %268 = llvm.load %267 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_80, %268 : i256, !llvm.ptr
+    %269 = llvm.getelementptr %268[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %269, %267 : !llvm.ptr, !llvm.ptr
+    %270 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_81 = arith.constant 1 : i64
+    %271 = arith.addi %270, %c1_i64_81 : i64
+    llvm.store %271, %9 : i64, !llvm.ptr
+    %272 = arith.cmpi ult, %c1024_i64, %271 : i64
+    %c92_i8_82 = arith.constant 92 : i8
+    cf.cond_br %272, ^bb1(%c92_i8_82 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %c0_i256_81 = arith.constant 0 : i256
-    %270 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %271 = llvm.load %270 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_81, %271 : i256, !llvm.ptr
-    %272 = llvm.getelementptr %271[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %272, %270 : !llvm.ptr, !llvm.ptr
-    %273 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_82 = arith.constant 1 : i64
-    %274 = arith.addi %273, %c1_i64_82 : i64
-    llvm.store %274, %9 : i64, !llvm.ptr
-    %275 = arith.cmpi ult, %c1024_i64, %274 : i64
-    %c92_i8_83 = arith.constant 92 : i8
-    cf.cond_br %275, ^bb1(%c92_i8_83 : i8), ^bb39
+    %c0_i256_83 = arith.constant 0 : i256
+    %273 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %274 = llvm.load %273 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_83, %274 : i256, !llvm.ptr
+    %275 = llvm.getelementptr %274[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %275, %273 : !llvm.ptr, !llvm.ptr
+    %276 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_84 = arith.constant 1 : i64
+    %277 = arith.addi %276, %c1_i64_84 : i64
+    llvm.store %277, %9 : i64, !llvm.ptr
+    %278 = arith.cmpi ult, %c1024_i64, %277 : i64
+    %c92_i8_85 = arith.constant 92 : i8
+    cf.cond_br %278, ^bb1(%c92_i8_85 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %c0_i256_84 = arith.constant 0 : i256
-    %276 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %277 = llvm.load %276 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_84, %277 : i256, !llvm.ptr
-    %278 = llvm.getelementptr %277[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %278, %276 : !llvm.ptr, !llvm.ptr
-    %279 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %280 = arith.addi %279, %c1_i64_85 : i64
-    llvm.store %280, %9 : i64, !llvm.ptr
-    %281 = arith.cmpi ult, %c1024_i64, %280 : i64
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %281, ^bb1(%c92_i8_86 : i8), ^bb40
-  ^bb40:  // pred: ^bb39
     %c32_i256 = arith.constant 32 : i256
-    %282 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %283 = llvm.load %282 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %283 : i256, !llvm.ptr
-    %284 = llvm.getelementptr %283[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %284, %282 : !llvm.ptr, !llvm.ptr
-    %285 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_87 = arith.constant 1 : i64
-    %286 = arith.addi %285, %c1_i64_87 : i64
-    llvm.store %286, %9 : i64, !llvm.ptr
-    %287 = arith.cmpi ult, %c1024_i64, %286 : i64
-    %c92_i8_88 = arith.constant 92 : i8
-    cf.cond_br %287, ^bb1(%c92_i8_88 : i8), ^bb41
+    %279 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %280 = llvm.load %279 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %280 : i256, !llvm.ptr
+    %281 = llvm.getelementptr %280[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %281, %279 : !llvm.ptr, !llvm.ptr
+    %282 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_86 = arith.constant 1 : i64
+    %283 = arith.addi %282, %c1_i64_86 : i64
+    llvm.store %283, %9 : i64, !llvm.ptr
+    %284 = arith.cmpi ult, %c1024_i64, %283 : i64
+    %c92_i8_87 = arith.constant 92 : i8
+    cf.cond_br %284, ^bb1(%c92_i8_87 : i8), ^bb40
+  ^bb40:  // pred: ^bb39
+    %c0_i256_88 = arith.constant 0 : i256
+    %285 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %286 = llvm.load %285 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_88, %286 : i256, !llvm.ptr
+    %287 = llvm.getelementptr %286[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %287, %285 : !llvm.ptr, !llvm.ptr
+    %288 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_89 = arith.constant 1 : i64
+    %289 = arith.addi %288, %c1_i64_89 : i64
+    llvm.store %289, %9 : i64, !llvm.ptr
+    %290 = arith.cmpi ult, %c1024_i64, %289 : i64
+    %c92_i8_90 = arith.constant 92 : i8
+    cf.cond_br %290, ^bb1(%c92_i8_90 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %c0_i256_89 = arith.constant 0 : i256
-    %288 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %289 = llvm.load %288 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_89, %289 : i256, !llvm.ptr
-    %290 = llvm.getelementptr %289[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %290, %288 : !llvm.ptr, !llvm.ptr
-    %291 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_90 = arith.constant 1 : i64
-    %292 = arith.addi %291, %c1_i64_90 : i64
-    llvm.store %292, %9 : i64, !llvm.ptr
-    %293 = arith.cmpi ult, %c1024_i64, %292 : i64
-    %c92_i8_91 = arith.constant 92 : i8
-    cf.cond_br %293, ^bb1(%c92_i8_91 : i8), ^bb42
+    %c0_i256_91 = arith.constant 0 : i256
+    %291 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %292 = llvm.load %291 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_91, %292 : i256, !llvm.ptr
+    %293 = llvm.getelementptr %292[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %293, %291 : !llvm.ptr, !llvm.ptr
+    %294 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_92 = arith.constant 1 : i64
+    %295 = arith.addi %294, %c1_i64_92 : i64
+    llvm.store %295, %9 : i64, !llvm.ptr
+    %296 = arith.cmpi ult, %c1024_i64, %295 : i64
+    %c92_i8_93 = arith.constant 92 : i8
+    cf.cond_br %296, ^bb1(%c92_i8_93 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %c0_i256_92 = arith.constant 0 : i256
-    %294 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %295 = llvm.load %294 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_92, %295 : i256, !llvm.ptr
-    %296 = llvm.getelementptr %295[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %296, %294 : !llvm.ptr, !llvm.ptr
-    %297 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_93 = arith.constant 1 : i64
-    %298 = arith.addi %297, %c1_i64_93 : i64
-    llvm.store %298, %9 : i64, !llvm.ptr
-    %299 = arith.cmpi ult, %c1024_i64, %298 : i64
-    %c92_i8_94 = arith.constant 92 : i8
-    cf.cond_br %299, ^bb1(%c92_i8_94 : i8), ^bb43
+    %297 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %298 = llvm.load %297 : !llvm.ptr -> !llvm.ptr
+    %299 = llvm.getelementptr %298[-7] : (!llvm.ptr) -> !llvm.ptr, i256
+    %300 = llvm.load %299 : !llvm.ptr -> i256
+    %301 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %302 = llvm.load %301 : !llvm.ptr -> !llvm.ptr
+    llvm.store %300, %302 : i256, !llvm.ptr
+    %303 = llvm.getelementptr %302[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %303, %301 : !llvm.ptr, !llvm.ptr
+    %304 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_94 = arith.constant 1 : i64
+    %305 = arith.addi %304, %c1_i64_94 : i64
+    llvm.store %305, %9 : i64, !llvm.ptr
+    %306 = arith.cmpi ult, %c1024_i64, %305 : i64
+    %c92_i8_95 = arith.constant 92 : i8
+    cf.cond_br %306, ^bb1(%c92_i8_95 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %300 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %301 = llvm.load %300 : !llvm.ptr -> !llvm.ptr
-    %302 = llvm.getelementptr %301[-7] : (!llvm.ptr) -> !llvm.ptr, i256
-    %303 = llvm.load %302 : !llvm.ptr -> i256
-    %304 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %305 = llvm.load %304 : !llvm.ptr -> !llvm.ptr
-    llvm.store %303, %305 : i256, !llvm.ptr
-    %306 = llvm.getelementptr %305[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %306, %304 : !llvm.ptr, !llvm.ptr
-    %307 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_95 = arith.constant 1 : i64
-    %308 = arith.addi %307, %c1_i64_95 : i64
-    llvm.store %308, %9 : i64, !llvm.ptr
-    %309 = arith.cmpi ult, %c1024_i64, %308 : i64
-    %c92_i8_96 = arith.constant 92 : i8
-    cf.cond_br %309, ^bb1(%c92_i8_96 : i8), ^bb44
+    %c65535_i256_96 = arith.constant 65535 : i256
+    %307 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %308 = llvm.load %307 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_96, %308 : i256, !llvm.ptr
+    %309 = llvm.getelementptr %308[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %309, %307 : !llvm.ptr, !llvm.ptr
+    %310 = llvm.load %9 : !llvm.ptr -> i64
+    %c-6_i64_97 = arith.constant -6 : i64
+    %311 = arith.addi %310, %c-6_i64_97 : i64
+    llvm.store %311, %9 : i64, !llvm.ptr
+    %c7_i64_98 = arith.constant 7 : i64
+    %312 = arith.cmpi ult, %310, %c7_i64_98 : i64
+    %c91_i8_99 = arith.constant 91 : i8
+    cf.cond_br %312, ^bb1(%c91_i8_99 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c65535_i256_97 = arith.constant 65535 : i256
-    %310 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %311 = llvm.load %310 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256_97, %311 : i256, !llvm.ptr
-    %312 = llvm.getelementptr %311[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %312, %310 : !llvm.ptr, !llvm.ptr
-    %313 = llvm.load %9 : !llvm.ptr -> i64
-    %c-6_i64_98 = arith.constant -6 : i64
-    %314 = arith.addi %313, %c-6_i64_98 : i64
-    llvm.store %314, %9 : i64, !llvm.ptr
-    %c7_i64_99 = arith.constant 7 : i64
-    %315 = arith.cmpi ult, %313, %c7_i64_99 : i64
-    %c91_i8_100 = arith.constant 91 : i8
-    cf.cond_br %315, ^bb1(%c91_i8_100 : i8), ^bb45
+    %313 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %314 = llvm.load %313 : !llvm.ptr -> !llvm.ptr
+    %315 = llvm.getelementptr %314[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %316 = llvm.load %315 : !llvm.ptr -> i256
+    llvm.store %315, %313 : !llvm.ptr, !llvm.ptr
+    %317 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %318 = llvm.load %317 : !llvm.ptr -> !llvm.ptr
+    %319 = llvm.getelementptr %318[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %320 = llvm.load %319 : !llvm.ptr -> i256
+    llvm.store %319, %317 : !llvm.ptr, !llvm.ptr
+    %321 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %322 = llvm.load %321 : !llvm.ptr -> !llvm.ptr
+    %323 = llvm.getelementptr %322[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %324 = llvm.load %323 : !llvm.ptr -> i256
+    llvm.store %323, %321 : !llvm.ptr, !llvm.ptr
+    %325 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %326 = llvm.load %325 : !llvm.ptr -> !llvm.ptr
+    %327 = llvm.getelementptr %326[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %328 = llvm.load %327 : !llvm.ptr -> i256
+    llvm.store %327, %325 : !llvm.ptr, !llvm.ptr
+    %329 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %330 = llvm.load %329 : !llvm.ptr -> !llvm.ptr
+    %331 = llvm.getelementptr %330[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %332 = llvm.load %331 : !llvm.ptr -> i256
+    llvm.store %331, %329 : !llvm.ptr, !llvm.ptr
+    %333 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %334 = llvm.load %333 : !llvm.ptr -> !llvm.ptr
+    %335 = llvm.getelementptr %334[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %336 = llvm.load %335 : !llvm.ptr -> i256
+    llvm.store %335, %333 : !llvm.ptr, !llvm.ptr
+    %337 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %338 = llvm.load %337 : !llvm.ptr -> !llvm.ptr
+    %339 = llvm.getelementptr %338[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %340 = llvm.load %339 : !llvm.ptr -> i256
+    llvm.store %339, %337 : !llvm.ptr, !llvm.ptr
+    %341 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
+    %342 = llvm.load %341 : !llvm.ptr -> i1
+    %c0_i256_100 = arith.constant 0 : i256
+    %343 = arith.cmpi ne, %324, %c0_i256_100 : i256
+    %344 = arith.andi %342, %343 : i1
+    %c86_i8_101 = arith.constant 86 : i8
+    cf.cond_br %344, ^bb1(%c86_i8_101 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %316 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %317 = llvm.load %316 : !llvm.ptr -> !llvm.ptr
-    %318 = llvm.getelementptr %317[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %319 = llvm.load %318 : !llvm.ptr -> i256
-    llvm.store %318, %316 : !llvm.ptr, !llvm.ptr
-    %320 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %321 = llvm.load %320 : !llvm.ptr -> !llvm.ptr
-    %322 = llvm.getelementptr %321[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %323 = llvm.load %322 : !llvm.ptr -> i256
-    llvm.store %322, %320 : !llvm.ptr, !llvm.ptr
-    %324 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %325 = llvm.load %324 : !llvm.ptr -> !llvm.ptr
-    %326 = llvm.getelementptr %325[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %327 = llvm.load %326 : !llvm.ptr -> i256
-    llvm.store %326, %324 : !llvm.ptr, !llvm.ptr
-    %328 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %329 = llvm.load %328 : !llvm.ptr -> !llvm.ptr
-    %330 = llvm.getelementptr %329[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %331 = llvm.load %330 : !llvm.ptr -> i256
-    llvm.store %330, %328 : !llvm.ptr, !llvm.ptr
-    %332 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %333 = llvm.load %332 : !llvm.ptr -> !llvm.ptr
-    %334 = llvm.getelementptr %333[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %335 = llvm.load %334 : !llvm.ptr -> i256
-    llvm.store %334, %332 : !llvm.ptr, !llvm.ptr
-    %336 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %337 = llvm.load %336 : !llvm.ptr -> !llvm.ptr
-    %338 = llvm.getelementptr %337[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %339 = llvm.load %338 : !llvm.ptr -> i256
-    llvm.store %338, %336 : !llvm.ptr, !llvm.ptr
-    %340 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %341 = llvm.load %340 : !llvm.ptr -> !llvm.ptr
-    %342 = llvm.getelementptr %341[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %343 = llvm.load %342 : !llvm.ptr -> i256
-    llvm.store %342, %340 : !llvm.ptr, !llvm.ptr
-    %344 = llvm.mlir.addressof @dora_global_ctx_is_static : !llvm.ptr
-    %345 = llvm.load %344 : !llvm.ptr -> i1
-    %c0_i256_101 = arith.constant 0 : i256
-    %346 = arith.cmpi ne, %327, %c0_i256_101 : i256
-    %347 = arith.andi %345, %346 : i1
-    %c86_i8_102 = arith.constant 86 : i8
-    cf.cond_br %347, ^bb1(%c86_i8_102 : i8), ^bb46
+    %345 = arith.trunci %316 : i256 to i64
+    %346 = arith.trunci %328 : i256 to i64
+    %c0_i64_102 = arith.constant 0 : i64
+    %347 = arith.cmpi slt, %346, %c0_i64_102 : i64
+    %c84_i8_103 = arith.constant 84 : i8
+    cf.cond_br %347, ^bb1(%c84_i8_103 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %348 = arith.trunci %319 : i256 to i64
-    %349 = arith.trunci %331 : i256 to i64
-    %c0_i64_103 = arith.constant 0 : i64
-    %350 = arith.cmpi slt, %349, %c0_i64_103 : i64
-    %c84_i8_104 = arith.constant 84 : i8
-    cf.cond_br %350, ^bb1(%c84_i8_104 : i8), ^bb47
+    %348 = arith.trunci %332 : i256 to i64
+    %c0_i64_104 = arith.constant 0 : i64
+    %349 = arith.cmpi slt, %348, %c0_i64_104 : i64
+    %c84_i8_105 = arith.constant 84 : i8
+    cf.cond_br %349, ^bb1(%c84_i8_105 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %351 = arith.trunci %335 : i256 to i64
-    %c0_i64_105 = arith.constant 0 : i64
-    %352 = arith.cmpi slt, %351, %c0_i64_105 : i64
-    %c84_i8_106 = arith.constant 84 : i8
-    cf.cond_br %352, ^bb1(%c84_i8_106 : i8), ^bb48
+    %350 = arith.trunci %336 : i256 to i64
+    %c0_i64_106 = arith.constant 0 : i64
+    %351 = arith.cmpi slt, %350, %c0_i64_106 : i64
+    %c84_i8_107 = arith.constant 84 : i8
+    cf.cond_br %351, ^bb1(%c84_i8_107 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %353 = arith.trunci %339 : i256 to i64
-    %c0_i64_107 = arith.constant 0 : i64
-    %354 = arith.cmpi slt, %353, %c0_i64_107 : i64
-    %c84_i8_108 = arith.constant 84 : i8
-    cf.cond_br %354, ^bb1(%c84_i8_108 : i8), ^bb49
+    %352 = arith.trunci %340 : i256 to i64
+    %c0_i64_108 = arith.constant 0 : i64
+    %353 = arith.cmpi slt, %352, %c0_i64_108 : i64
+    %c84_i8_109 = arith.constant 84 : i8
+    cf.cond_br %353, ^bb1(%c84_i8_109 : i8), ^bb49
   ^bb49:  // pred: ^bb48
-    %355 = arith.trunci %343 : i256 to i64
-    %c0_i64_109 = arith.constant 0 : i64
-    %356 = arith.cmpi slt, %355, %c0_i64_109 : i64
-    %c84_i8_110 = arith.constant 84 : i8
-    cf.cond_br %356, ^bb1(%c84_i8_110 : i8), ^bb50
+    %354 = arith.addi %346, %348 : i64
+    %355 = arith.addi %350, %352 : i64
+    %356 = arith.maxui %354, %355 : i64
+    %c0_i64_110 = arith.constant 0 : i64
+    %357 = arith.cmpi slt, %356, %c0_i64_110 : i64
+    %c84_i8_111 = arith.constant 84 : i8
+    cf.cond_br %357, ^bb1(%c84_i8_111 : i8), ^bb50
   ^bb50:  // pred: ^bb49
-    %357 = arith.addi %349, %351 : i64
-    %358 = arith.addi %353, %355 : i64
-    %359 = arith.maxui %357, %358 : i64
-    %c0_i64_111 = arith.constant 0 : i64
-    %360 = arith.cmpi slt, %359, %c0_i64_111 : i64
-    %c84_i8_112 = arith.constant 84 : i8
-    cf.cond_br %360, ^bb1(%c84_i8_112 : i8), ^bb51
+    %c31_i64_112 = arith.constant 31 : i64
+    %c32_i64_113 = arith.constant 32 : i64
+    %358 = arith.addi %356, %c31_i64_112 : i64
+    %359 = arith.divui %358, %c32_i64_113 : i64
+    %360 = arith.muli %359, %c32_i64_113 : i64
+    %361 = call @dora_fn_extend_memory(%arg0, %360) : (!llvm.ptr, i64) -> !llvm.ptr
+    %362 = llvm.getelementptr %361[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %363 = llvm.load %362 : !llvm.ptr -> !llvm.ptr
+    %364 = llvm.getelementptr %361[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %365 = llvm.load %364 : !llvm.ptr -> i8
+    %c0_i8_114 = arith.constant 0 : i8
+    %366 = arith.cmpi ne, %365, %c0_i8_114 : i8
+    cf.cond_br %366, ^bb1(%365 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %c31_i64_113 = arith.constant 31 : i64
-    %c32_i64_114 = arith.constant 32 : i64
-    %361 = arith.addi %359, %c31_i64_113 : i64
-    %362 = arith.divui %361, %c32_i64_114 : i64
-    %363 = arith.muli %362, %c32_i64_114 : i64
-    %364 = call @dora_fn_extend_memory(%arg0, %363) : (!llvm.ptr, i64) -> !llvm.ptr
-    %365 = llvm.getelementptr %364[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %366 = llvm.load %365 : !llvm.ptr -> !llvm.ptr
-    %367 = llvm.getelementptr %364[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %368 = llvm.load %367 : !llvm.ptr -> i8
-    %c0_i8_115 = arith.constant 0 : i8
-    %369 = arith.cmpi ne, %368, %c0_i8_115 : i8
-    cf.cond_br %369, ^bb1(%368 : i8), ^bb52
-  ^bb52:  // pred: ^bb51
-    %370 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %366, %370 : !llvm.ptr, !llvm.ptr
-    %371 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %363, %371 : i64, !llvm.ptr
-    %372 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %373 = llvm.load %372 : !llvm.ptr -> i64
+    %367 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %363, %367 : !llvm.ptr, !llvm.ptr
+    %368 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %360, %368 : i64, !llvm.ptr
+    %369 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %370 = llvm.load %369 : !llvm.ptr -> i64
+    %c1_i256_115 = arith.constant 1 : i256
+    %371 = llvm.alloca %c1_i256_115 x i256 : (i256) -> !llvm.ptr
+    llvm.store %324, %371 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_116 = arith.constant 1 : i256
-    %374 = llvm.alloca %c1_i256_116 x i256 : (i256) -> !llvm.ptr
-    llvm.store %327, %374 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_117 = arith.constant 1 : i256
-    %375 = llvm.alloca %c1_i256_117 x i256 : (i256) -> !llvm.ptr
-    llvm.store %323, %375 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_118 = arith.constant 1 : i64
-    %376 = llvm.alloca %c1_i64_118 x i64 : (i64) -> !llvm.ptr
+    %372 = llvm.alloca %c1_i256_116 x i256 : (i256) -> !llvm.ptr
+    llvm.store %320, %372 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_117 = arith.constant 1 : i64
+    %373 = llvm.alloca %c1_i64_117 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_118 = arith.constant 0 : i8
+    %374 = call @dora_fn_call(%arg0, %345, %372, %371, %346, %348, %350, %352, %370, %373, %c0_i8_118) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %375 = llvm.getelementptr %374[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %376 = llvm.load %375 : !llvm.ptr -> i8
+    %377 = llvm.getelementptr %374[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %378 = llvm.load %377 : !llvm.ptr -> i8
     %c0_i8_119 = arith.constant 0 : i8
-    %377 = call @dora_fn_call(%arg0, %348, %375, %374, %349, %351, %353, %355, %373, %376, %c0_i8_119) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %378 = llvm.getelementptr %377[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %379 = llvm.load %378 : !llvm.ptr -> i8
-    %380 = llvm.getelementptr %377[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %381 = llvm.load %380 : !llvm.ptr -> i8
-    %c0_i8_120 = arith.constant 0 : i8
-    %382 = arith.cmpi ne, %381, %c0_i8_120 : i8
-    cf.cond_br %382, ^bb1(%381 : i8), ^bb53
+    %379 = arith.cmpi ne, %378, %c0_i8_119 : i8
+    cf.cond_br %379, ^bb1(%378 : i8), ^bb52
+  ^bb52:  // pred: ^bb51
+    %380 = llvm.load %373 : !llvm.ptr -> i64
+    %381 = arith.extui %376 : i8 to i256
+    %382 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %383 = llvm.load %382 : !llvm.ptr -> !llvm.ptr
+    llvm.store %381, %383 : i256, !llvm.ptr
+    %384 = llvm.getelementptr %383[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %384, %382 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb53
   ^bb53:  // pred: ^bb52
-    %383 = llvm.load %376 : !llvm.ptr -> i64
-    %384 = arith.extui %379 : i8 to i256
-    %385 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %386 = llvm.load %385 : !llvm.ptr -> !llvm.ptr
-    llvm.store %384, %386 : i256, !llvm.ptr
-    %387 = llvm.getelementptr %386[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %387, %385 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb54
-  ^bb54:  // pred: ^bb53
-    %c0_i64_121 = arith.constant 0 : i64
+    %c0_i64_120 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %388 = call @dora_fn_write_result(%arg0, %c0_i64_121, %c0_i64_121, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %385 = call @dora_fn_write_result(%arg0, %c0_i64_120, %c0_i64_120, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 49 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49
+  ^bb1(%13: i8):  // 48 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -278,508 +278,501 @@ module {
     %108 = llvm.alloca %c1_i64_26 x i64 : (i64) -> !llvm.ptr
     llvm.store %107, %108 {alignment = 1 : i64} : i64, !llvm.ptr
     %109 = call @dora_fn_create(%arg0, %90, %88, %105, %108) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %110 = llvm.getelementptr %109[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %110 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %111 = llvm.load %110 : !llvm.ptr -> i8
-    %112 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %113 = llvm.load %112 : !llvm.ptr -> i8
     %c0_i8_27 = arith.constant 0 : i8
-    %114 = arith.cmpi ne, %113, %c0_i8_27 : i8
-    cf.cond_br %114, ^bb1(%113 : i8), ^bb17
+    %112 = arith.cmpi ne, %111, %c0_i8_27 : i8
+    cf.cond_br %112, ^bb1(%111 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i8_28 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %c0_i8_28, %111 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %115, ^bb1(%c94_i8 : i8), ^bb18
+    %113 = llvm.load %105 : !llvm.ptr -> i256
+    %114 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> !llvm.ptr
+    llvm.store %113, %115 : i256, !llvm.ptr
+    %116 = llvm.getelementptr %115[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %116, %114 : !llvm.ptr, !llvm.ptr
+    %117 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_28 = arith.constant 1 : i64
+    %118 = arith.addi %117, %c1_i64_28 : i64
+    llvm.store %118, %9 : i64, !llvm.ptr
+    %119 = arith.cmpi ult, %c1024_i64, %118 : i64
+    %c92_i8_29 = arith.constant 92 : i8
+    cf.cond_br %119, ^bb1(%c92_i8_29 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %116 = llvm.load %105 : !llvm.ptr -> i256
-    %117 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %118 = llvm.load %117 : !llvm.ptr -> !llvm.ptr
-    llvm.store %116, %118 : i256, !llvm.ptr
-    %119 = llvm.getelementptr %118[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %119, %117 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_29 : i64
-    llvm.store %121, %9 : i64, !llvm.ptr
-    %122 = arith.cmpi ult, %c1024_i64, %121 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_30 : i8), ^bb19
+    %c0_i256_30 = arith.constant 0 : i256
+    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_30, %121 : i256, !llvm.ptr
+    %122 = llvm.getelementptr %121[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
+    %123 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_31 = arith.constant 1 : i64
+    %124 = arith.addi %123, %c1_i64_31 : i64
+    llvm.store %124, %9 : i64, !llvm.ptr
+    %125 = arith.cmpi ult, %c1024_i64, %124 : i64
+    %c92_i8_32 = arith.constant 92 : i8
+    cf.cond_br %125, ^bb1(%c92_i8_32 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %c0_i256_31 = arith.constant 0 : i256
-    %123 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %124 = llvm.load %123 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_31, %124 : i256, !llvm.ptr
-    %125 = llvm.getelementptr %124[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %125, %123 : !llvm.ptr, !llvm.ptr
-    %126 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %127 = arith.addi %126, %c1_i64_32 : i64
-    llvm.store %127, %9 : i64, !llvm.ptr
-    %128 = arith.cmpi ult, %c1024_i64, %127 : i64
-    %c92_i8_33 = arith.constant 92 : i8
-    cf.cond_br %128, ^bb1(%c92_i8_33 : i8), ^bb20
+    %c0_i256_33 = arith.constant 0 : i256
+    %126 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %127 = llvm.load %126 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_33, %127 : i256, !llvm.ptr
+    %128 = llvm.getelementptr %127[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %128, %126 : !llvm.ptr, !llvm.ptr
+    %129 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %130 = arith.addi %129, %c1_i64_34 : i64
+    llvm.store %130, %9 : i64, !llvm.ptr
+    %131 = arith.cmpi ult, %c1024_i64, %130 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %131, ^bb1(%c92_i8_35 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %c0_i256_34 = arith.constant 0 : i256
-    %129 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %130 = llvm.load %129 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_34, %130 : i256, !llvm.ptr
-    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %131, %129 : !llvm.ptr, !llvm.ptr
-    %132 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %133 = arith.addi %132, %c1_i64_35 : i64
-    llvm.store %133, %9 : i64, !llvm.ptr
-    %134 = arith.cmpi ult, %c1024_i64, %133 : i64
-    %c92_i8_36 = arith.constant 92 : i8
-    cf.cond_br %134, ^bb1(%c92_i8_36 : i8), ^bb21
+    %c0_i256_36 = arith.constant 0 : i256
+    %132 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %133 = llvm.load %132 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_36, %133 : i256, !llvm.ptr
+    %134 = llvm.getelementptr %133[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %134, %132 : !llvm.ptr, !llvm.ptr
+    %135 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_37 = arith.constant 1 : i64
+    %136 = arith.addi %135, %c1_i64_37 : i64
+    llvm.store %136, %9 : i64, !llvm.ptr
+    %137 = arith.cmpi ult, %c1024_i64, %136 : i64
+    %c92_i8_38 = arith.constant 92 : i8
+    cf.cond_br %137, ^bb1(%c92_i8_38 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %c0_i256_37 = arith.constant 0 : i256
-    %135 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %136 = llvm.load %135 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_37, %136 : i256, !llvm.ptr
-    %137 = llvm.getelementptr %136[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %137, %135 : !llvm.ptr, !llvm.ptr
-    %138 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_38 : i64
-    llvm.store %139, %9 : i64, !llvm.ptr
-    %140 = arith.cmpi ult, %c1024_i64, %139 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_39 : i8), ^bb22
+    %c0_i256_39 = arith.constant 0 : i256
+    %138 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %139 = llvm.load %138 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_39, %139 : i256, !llvm.ptr
+    %140 = llvm.getelementptr %139[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %140, %138 : !llvm.ptr, !llvm.ptr
+    %141 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %142 = arith.addi %141, %c1_i64_40 : i64
+    llvm.store %142, %9 : i64, !llvm.ptr
+    %143 = arith.cmpi ult, %c1024_i64, %142 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %143, ^bb1(%c92_i8_41 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i256_40 = arith.constant 0 : i256
-    %141 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %142 = llvm.load %141 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_40, %142 : i256, !llvm.ptr
-    %143 = llvm.getelementptr %142[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %143, %141 : !llvm.ptr, !llvm.ptr
-    %144 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_41 = arith.constant 1 : i64
-    %145 = arith.addi %144, %c1_i64_41 : i64
-    llvm.store %145, %9 : i64, !llvm.ptr
-    %146 = arith.cmpi ult, %c1024_i64, %145 : i64
-    %c92_i8_42 = arith.constant 92 : i8
-    cf.cond_br %146, ^bb1(%c92_i8_42 : i8), ^bb23
+    %c0_i256_42 = arith.constant 0 : i256
+    %144 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %145 = llvm.load %144 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_42, %145 : i256, !llvm.ptr
+    %146 = llvm.getelementptr %145[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %146, %144 : !llvm.ptr, !llvm.ptr
+    %147 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_43 = arith.constant 1 : i64
+    %148 = arith.addi %147, %c1_i64_43 : i64
+    llvm.store %148, %9 : i64, !llvm.ptr
+    %149 = arith.cmpi ult, %c1024_i64, %148 : i64
+    %c92_i8_44 = arith.constant 92 : i8
+    cf.cond_br %149, ^bb1(%c92_i8_44 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i256_43 = arith.constant 0 : i256
-    %147 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_43, %148 : i256, !llvm.ptr
-    %149 = llvm.getelementptr %148[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %149, %147 : !llvm.ptr, !llvm.ptr
-    %150 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %151 = arith.addi %150, %c1_i64_44 : i64
-    llvm.store %151, %9 : i64, !llvm.ptr
-    %152 = arith.cmpi ult, %c1024_i64, %151 : i64
-    %c92_i8_45 = arith.constant 92 : i8
-    cf.cond_br %152, ^bb1(%c92_i8_45 : i8), ^bb24
+    %150 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %151 = llvm.load %150 : !llvm.ptr -> !llvm.ptr
+    %152 = llvm.getelementptr %151[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %153 = llvm.load %152 : !llvm.ptr -> i256
+    %154 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %155 = llvm.load %154 : !llvm.ptr -> !llvm.ptr
+    llvm.store %153, %155 : i256, !llvm.ptr
+    %156 = llvm.getelementptr %155[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %156, %154 : !llvm.ptr, !llvm.ptr
+    %157 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_45 = arith.constant 1 : i64
+    %158 = arith.addi %157, %c1_i64_45 : i64
+    llvm.store %158, %9 : i64, !llvm.ptr
+    %159 = arith.cmpi ult, %c1024_i64, %158 : i64
+    %c92_i8_46 = arith.constant 92 : i8
+    cf.cond_br %159, ^bb1(%c92_i8_46 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %153 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %154 = llvm.load %153 : !llvm.ptr -> !llvm.ptr
-    %155 = llvm.getelementptr %154[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %158 = llvm.load %157 : !llvm.ptr -> !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
-    %159 = llvm.getelementptr %158[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %159, %157 : !llvm.ptr, !llvm.ptr
-    %160 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_46 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_46 : i64
-    llvm.store %161, %9 : i64, !llvm.ptr
-    %162 = arith.cmpi ult, %c1024_i64, %161 : i64
-    %c92_i8_47 = arith.constant 92 : i8
-    cf.cond_br %162, ^bb1(%c92_i8_47 : i8), ^bb25
-  ^bb25:  // pred: ^bb24
     %c65535_i256 = arith.constant 65535 : i256
-    %163 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %164 = llvm.load %163 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256, %164 : i256, !llvm.ptr
-    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %165, %163 : !llvm.ptr, !llvm.ptr
-    %166 = llvm.load %9 : !llvm.ptr -> i64
+    %160 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %161 = llvm.load %160 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %161 : i256, !llvm.ptr
+    %162 = llvm.getelementptr %161[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %162, %160 : !llvm.ptr, !llvm.ptr
+    %163 = llvm.load %9 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %167 = arith.addi %166, %c-5_i64 : i64
-    llvm.store %167, %9 : i64, !llvm.ptr
+    %164 = arith.addi %163, %c-5_i64 : i64
+    llvm.store %164, %9 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %168 = arith.cmpi ult, %166, %c6_i64 : i64
-    %c91_i8_48 = arith.constant 91 : i8
-    cf.cond_br %168, ^bb1(%c91_i8_48 : i8), ^bb26
+    %165 = arith.cmpi ult, %163, %c6_i64 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %165, ^bb1(%c91_i8_47 : i8), ^bb25
+  ^bb25:  // pred: ^bb24
+    %166 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %167 = llvm.load %166 : !llvm.ptr -> !llvm.ptr
+    %168 = llvm.getelementptr %167[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %169 = llvm.load %168 : !llvm.ptr -> i256
+    llvm.store %168, %166 : !llvm.ptr, !llvm.ptr
+    %170 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %171 = llvm.load %170 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %170 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
+    %176 = llvm.getelementptr %175[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %177 = llvm.load %176 : !llvm.ptr -> i256
+    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
+    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    %180 = llvm.getelementptr %179[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %181 = llvm.load %180 : !llvm.ptr -> i256
+    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
+    %182 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %183 = llvm.load %182 : !llvm.ptr -> !llvm.ptr
+    %184 = llvm.getelementptr %183[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %185 = llvm.load %184 : !llvm.ptr -> i256
+    llvm.store %184, %182 : !llvm.ptr, !llvm.ptr
+    %186 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %187 = llvm.load %186 : !llvm.ptr -> !llvm.ptr
+    %188 = llvm.getelementptr %187[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %189 = llvm.load %188 : !llvm.ptr -> i256
+    llvm.store %188, %186 : !llvm.ptr, !llvm.ptr
+    %c0_i256_48 = arith.constant 0 : i256
+    %190 = arith.trunci %169 : i256 to i64
+    %191 = arith.trunci %177 : i256 to i64
+    %c0_i64_49 = arith.constant 0 : i64
+    %192 = arith.cmpi slt, %191, %c0_i64_49 : i64
+    %c84_i8_50 = arith.constant 84 : i8
+    cf.cond_br %192, ^bb1(%c84_i8_50 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %169 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %170 = llvm.load %169 : !llvm.ptr -> !llvm.ptr
-    %171 = llvm.getelementptr %170[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %172 = llvm.load %171 : !llvm.ptr -> i256
-    llvm.store %171, %169 : !llvm.ptr, !llvm.ptr
-    %173 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %174 = llvm.load %173 : !llvm.ptr -> !llvm.ptr
-    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %176 = llvm.load %175 : !llvm.ptr -> i256
-    llvm.store %175, %173 : !llvm.ptr, !llvm.ptr
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    %179 = llvm.getelementptr %178[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    %181 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %182 = llvm.load %181 : !llvm.ptr -> !llvm.ptr
-    %183 = llvm.getelementptr %182[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    llvm.store %183, %181 : !llvm.ptr, !llvm.ptr
-    %185 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %186 = llvm.load %185 : !llvm.ptr -> !llvm.ptr
-    %187 = llvm.getelementptr %186[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    llvm.store %187, %185 : !llvm.ptr, !llvm.ptr
-    %189 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %190 = llvm.load %189 : !llvm.ptr -> !llvm.ptr
-    %191 = llvm.getelementptr %190[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    llvm.store %191, %189 : !llvm.ptr, !llvm.ptr
-    %c0_i256_49 = arith.constant 0 : i256
-    %193 = arith.trunci %172 : i256 to i64
-    %194 = arith.trunci %180 : i256 to i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %195 = arith.cmpi slt, %194, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %195, ^bb1(%c84_i8_51 : i8), ^bb27
+    %193 = arith.trunci %181 : i256 to i64
+    %c0_i64_51 = arith.constant 0 : i64
+    %194 = arith.cmpi slt, %193, %c0_i64_51 : i64
+    %c84_i8_52 = arith.constant 84 : i8
+    cf.cond_br %194, ^bb1(%c84_i8_52 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %196 = arith.trunci %184 : i256 to i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %197 = arith.cmpi slt, %196, %c0_i64_52 : i64
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %197, ^bb1(%c84_i8_53 : i8), ^bb28
+    %195 = arith.trunci %185 : i256 to i64
+    %c0_i64_53 = arith.constant 0 : i64
+    %196 = arith.cmpi slt, %195, %c0_i64_53 : i64
+    %c84_i8_54 = arith.constant 84 : i8
+    cf.cond_br %196, ^bb1(%c84_i8_54 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %198 = arith.trunci %188 : i256 to i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %199 = arith.cmpi slt, %198, %c0_i64_54 : i64
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %199, ^bb1(%c84_i8_55 : i8), ^bb29
+    %197 = arith.trunci %189 : i256 to i64
+    %c0_i64_55 = arith.constant 0 : i64
+    %198 = arith.cmpi slt, %197, %c0_i64_55 : i64
+    %c84_i8_56 = arith.constant 84 : i8
+    cf.cond_br %198, ^bb1(%c84_i8_56 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %200 = arith.trunci %192 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %201 = arith.cmpi slt, %200, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %201, ^bb1(%c84_i8_57 : i8), ^bb30
+    %199 = arith.addi %191, %193 : i64
+    %200 = arith.addi %195, %197 : i64
+    %201 = arith.maxui %199, %200 : i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %202 = arith.cmpi slt, %201, %c0_i64_57 : i64
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %202, ^bb1(%c84_i8_58 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %202 = arith.addi %194, %196 : i64
-    %203 = arith.addi %198, %200 : i64
-    %204 = arith.maxui %202, %203 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %205 = arith.cmpi slt, %204, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %205, ^bb1(%c84_i8_59 : i8), ^bb31
+    %c31_i64_59 = arith.constant 31 : i64
+    %c32_i64_60 = arith.constant 32 : i64
+    %203 = arith.addi %201, %c31_i64_59 : i64
+    %204 = arith.divui %203, %c32_i64_60 : i64
+    %205 = arith.muli %204, %c32_i64_60 : i64
+    %206 = call @dora_fn_extend_memory(%arg0, %205) : (!llvm.ptr, i64) -> !llvm.ptr
+    %207 = llvm.getelementptr %206[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %208 = llvm.load %207 : !llvm.ptr -> !llvm.ptr
+    %209 = llvm.getelementptr %206[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %210 = llvm.load %209 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %211 = arith.cmpi ne, %210, %c0_i8_61 : i8
+    cf.cond_br %211, ^bb1(%210 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c31_i64_60 = arith.constant 31 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %206 = arith.addi %204, %c31_i64_60 : i64
-    %207 = arith.divui %206, %c32_i64_61 : i64
-    %208 = arith.muli %207, %c32_i64_61 : i64
-    %209 = call @dora_fn_extend_memory(%arg0, %208) : (!llvm.ptr, i64) -> !llvm.ptr
-    %210 = llvm.getelementptr %209[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %211 = llvm.load %210 : !llvm.ptr -> !llvm.ptr
-    %212 = llvm.getelementptr %209[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %213 = llvm.load %212 : !llvm.ptr -> i8
-    %c0_i8_62 = arith.constant 0 : i8
-    %214 = arith.cmpi ne, %213, %c0_i8_62 : i8
-    cf.cond_br %214, ^bb1(%213 : i8), ^bb32
-  ^bb32:  // pred: ^bb31
-    %215 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %211, %215 : !llvm.ptr, !llvm.ptr
-    %216 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %208, %216 : i64, !llvm.ptr
-    %217 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %218 = llvm.load %217 : !llvm.ptr -> i64
+    %212 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %208, %212 : !llvm.ptr, !llvm.ptr
+    %213 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %205, %213 : i64, !llvm.ptr
+    %214 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %215 = llvm.load %214 : !llvm.ptr -> i64
+    %c1_i256_62 = arith.constant 1 : i256
+    %216 = llvm.alloca %c1_i256_62 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_48, %216 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_63 = arith.constant 1 : i256
-    %219 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_49, %219 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_64 = arith.constant 1 : i256
-    %220 = llvm.alloca %c1_i256_64 x i256 : (i256) -> !llvm.ptr
-    llvm.store %176, %220 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_65 = arith.constant 1 : i64
-    %221 = llvm.alloca %c1_i64_65 x i64 : (i64) -> !llvm.ptr
+    %217 = llvm.alloca %c1_i256_63 x i256 : (i256) -> !llvm.ptr
+    llvm.store %173, %217 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_64 = arith.constant 1 : i64
+    %218 = llvm.alloca %c1_i64_64 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_65 = arith.constant 0 : i8
+    %219 = call @dora_fn_call(%arg0, %190, %217, %216, %191, %193, %195, %197, %215, %218, %c0_i8_65) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %221 = llvm.load %220 : !llvm.ptr -> i8
+    %222 = llvm.getelementptr %219[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %223 = llvm.load %222 : !llvm.ptr -> i8
     %c0_i8_66 = arith.constant 0 : i8
-    %222 = call @dora_fn_call(%arg0, %193, %220, %219, %194, %196, %198, %200, %218, %221, %c0_i8_66) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %223 = llvm.getelementptr %222[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %224 = llvm.load %223 : !llvm.ptr -> i8
-    %225 = llvm.getelementptr %222[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %226 = llvm.load %225 : !llvm.ptr -> i8
-    %c0_i8_67 = arith.constant 0 : i8
-    %227 = arith.cmpi ne, %226, %c0_i8_67 : i8
-    cf.cond_br %227, ^bb1(%226 : i8), ^bb33
+    %224 = arith.cmpi ne, %223, %c0_i8_66 : i8
+    cf.cond_br %224, ^bb1(%223 : i8), ^bb32
+  ^bb32:  // pred: ^bb31
+    %225 = llvm.load %218 : !llvm.ptr -> i64
+    %226 = arith.extui %221 : i8 to i256
+    %227 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %228 = llvm.load %227 : !llvm.ptr -> !llvm.ptr
+    llvm.store %226, %228 : i256, !llvm.ptr
+    %229 = llvm.getelementptr %228[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %229, %227 : !llvm.ptr, !llvm.ptr
+    %230 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_67 = arith.constant 1 : i64
+    %231 = arith.addi %230, %c1_i64_67 : i64
+    llvm.store %231, %9 : i64, !llvm.ptr
+    %232 = arith.cmpi ult, %c1024_i64, %231 : i64
+    %c92_i8_68 = arith.constant 92 : i8
+    cf.cond_br %232, ^bb1(%c92_i8_68 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %228 = llvm.load %221 : !llvm.ptr -> i64
-    %229 = arith.extui %224 : i8 to i256
-    %230 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %231 = llvm.load %230 : !llvm.ptr -> !llvm.ptr
-    llvm.store %229, %231 : i256, !llvm.ptr
-    %232 = llvm.getelementptr %231[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %232, %230 : !llvm.ptr, !llvm.ptr
-    %233 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_68 = arith.constant 1 : i64
-    %234 = arith.addi %233, %c1_i64_68 : i64
-    llvm.store %234, %9 : i64, !llvm.ptr
-    %235 = arith.cmpi ult, %c1024_i64, %234 : i64
-    %c92_i8_69 = arith.constant 92 : i8
-    cf.cond_br %235, ^bb1(%c92_i8_69 : i8), ^bb34
+    %c1_i256_69 = arith.constant 1 : i256
+    %233 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %234 = llvm.load %233 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_69, %234 : i256, !llvm.ptr
+    %235 = llvm.getelementptr %234[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %235, %233 : !llvm.ptr, !llvm.ptr
+    %236 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_70 = arith.constant 1 : i64
+    %237 = arith.addi %236, %c1_i64_70 : i64
+    llvm.store %237, %9 : i64, !llvm.ptr
+    %238 = arith.cmpi ult, %c1024_i64, %237 : i64
+    %c92_i8_71 = arith.constant 92 : i8
+    cf.cond_br %238, ^bb1(%c92_i8_71 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %c1_i256_70 = arith.constant 1 : i256
-    %236 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %237 = llvm.load %236 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c1_i256_70, %237 : i256, !llvm.ptr
-    %238 = llvm.getelementptr %237[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %238, %236 : !llvm.ptr, !llvm.ptr
-    %239 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_71 = arith.constant 1 : i64
-    %240 = arith.addi %239, %c1_i64_71 : i64
-    llvm.store %240, %9 : i64, !llvm.ptr
-    %241 = arith.cmpi ult, %c1024_i64, %240 : i64
-    %c92_i8_72 = arith.constant 92 : i8
-    cf.cond_br %241, ^bb1(%c92_i8_72 : i8), ^bb35
+    %c0_i256_72 = arith.constant 0 : i256
+    %239 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %240 = llvm.load %239 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_72, %240 : i256, !llvm.ptr
+    %241 = llvm.getelementptr %240[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %241, %239 : !llvm.ptr, !llvm.ptr
+    %242 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_73 = arith.constant -2 : i64
+    %243 = arith.addi %242, %c-2_i64_73 : i64
+    llvm.store %243, %9 : i64, !llvm.ptr
+    %c2_i64_74 = arith.constant 2 : i64
+    %244 = arith.cmpi ult, %242, %c2_i64_74 : i64
+    %c91_i8_75 = arith.constant 91 : i8
+    cf.cond_br %244, ^bb1(%c91_i8_75 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %c0_i256_73 = arith.constant 0 : i256
-    %242 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %243 = llvm.load %242 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_73, %243 : i256, !llvm.ptr
-    %244 = llvm.getelementptr %243[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %244, %242 : !llvm.ptr, !llvm.ptr
-    %245 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_74 = arith.constant -2 : i64
-    %246 = arith.addi %245, %c-2_i64_74 : i64
-    llvm.store %246, %9 : i64, !llvm.ptr
-    %c2_i64_75 = arith.constant 2 : i64
-    %247 = arith.cmpi ult, %245, %c2_i64_75 : i64
-    %c91_i8_76 = arith.constant 91 : i8
-    cf.cond_br %247, ^bb1(%c91_i8_76 : i8), ^bb36
-  ^bb36:  // pred: ^bb35
-    %248 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %249 = llvm.load %248 : !llvm.ptr -> !llvm.ptr
-    %250 = llvm.getelementptr %249[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %251 = llvm.load %250 : !llvm.ptr -> i256
-    llvm.store %250, %248 : !llvm.ptr, !llvm.ptr
-    %252 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %253 = llvm.load %252 : !llvm.ptr -> !llvm.ptr
-    %254 = llvm.getelementptr %253[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %255 = llvm.load %254 : !llvm.ptr -> i256
-    llvm.store %254, %252 : !llvm.ptr, !llvm.ptr
+    %245 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %246 = llvm.load %245 : !llvm.ptr -> !llvm.ptr
+    %247 = llvm.getelementptr %246[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %248 = llvm.load %247 : !llvm.ptr -> i256
+    llvm.store %247, %245 : !llvm.ptr, !llvm.ptr
+    %249 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %250 = llvm.load %249 : !llvm.ptr -> !llvm.ptr
+    %251 = llvm.getelementptr %250[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %252 = llvm.load %251 : !llvm.ptr -> i256
+    llvm.store %251, %249 : !llvm.ptr, !llvm.ptr
+    %c1_i256_76 = arith.constant 1 : i256
+    %253 = llvm.alloca %c1_i256_76 x i256 : (i256) -> !llvm.ptr
+    llvm.store %248, %253 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_77 = arith.constant 1 : i256
-    %256 = llvm.alloca %c1_i256_77 x i256 : (i256) -> !llvm.ptr
-    llvm.store %251, %256 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_78 = arith.constant 1 : i256
-    %257 = llvm.alloca %c1_i256_78 x i256 : (i256) -> !llvm.ptr
-    llvm.store %255, %257 {alignment = 1 : i64} : i256, !llvm.ptr
-    %258 = call @dora_fn_sstore(%arg0, %256, %257) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %259 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %260 = arith.addi %259, %c1_i64_79 : i64
-    llvm.store %260, %9 : i64, !llvm.ptr
-    %261 = arith.cmpi ult, %c1024_i64, %260 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %261, ^bb1(%c92_i8_80 : i8), ^bb37
+    %254 = llvm.alloca %c1_i256_77 x i256 : (i256) -> !llvm.ptr
+    llvm.store %252, %254 {alignment = 1 : i64} : i256, !llvm.ptr
+    %255 = call @dora_fn_sstore(%arg0, %253, %254) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %256 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_78 = arith.constant 1 : i64
+    %257 = arith.addi %256, %c1_i64_78 : i64
+    llvm.store %257, %9 : i64, !llvm.ptr
+    %258 = arith.cmpi ult, %c1024_i64, %257 : i64
+    %c92_i8_79 = arith.constant 92 : i8
+    cf.cond_br %258, ^bb1(%c92_i8_79 : i8), ^bb36
+  ^bb36:  // pred: ^bb35
+    %c0_i256_80 = arith.constant 0 : i256
+    %259 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %260 = llvm.load %259 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_80, %260 : i256, !llvm.ptr
+    %261 = llvm.getelementptr %260[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %261, %259 : !llvm.ptr, !llvm.ptr
+    %262 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_81 = arith.constant 1 : i64
+    %263 = arith.addi %262, %c1_i64_81 : i64
+    llvm.store %263, %9 : i64, !llvm.ptr
+    %264 = arith.cmpi ult, %c1024_i64, %263 : i64
+    %c92_i8_82 = arith.constant 92 : i8
+    cf.cond_br %264, ^bb1(%c92_i8_82 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %c0_i256_81 = arith.constant 0 : i256
-    %262 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %263 = llvm.load %262 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_81, %263 : i256, !llvm.ptr
-    %264 = llvm.getelementptr %263[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %264, %262 : !llvm.ptr, !llvm.ptr
-    %265 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_82 = arith.constant 1 : i64
-    %266 = arith.addi %265, %c1_i64_82 : i64
-    llvm.store %266, %9 : i64, !llvm.ptr
-    %267 = arith.cmpi ult, %c1024_i64, %266 : i64
-    %c92_i8_83 = arith.constant 92 : i8
-    cf.cond_br %267, ^bb1(%c92_i8_83 : i8), ^bb38
+    %c0_i256_83 = arith.constant 0 : i256
+    %265 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %266 = llvm.load %265 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_83, %266 : i256, !llvm.ptr
+    %267 = llvm.getelementptr %266[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %267, %265 : !llvm.ptr, !llvm.ptr
+    %268 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_84 = arith.constant 1 : i64
+    %269 = arith.addi %268, %c1_i64_84 : i64
+    llvm.store %269, %9 : i64, !llvm.ptr
+    %270 = arith.cmpi ult, %c1024_i64, %269 : i64
+    %c92_i8_85 = arith.constant 92 : i8
+    cf.cond_br %270, ^bb1(%c92_i8_85 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %c0_i256_84 = arith.constant 0 : i256
-    %268 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %269 = llvm.load %268 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_84, %269 : i256, !llvm.ptr
-    %270 = llvm.getelementptr %269[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %270, %268 : !llvm.ptr, !llvm.ptr
-    %271 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %272 = arith.addi %271, %c1_i64_85 : i64
-    llvm.store %272, %9 : i64, !llvm.ptr
-    %273 = arith.cmpi ult, %c1024_i64, %272 : i64
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %273, ^bb1(%c92_i8_86 : i8), ^bb39
-  ^bb39:  // pred: ^bb38
     %c32_i256 = arith.constant 32 : i256
-    %274 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %275 = llvm.load %274 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256, %275 : i256, !llvm.ptr
-    %276 = llvm.getelementptr %275[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %276, %274 : !llvm.ptr, !llvm.ptr
-    %277 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_87 = arith.constant 1 : i64
-    %278 = arith.addi %277, %c1_i64_87 : i64
-    llvm.store %278, %9 : i64, !llvm.ptr
-    %279 = arith.cmpi ult, %c1024_i64, %278 : i64
-    %c92_i8_88 = arith.constant 92 : i8
-    cf.cond_br %279, ^bb1(%c92_i8_88 : i8), ^bb40
+    %271 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %272 = llvm.load %271 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %272 : i256, !llvm.ptr
+    %273 = llvm.getelementptr %272[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %273, %271 : !llvm.ptr, !llvm.ptr
+    %274 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_86 = arith.constant 1 : i64
+    %275 = arith.addi %274, %c1_i64_86 : i64
+    llvm.store %275, %9 : i64, !llvm.ptr
+    %276 = arith.cmpi ult, %c1024_i64, %275 : i64
+    %c92_i8_87 = arith.constant 92 : i8
+    cf.cond_br %276, ^bb1(%c92_i8_87 : i8), ^bb39
+  ^bb39:  // pred: ^bb38
+    %c0_i256_88 = arith.constant 0 : i256
+    %277 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %278 = llvm.load %277 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_88, %278 : i256, !llvm.ptr
+    %279 = llvm.getelementptr %278[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %279, %277 : !llvm.ptr, !llvm.ptr
+    %280 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_89 = arith.constant 1 : i64
+    %281 = arith.addi %280, %c1_i64_89 : i64
+    llvm.store %281, %9 : i64, !llvm.ptr
+    %282 = arith.cmpi ult, %c1024_i64, %281 : i64
+    %c92_i8_90 = arith.constant 92 : i8
+    cf.cond_br %282, ^bb1(%c92_i8_90 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %c0_i256_89 = arith.constant 0 : i256
-    %280 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %281 = llvm.load %280 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_89, %281 : i256, !llvm.ptr
-    %282 = llvm.getelementptr %281[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %282, %280 : !llvm.ptr, !llvm.ptr
-    %283 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_90 = arith.constant 1 : i64
-    %284 = arith.addi %283, %c1_i64_90 : i64
-    llvm.store %284, %9 : i64, !llvm.ptr
-    %285 = arith.cmpi ult, %c1024_i64, %284 : i64
-    %c92_i8_91 = arith.constant 92 : i8
-    cf.cond_br %285, ^bb1(%c92_i8_91 : i8), ^bb41
+    %283 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %284 = llvm.load %283 : !llvm.ptr -> !llvm.ptr
+    %285 = llvm.getelementptr %284[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %286 = llvm.load %285 : !llvm.ptr -> i256
+    %287 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %288 = llvm.load %287 : !llvm.ptr -> !llvm.ptr
+    llvm.store %286, %288 : i256, !llvm.ptr
+    %289 = llvm.getelementptr %288[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %289, %287 : !llvm.ptr, !llvm.ptr
+    %290 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_91 = arith.constant 1 : i64
+    %291 = arith.addi %290, %c1_i64_91 : i64
+    llvm.store %291, %9 : i64, !llvm.ptr
+    %292 = arith.cmpi ult, %c1024_i64, %291 : i64
+    %c92_i8_92 = arith.constant 92 : i8
+    cf.cond_br %292, ^bb1(%c92_i8_92 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %286 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %287 = llvm.load %286 : !llvm.ptr -> !llvm.ptr
-    %288 = llvm.getelementptr %287[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %289 = llvm.load %288 : !llvm.ptr -> i256
-    %290 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %291 = llvm.load %290 : !llvm.ptr -> !llvm.ptr
-    llvm.store %289, %291 : i256, !llvm.ptr
-    %292 = llvm.getelementptr %291[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %292, %290 : !llvm.ptr, !llvm.ptr
-    %293 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_92 = arith.constant 1 : i64
-    %294 = arith.addi %293, %c1_i64_92 : i64
-    llvm.store %294, %9 : i64, !llvm.ptr
-    %295 = arith.cmpi ult, %c1024_i64, %294 : i64
-    %c92_i8_93 = arith.constant 92 : i8
-    cf.cond_br %295, ^bb1(%c92_i8_93 : i8), ^bb42
+    %c65535_i256_93 = arith.constant 65535 : i256
+    %293 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %294 = llvm.load %293 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_93, %294 : i256, !llvm.ptr
+    %295 = llvm.getelementptr %294[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %295, %293 : !llvm.ptr, !llvm.ptr
+    %296 = llvm.load %9 : !llvm.ptr -> i64
+    %c-5_i64_94 = arith.constant -5 : i64
+    %297 = arith.addi %296, %c-5_i64_94 : i64
+    llvm.store %297, %9 : i64, !llvm.ptr
+    %c6_i64_95 = arith.constant 6 : i64
+    %298 = arith.cmpi ult, %296, %c6_i64_95 : i64
+    %c91_i8_96 = arith.constant 91 : i8
+    cf.cond_br %298, ^bb1(%c91_i8_96 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %c65535_i256_94 = arith.constant 65535 : i256
-    %296 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %297 = llvm.load %296 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c65535_i256_94, %297 : i256, !llvm.ptr
-    %298 = llvm.getelementptr %297[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %298, %296 : !llvm.ptr, !llvm.ptr
-    %299 = llvm.load %9 : !llvm.ptr -> i64
-    %c-5_i64_95 = arith.constant -5 : i64
-    %300 = arith.addi %299, %c-5_i64_95 : i64
-    llvm.store %300, %9 : i64, !llvm.ptr
-    %c6_i64_96 = arith.constant 6 : i64
-    %301 = arith.cmpi ult, %299, %c6_i64_96 : i64
-    %c91_i8_97 = arith.constant 91 : i8
-    cf.cond_br %301, ^bb1(%c91_i8_97 : i8), ^bb43
+    %299 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %300 = llvm.load %299 : !llvm.ptr -> !llvm.ptr
+    %301 = llvm.getelementptr %300[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %302 = llvm.load %301 : !llvm.ptr -> i256
+    llvm.store %301, %299 : !llvm.ptr, !llvm.ptr
+    %303 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %304 = llvm.load %303 : !llvm.ptr -> !llvm.ptr
+    %305 = llvm.getelementptr %304[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %306 = llvm.load %305 : !llvm.ptr -> i256
+    llvm.store %305, %303 : !llvm.ptr, !llvm.ptr
+    %307 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %308 = llvm.load %307 : !llvm.ptr -> !llvm.ptr
+    %309 = llvm.getelementptr %308[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %310 = llvm.load %309 : !llvm.ptr -> i256
+    llvm.store %309, %307 : !llvm.ptr, !llvm.ptr
+    %311 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %312 = llvm.load %311 : !llvm.ptr -> !llvm.ptr
+    %313 = llvm.getelementptr %312[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %314 = llvm.load %313 : !llvm.ptr -> i256
+    llvm.store %313, %311 : !llvm.ptr, !llvm.ptr
+    %315 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %316 = llvm.load %315 : !llvm.ptr -> !llvm.ptr
+    %317 = llvm.getelementptr %316[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %318 = llvm.load %317 : !llvm.ptr -> i256
+    llvm.store %317, %315 : !llvm.ptr, !llvm.ptr
+    %319 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %320 = llvm.load %319 : !llvm.ptr -> !llvm.ptr
+    %321 = llvm.getelementptr %320[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %322 = llvm.load %321 : !llvm.ptr -> i256
+    llvm.store %321, %319 : !llvm.ptr, !llvm.ptr
+    %c0_i256_97 = arith.constant 0 : i256
+    %323 = arith.trunci %302 : i256 to i64
+    %324 = arith.trunci %310 : i256 to i64
+    %c0_i64_98 = arith.constant 0 : i64
+    %325 = arith.cmpi slt, %324, %c0_i64_98 : i64
+    %c84_i8_99 = arith.constant 84 : i8
+    cf.cond_br %325, ^bb1(%c84_i8_99 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %302 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %303 = llvm.load %302 : !llvm.ptr -> !llvm.ptr
-    %304 = llvm.getelementptr %303[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %305 = llvm.load %304 : !llvm.ptr -> i256
-    llvm.store %304, %302 : !llvm.ptr, !llvm.ptr
-    %306 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %307 = llvm.load %306 : !llvm.ptr -> !llvm.ptr
-    %308 = llvm.getelementptr %307[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %309 = llvm.load %308 : !llvm.ptr -> i256
-    llvm.store %308, %306 : !llvm.ptr, !llvm.ptr
-    %310 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %311 = llvm.load %310 : !llvm.ptr -> !llvm.ptr
-    %312 = llvm.getelementptr %311[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %313 = llvm.load %312 : !llvm.ptr -> i256
-    llvm.store %312, %310 : !llvm.ptr, !llvm.ptr
-    %314 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %315 = llvm.load %314 : !llvm.ptr -> !llvm.ptr
-    %316 = llvm.getelementptr %315[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %317 = llvm.load %316 : !llvm.ptr -> i256
-    llvm.store %316, %314 : !llvm.ptr, !llvm.ptr
-    %318 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %319 = llvm.load %318 : !llvm.ptr -> !llvm.ptr
-    %320 = llvm.getelementptr %319[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %321 = llvm.load %320 : !llvm.ptr -> i256
-    llvm.store %320, %318 : !llvm.ptr, !llvm.ptr
-    %322 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %323 = llvm.load %322 : !llvm.ptr -> !llvm.ptr
-    %324 = llvm.getelementptr %323[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %325 = llvm.load %324 : !llvm.ptr -> i256
-    llvm.store %324, %322 : !llvm.ptr, !llvm.ptr
-    %c0_i256_98 = arith.constant 0 : i256
-    %326 = arith.trunci %305 : i256 to i64
-    %327 = arith.trunci %313 : i256 to i64
-    %c0_i64_99 = arith.constant 0 : i64
-    %328 = arith.cmpi slt, %327, %c0_i64_99 : i64
-    %c84_i8_100 = arith.constant 84 : i8
-    cf.cond_br %328, ^bb1(%c84_i8_100 : i8), ^bb44
+    %326 = arith.trunci %314 : i256 to i64
+    %c0_i64_100 = arith.constant 0 : i64
+    %327 = arith.cmpi slt, %326, %c0_i64_100 : i64
+    %c84_i8_101 = arith.constant 84 : i8
+    cf.cond_br %327, ^bb1(%c84_i8_101 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %329 = arith.trunci %317 : i256 to i64
-    %c0_i64_101 = arith.constant 0 : i64
-    %330 = arith.cmpi slt, %329, %c0_i64_101 : i64
-    %c84_i8_102 = arith.constant 84 : i8
-    cf.cond_br %330, ^bb1(%c84_i8_102 : i8), ^bb45
+    %328 = arith.trunci %318 : i256 to i64
+    %c0_i64_102 = arith.constant 0 : i64
+    %329 = arith.cmpi slt, %328, %c0_i64_102 : i64
+    %c84_i8_103 = arith.constant 84 : i8
+    cf.cond_br %329, ^bb1(%c84_i8_103 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %331 = arith.trunci %321 : i256 to i64
-    %c0_i64_103 = arith.constant 0 : i64
-    %332 = arith.cmpi slt, %331, %c0_i64_103 : i64
-    %c84_i8_104 = arith.constant 84 : i8
-    cf.cond_br %332, ^bb1(%c84_i8_104 : i8), ^bb46
+    %330 = arith.trunci %322 : i256 to i64
+    %c0_i64_104 = arith.constant 0 : i64
+    %331 = arith.cmpi slt, %330, %c0_i64_104 : i64
+    %c84_i8_105 = arith.constant 84 : i8
+    cf.cond_br %331, ^bb1(%c84_i8_105 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %333 = arith.trunci %325 : i256 to i64
-    %c0_i64_105 = arith.constant 0 : i64
-    %334 = arith.cmpi slt, %333, %c0_i64_105 : i64
-    %c84_i8_106 = arith.constant 84 : i8
-    cf.cond_br %334, ^bb1(%c84_i8_106 : i8), ^bb47
+    %332 = arith.addi %324, %326 : i64
+    %333 = arith.addi %328, %330 : i64
+    %334 = arith.maxui %332, %333 : i64
+    %c0_i64_106 = arith.constant 0 : i64
+    %335 = arith.cmpi slt, %334, %c0_i64_106 : i64
+    %c84_i8_107 = arith.constant 84 : i8
+    cf.cond_br %335, ^bb1(%c84_i8_107 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %335 = arith.addi %327, %329 : i64
-    %336 = arith.addi %331, %333 : i64
-    %337 = arith.maxui %335, %336 : i64
-    %c0_i64_107 = arith.constant 0 : i64
-    %338 = arith.cmpi slt, %337, %c0_i64_107 : i64
-    %c84_i8_108 = arith.constant 84 : i8
-    cf.cond_br %338, ^bb1(%c84_i8_108 : i8), ^bb48
+    %c31_i64_108 = arith.constant 31 : i64
+    %c32_i64_109 = arith.constant 32 : i64
+    %336 = arith.addi %334, %c31_i64_108 : i64
+    %337 = arith.divui %336, %c32_i64_109 : i64
+    %338 = arith.muli %337, %c32_i64_109 : i64
+    %339 = call @dora_fn_extend_memory(%arg0, %338) : (!llvm.ptr, i64) -> !llvm.ptr
+    %340 = llvm.getelementptr %339[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %341 = llvm.load %340 : !llvm.ptr -> !llvm.ptr
+    %342 = llvm.getelementptr %339[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %343 = llvm.load %342 : !llvm.ptr -> i8
+    %c0_i8_110 = arith.constant 0 : i8
+    %344 = arith.cmpi ne, %343, %c0_i8_110 : i8
+    cf.cond_br %344, ^bb1(%343 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %c31_i64_109 = arith.constant 31 : i64
-    %c32_i64_110 = arith.constant 32 : i64
-    %339 = arith.addi %337, %c31_i64_109 : i64
-    %340 = arith.divui %339, %c32_i64_110 : i64
-    %341 = arith.muli %340, %c32_i64_110 : i64
-    %342 = call @dora_fn_extend_memory(%arg0, %341) : (!llvm.ptr, i64) -> !llvm.ptr
-    %343 = llvm.getelementptr %342[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %344 = llvm.load %343 : !llvm.ptr -> !llvm.ptr
-    %345 = llvm.getelementptr %342[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %346 = llvm.load %345 : !llvm.ptr -> i8
-    %c0_i8_111 = arith.constant 0 : i8
-    %347 = arith.cmpi ne, %346, %c0_i8_111 : i8
-    cf.cond_br %347, ^bb1(%346 : i8), ^bb49
-  ^bb49:  // pred: ^bb48
-    %348 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %344, %348 : !llvm.ptr, !llvm.ptr
-    %349 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %341, %349 : i64, !llvm.ptr
-    %350 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %351 = llvm.load %350 : !llvm.ptr -> i64
+    %345 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %341, %345 : !llvm.ptr, !llvm.ptr
+    %346 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %338, %346 : i64, !llvm.ptr
+    %347 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %348 = llvm.load %347 : !llvm.ptr -> i64
+    %c1_i256_111 = arith.constant 1 : i256
+    %349 = llvm.alloca %c1_i256_111 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_97, %349 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_112 = arith.constant 1 : i256
-    %352 = llvm.alloca %c1_i256_112 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_98, %352 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_113 = arith.constant 1 : i256
-    %353 = llvm.alloca %c1_i256_113 x i256 : (i256) -> !llvm.ptr
-    llvm.store %309, %353 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_114 = arith.constant 1 : i64
-    %354 = llvm.alloca %c1_i64_114 x i64 : (i64) -> !llvm.ptr
+    %350 = llvm.alloca %c1_i256_112 x i256 : (i256) -> !llvm.ptr
+    llvm.store %306, %350 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_113 = arith.constant 1 : i64
+    %351 = llvm.alloca %c1_i64_113 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_114 = arith.constant 0 : i8
+    %352 = call @dora_fn_call(%arg0, %323, %350, %349, %324, %326, %328, %330, %348, %351, %c0_i8_114) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %353 = llvm.getelementptr %352[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %354 = llvm.load %353 : !llvm.ptr -> i8
+    %355 = llvm.getelementptr %352[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %356 = llvm.load %355 : !llvm.ptr -> i8
     %c0_i8_115 = arith.constant 0 : i8
-    %355 = call @dora_fn_call(%arg0, %326, %353, %352, %327, %329, %331, %333, %351, %354, %c0_i8_115) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %356 = llvm.getelementptr %355[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %357 = llvm.load %356 : !llvm.ptr -> i8
-    %358 = llvm.getelementptr %355[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %359 = llvm.load %358 : !llvm.ptr -> i8
-    %c0_i8_116 = arith.constant 0 : i8
-    %360 = arith.cmpi ne, %359, %c0_i8_116 : i8
-    cf.cond_br %360, ^bb1(%359 : i8), ^bb50
+    %357 = arith.cmpi ne, %356, %c0_i8_115 : i8
+    cf.cond_br %357, ^bb1(%356 : i8), ^bb49
+  ^bb49:  // pred: ^bb48
+    %358 = llvm.load %351 : !llvm.ptr -> i64
+    %359 = arith.extui %354 : i8 to i256
+    %360 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %361 = llvm.load %360 : !llvm.ptr -> !llvm.ptr
+    llvm.store %359, %361 : i256, !llvm.ptr
+    %362 = llvm.getelementptr %361[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %362, %360 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb50
   ^bb50:  // pred: ^bb49
-    %361 = llvm.load %354 : !llvm.ptr -> i64
-    %362 = arith.extui %357 : i8 to i256
-    %363 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %364 = llvm.load %363 : !llvm.ptr -> !llvm.ptr
-    llvm.store %362, %364 : i256, !llvm.ptr
-    %365 = llvm.getelementptr %364[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %365, %363 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb51
-  ^bb51:  // pred: ^bb50
-    %c0_i64_117 = arith.constant 0 : i64
+    %c0_i64_116 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %366 = call @dora_fn_write_result(%arg0, %c0_i64_117, %c0_i64_117, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %363 = call @dora_fn_write_result(%arg0, %c0_i64_116, %c0_i64_116, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 45 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45
+  ^bb1(%13: i8):  // 44 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -361,330 +361,323 @@ module {
     %150 = llvm.alloca %c1_i64_43 x i64 : (i64) -> !llvm.ptr
     llvm.store %149, %150 {alignment = 1 : i64} : i64, !llvm.ptr
     %151 = call @dora_fn_create(%arg0, %132, %130, %147, %150) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %152 = llvm.getelementptr %151[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %152 = llvm.getelementptr %151[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %153 = llvm.load %152 : !llvm.ptr -> i8
-    %154 = llvm.getelementptr %151[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %155 = llvm.load %154 : !llvm.ptr -> i8
     %c0_i8_44 = arith.constant 0 : i8
-    %156 = arith.cmpi ne, %155, %c0_i8_44 : i8
-    cf.cond_br %156, ^bb1(%155 : i8), ^bb23
+    %154 = arith.cmpi ne, %153, %c0_i8_44 : i8
+    cf.cond_br %154, ^bb1(%153 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i8_45 = arith.constant 0 : i8
-    %157 = arith.cmpi ne, %c0_i8_45, %153 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %157, ^bb1(%c94_i8 : i8), ^bb24
+    %155 = llvm.load %147 : !llvm.ptr -> i256
+    %156 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %157 = llvm.load %156 : !llvm.ptr -> !llvm.ptr
+    llvm.store %155, %157 : i256, !llvm.ptr
+    %158 = llvm.getelementptr %157[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
+    %159 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_45 = arith.constant 1 : i64
+    %160 = arith.addi %159, %c1_i64_45 : i64
+    llvm.store %160, %9 : i64, !llvm.ptr
+    %161 = arith.cmpi ult, %c1024_i64, %160 : i64
+    %c92_i8_46 = arith.constant 92 : i8
+    cf.cond_br %161, ^bb1(%c92_i8_46 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %158 = llvm.load %147 : !llvm.ptr -> i256
-    %159 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %160 = llvm.load %159 : !llvm.ptr -> !llvm.ptr
-    llvm.store %158, %160 : i256, !llvm.ptr
-    %161 = llvm.getelementptr %160[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %161, %159 : !llvm.ptr, !llvm.ptr
-    %162 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_46 = arith.constant 1 : i64
-    %163 = arith.addi %162, %c1_i64_46 : i64
-    llvm.store %163, %9 : i64, !llvm.ptr
-    %164 = arith.cmpi ult, %c1024_i64, %163 : i64
-    %c92_i8_47 = arith.constant 92 : i8
-    cf.cond_br %164, ^bb1(%c92_i8_47 : i8), ^bb25
+    %c0_i256_47 = arith.constant 0 : i256
+    %162 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %163 = llvm.load %162 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_47, %163 : i256, !llvm.ptr
+    %164 = llvm.getelementptr %163[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %164, %162 : !llvm.ptr, !llvm.ptr
+    %165 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_48 = arith.constant 1 : i64
+    %166 = arith.addi %165, %c1_i64_48 : i64
+    llvm.store %166, %9 : i64, !llvm.ptr
+    %167 = arith.cmpi ult, %c1024_i64, %166 : i64
+    %c92_i8_49 = arith.constant 92 : i8
+    cf.cond_br %167, ^bb1(%c92_i8_49 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %c0_i256_48 = arith.constant 0 : i256
-    %165 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_48, %166 : i256, !llvm.ptr
-    %167 = llvm.getelementptr %166[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %167, %165 : !llvm.ptr, !llvm.ptr
-    %168 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_49 = arith.constant 1 : i64
-    %169 = arith.addi %168, %c1_i64_49 : i64
-    llvm.store %169, %9 : i64, !llvm.ptr
-    %170 = arith.cmpi ult, %c1024_i64, %169 : i64
-    %c92_i8_50 = arith.constant 92 : i8
-    cf.cond_br %170, ^bb1(%c92_i8_50 : i8), ^bb26
+    %c0_i256_50 = arith.constant 0 : i256
+    %168 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %169 = llvm.load %168 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_50, %169 : i256, !llvm.ptr
+    %170 = llvm.getelementptr %169[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %170, %168 : !llvm.ptr, !llvm.ptr
+    %171 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_51 = arith.constant -2 : i64
+    %172 = arith.addi %171, %c-2_i64_51 : i64
+    llvm.store %172, %9 : i64, !llvm.ptr
+    %c2_i64_52 = arith.constant 2 : i64
+    %173 = arith.cmpi ult, %171, %c2_i64_52 : i64
+    %c91_i8_53 = arith.constant 91 : i8
+    cf.cond_br %173, ^bb1(%c91_i8_53 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i256_51 = arith.constant 0 : i256
-    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_51, %172 : i256, !llvm.ptr
-    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
-    %174 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_52 = arith.constant -2 : i64
-    %175 = arith.addi %174, %c-2_i64_52 : i64
-    llvm.store %175, %9 : i64, !llvm.ptr
-    %c2_i64_53 = arith.constant 2 : i64
-    %176 = arith.cmpi ult, %174, %c2_i64_53 : i64
-    %c91_i8_54 = arith.constant 91 : i8
-    cf.cond_br %176, ^bb1(%c91_i8_54 : i8), ^bb27
+    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
+    %176 = llvm.getelementptr %175[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %177 = llvm.load %176 : !llvm.ptr -> i256
+    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
+    %178 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %179 = llvm.load %178 : !llvm.ptr -> !llvm.ptr
+    %180 = llvm.getelementptr %179[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %181 = llvm.load %180 : !llvm.ptr -> i256
+    llvm.store %180, %178 : !llvm.ptr, !llvm.ptr
+    %182 = arith.trunci %177 : i256 to i64
+    %c0_i64_54 = arith.constant 0 : i64
+    %183 = arith.cmpi slt, %182, %c0_i64_54 : i64
+    %c84_i8_55 = arith.constant 84 : i8
+    cf.cond_br %183, ^bb1(%c84_i8_55 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %177 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %178 = llvm.load %177 : !llvm.ptr -> !llvm.ptr
-    %179 = llvm.getelementptr %178[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    llvm.store %179, %177 : !llvm.ptr, !llvm.ptr
-    %181 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %182 = llvm.load %181 : !llvm.ptr -> !llvm.ptr
-    %183 = llvm.getelementptr %182[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    llvm.store %183, %181 : !llvm.ptr, !llvm.ptr
-    %185 = arith.trunci %180 : i256 to i64
-    %c0_i64_55 = arith.constant 0 : i64
-    %186 = arith.cmpi slt, %185, %c0_i64_55 : i64
-    %c84_i8_56 = arith.constant 84 : i8
-    cf.cond_br %186, ^bb1(%c84_i8_56 : i8), ^bb28
+    %c32_i64_56 = arith.constant 32 : i64
+    %184 = arith.addi %182, %c32_i64_56 : i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %185 = arith.cmpi slt, %184, %c0_i64_57 : i64
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %185, ^bb1(%c84_i8_58 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %c32_i64_57 = arith.constant 32 : i64
-    %187 = arith.addi %185, %c32_i64_57 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %188 = arith.cmpi slt, %187, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %188, ^bb1(%c84_i8_59 : i8), ^bb29
+    %c31_i64_59 = arith.constant 31 : i64
+    %c32_i64_60 = arith.constant 32 : i64
+    %186 = arith.addi %184, %c31_i64_59 : i64
+    %187 = arith.divui %186, %c32_i64_60 : i64
+    %188 = arith.muli %187, %c32_i64_60 : i64
+    %189 = call @dora_fn_extend_memory(%arg0, %188) : (!llvm.ptr, i64) -> !llvm.ptr
+    %190 = llvm.getelementptr %189[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %191 = llvm.load %190 : !llvm.ptr -> !llvm.ptr
+    %192 = llvm.getelementptr %189[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %193 = llvm.load %192 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %194 = arith.cmpi ne, %193, %c0_i8_61 : i8
+    cf.cond_br %194, ^bb1(%193 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c31_i64_60 = arith.constant 31 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %189 = arith.addi %187, %c31_i64_60 : i64
-    %190 = arith.divui %189, %c32_i64_61 : i64
-    %191 = arith.muli %190, %c32_i64_61 : i64
-    %192 = call @dora_fn_extend_memory(%arg0, %191) : (!llvm.ptr, i64) -> !llvm.ptr
-    %193 = llvm.getelementptr %192[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %194 = llvm.load %193 : !llvm.ptr -> !llvm.ptr
-    %195 = llvm.getelementptr %192[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %196 = llvm.load %195 : !llvm.ptr -> i8
-    %c0_i8_62 = arith.constant 0 : i8
-    %197 = arith.cmpi ne, %196, %c0_i8_62 : i8
-    cf.cond_br %197, ^bb1(%196 : i8), ^bb30
+    %195 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %191, %195 : !llvm.ptr, !llvm.ptr
+    %196 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %188, %196 : i64, !llvm.ptr
+    %197 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %198 = llvm.load %197 : !llvm.ptr -> !llvm.ptr
+    %199 = llvm.getelementptr %198[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %200 = llvm.intr.bswap(%181)  : (i256) -> i256
+    llvm.store %200, %199 {alignment = 1 : i64} : i256, !llvm.ptr
+    %201 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_62 = arith.constant 1 : i64
+    %202 = arith.addi %201, %c1_i64_62 : i64
+    llvm.store %202, %9 : i64, !llvm.ptr
+    %203 = arith.cmpi ult, %c1024_i64, %202 : i64
+    %c92_i8_63 = arith.constant 92 : i8
+    cf.cond_br %203, ^bb1(%c92_i8_63 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %198 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %194, %198 : !llvm.ptr, !llvm.ptr
-    %199 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %191, %199 : i64, !llvm.ptr
-    %200 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %201 = llvm.load %200 : !llvm.ptr -> !llvm.ptr
-    %202 = llvm.getelementptr %201[%185] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %203 = llvm.intr.bswap(%184)  : (i256) -> i256
-    llvm.store %203, %202 {alignment = 1 : i64} : i256, !llvm.ptr
-    %204 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_63 = arith.constant 1 : i64
-    %205 = arith.addi %204, %c1_i64_63 : i64
-    llvm.store %205, %9 : i64, !llvm.ptr
-    %206 = arith.cmpi ult, %c1024_i64, %205 : i64
-    %c92_i8_64 = arith.constant 92 : i8
-    cf.cond_br %206, ^bb1(%c92_i8_64 : i8), ^bb31
+    %c0_i256_64 = arith.constant 0 : i256
+    %204 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %205 = llvm.load %204 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_64, %205 : i256, !llvm.ptr
+    %206 = llvm.getelementptr %205[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %206, %204 : !llvm.ptr, !llvm.ptr
+    %207 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_65 = arith.constant 1 : i64
+    %208 = arith.addi %207, %c1_i64_65 : i64
+    llvm.store %208, %9 : i64, !llvm.ptr
+    %209 = arith.cmpi ult, %c1024_i64, %208 : i64
+    %c92_i8_66 = arith.constant 92 : i8
+    cf.cond_br %209, ^bb1(%c92_i8_66 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i256_65 = arith.constant 0 : i256
-    %207 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %208 = llvm.load %207 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_65, %208 : i256, !llvm.ptr
-    %209 = llvm.getelementptr %208[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %209, %207 : !llvm.ptr, !llvm.ptr
-    %210 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_66 = arith.constant 1 : i64
-    %211 = arith.addi %210, %c1_i64_66 : i64
-    llvm.store %211, %9 : i64, !llvm.ptr
-    %212 = arith.cmpi ult, %c1024_i64, %211 : i64
-    %c92_i8_67 = arith.constant 92 : i8
-    cf.cond_br %212, ^bb1(%c92_i8_67 : i8), ^bb32
+    %c32_i256_67 = arith.constant 32 : i256
+    %210 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %211 = llvm.load %210 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_67, %211 : i256, !llvm.ptr
+    %212 = llvm.getelementptr %211[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %212, %210 : !llvm.ptr, !llvm.ptr
+    %213 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_68 = arith.constant -2 : i64
+    %214 = arith.addi %213, %c-2_i64_68 : i64
+    llvm.store %214, %9 : i64, !llvm.ptr
+    %c2_i64_69 = arith.constant 2 : i64
+    %215 = arith.cmpi ult, %213, %c2_i64_69 : i64
+    %c91_i8_70 = arith.constant 91 : i8
+    cf.cond_br %215, ^bb1(%c91_i8_70 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c32_i256_68 = arith.constant 32 : i256
-    %213 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %214 = llvm.load %213 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_68, %214 : i256, !llvm.ptr
-    %215 = llvm.getelementptr %214[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %215, %213 : !llvm.ptr, !llvm.ptr
-    %216 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_69 = arith.constant -2 : i64
-    %217 = arith.addi %216, %c-2_i64_69 : i64
-    llvm.store %217, %9 : i64, !llvm.ptr
-    %c2_i64_70 = arith.constant 2 : i64
-    %218 = arith.cmpi ult, %216, %c2_i64_70 : i64
-    %c91_i8_71 = arith.constant 91 : i8
-    cf.cond_br %218, ^bb1(%c91_i8_71 : i8), ^bb33
+    %216 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
+    %218 = llvm.getelementptr %217[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %219 = llvm.load %218 : !llvm.ptr -> i256
+    llvm.store %218, %216 : !llvm.ptr, !llvm.ptr
+    %220 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %221 = llvm.load %220 : !llvm.ptr -> !llvm.ptr
+    %222 = llvm.getelementptr %221[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %223 = llvm.load %222 : !llvm.ptr -> i256
+    llvm.store %222, %220 : !llvm.ptr, !llvm.ptr
+    %224 = arith.trunci %219 : i256 to i64
+    %c0_i64_71 = arith.constant 0 : i64
+    %225 = arith.cmpi slt, %224, %c0_i64_71 : i64
+    %c84_i8_72 = arith.constant 84 : i8
+    cf.cond_br %225, ^bb1(%c84_i8_72 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
-    %221 = llvm.getelementptr %220[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %222 = llvm.load %221 : !llvm.ptr -> i256
-    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
-    %223 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %224 = llvm.load %223 : !llvm.ptr -> !llvm.ptr
-    %225 = llvm.getelementptr %224[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %226 = llvm.load %225 : !llvm.ptr -> i256
-    llvm.store %225, %223 : !llvm.ptr, !llvm.ptr
-    %227 = arith.trunci %222 : i256 to i64
-    %c0_i64_72 = arith.constant 0 : i64
-    %228 = arith.cmpi slt, %227, %c0_i64_72 : i64
-    %c84_i8_73 = arith.constant 84 : i8
-    cf.cond_br %228, ^bb1(%c84_i8_73 : i8), ^bb34
+    %c32_i64_73 = arith.constant 32 : i64
+    %226 = arith.addi %224, %c32_i64_73 : i64
+    %c0_i64_74 = arith.constant 0 : i64
+    %227 = arith.cmpi slt, %226, %c0_i64_74 : i64
+    %c84_i8_75 = arith.constant 84 : i8
+    cf.cond_br %227, ^bb1(%c84_i8_75 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %c32_i64_74 = arith.constant 32 : i64
-    %229 = arith.addi %227, %c32_i64_74 : i64
-    %c0_i64_75 = arith.constant 0 : i64
-    %230 = arith.cmpi slt, %229, %c0_i64_75 : i64
-    %c84_i8_76 = arith.constant 84 : i8
-    cf.cond_br %230, ^bb1(%c84_i8_76 : i8), ^bb35
+    %c31_i64_76 = arith.constant 31 : i64
+    %c32_i64_77 = arith.constant 32 : i64
+    %228 = arith.addi %226, %c31_i64_76 : i64
+    %229 = arith.divui %228, %c32_i64_77 : i64
+    %230 = arith.muli %229, %c32_i64_77 : i64
+    %231 = call @dora_fn_extend_memory(%arg0, %230) : (!llvm.ptr, i64) -> !llvm.ptr
+    %232 = llvm.getelementptr %231[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %233 = llvm.load %232 : !llvm.ptr -> !llvm.ptr
+    %234 = llvm.getelementptr %231[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %235 = llvm.load %234 : !llvm.ptr -> i8
+    %c0_i8_78 = arith.constant 0 : i8
+    %236 = arith.cmpi ne, %235, %c0_i8_78 : i8
+    cf.cond_br %236, ^bb1(%235 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %c31_i64_77 = arith.constant 31 : i64
-    %c32_i64_78 = arith.constant 32 : i64
-    %231 = arith.addi %229, %c31_i64_77 : i64
-    %232 = arith.divui %231, %c32_i64_78 : i64
-    %233 = arith.muli %232, %c32_i64_78 : i64
-    %234 = call @dora_fn_extend_memory(%arg0, %233) : (!llvm.ptr, i64) -> !llvm.ptr
-    %235 = llvm.getelementptr %234[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %236 = llvm.load %235 : !llvm.ptr -> !llvm.ptr
-    %237 = llvm.getelementptr %234[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %238 = llvm.load %237 : !llvm.ptr -> i8
-    %c0_i8_79 = arith.constant 0 : i8
-    %239 = arith.cmpi ne, %238, %c0_i8_79 : i8
-    cf.cond_br %239, ^bb1(%238 : i8), ^bb36
+    %237 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %233, %237 : !llvm.ptr, !llvm.ptr
+    %238 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %230, %238 : i64, !llvm.ptr
+    %239 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %240 = llvm.load %239 : !llvm.ptr -> !llvm.ptr
+    %241 = llvm.getelementptr %240[%224] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %242 = llvm.intr.bswap(%223)  : (i256) -> i256
+    llvm.store %242, %241 {alignment = 1 : i64} : i256, !llvm.ptr
+    %243 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_79 = arith.constant 1 : i64
+    %244 = arith.addi %243, %c1_i64_79 : i64
+    llvm.store %244, %9 : i64, !llvm.ptr
+    %245 = arith.cmpi ult, %c1024_i64, %244 : i64
+    %c92_i8_80 = arith.constant 92 : i8
+    cf.cond_br %245, ^bb1(%c92_i8_80 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %240 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %236, %240 : !llvm.ptr, !llvm.ptr
-    %241 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %233, %241 : i64, !llvm.ptr
-    %242 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %243 = llvm.load %242 : !llvm.ptr -> !llvm.ptr
-    %244 = llvm.getelementptr %243[%227] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %245 = llvm.intr.bswap(%226)  : (i256) -> i256
-    llvm.store %245, %244 {alignment = 1 : i64} : i256, !llvm.ptr
-    %246 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_80 = arith.constant 1 : i64
-    %247 = arith.addi %246, %c1_i64_80 : i64
-    llvm.store %247, %9 : i64, !llvm.ptr
-    %248 = arith.cmpi ult, %c1024_i64, %247 : i64
-    %c92_i8_81 = arith.constant 92 : i8
-    cf.cond_br %248, ^bb1(%c92_i8_81 : i8), ^bb37
+    %c32_i256_81 = arith.constant 32 : i256
+    %246 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %247 = llvm.load %246 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_81, %247 : i256, !llvm.ptr
+    %248 = llvm.getelementptr %247[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %248, %246 : !llvm.ptr, !llvm.ptr
+    %249 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_82 = arith.constant 1 : i64
+    %250 = arith.addi %249, %c1_i64_82 : i64
+    llvm.store %250, %9 : i64, !llvm.ptr
+    %251 = arith.cmpi ult, %c1024_i64, %250 : i64
+    %c92_i8_83 = arith.constant 92 : i8
+    cf.cond_br %251, ^bb1(%c92_i8_83 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %c32_i256_82 = arith.constant 32 : i256
-    %249 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %250 = llvm.load %249 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_82, %250 : i256, !llvm.ptr
-    %251 = llvm.getelementptr %250[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %251, %249 : !llvm.ptr, !llvm.ptr
-    %252 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_83 = arith.constant 1 : i64
-    %253 = arith.addi %252, %c1_i64_83 : i64
-    llvm.store %253, %9 : i64, !llvm.ptr
-    %254 = arith.cmpi ult, %c1024_i64, %253 : i64
-    %c92_i8_84 = arith.constant 92 : i8
-    cf.cond_br %254, ^bb1(%c92_i8_84 : i8), ^bb38
+    %c0_i256_84 = arith.constant 0 : i256
+    %252 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %253 = llvm.load %252 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_84, %253 : i256, !llvm.ptr
+    %254 = llvm.getelementptr %253[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %254, %252 : !llvm.ptr, !llvm.ptr
+    %255 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_85 = arith.constant 1 : i64
+    %256 = arith.addi %255, %c1_i64_85 : i64
+    llvm.store %256, %9 : i64, !llvm.ptr
+    %257 = arith.cmpi ult, %c1024_i64, %256 : i64
+    %c92_i8_86 = arith.constant 92 : i8
+    cf.cond_br %257, ^bb1(%c92_i8_86 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %c0_i256_85 = arith.constant 0 : i256
-    %255 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_85, %256 : i256, !llvm.ptr
-    %257 = llvm.getelementptr %256[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %257, %255 : !llvm.ptr, !llvm.ptr
-    %258 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_86 = arith.constant 1 : i64
-    %259 = arith.addi %258, %c1_i64_86 : i64
-    llvm.store %259, %9 : i64, !llvm.ptr
-    %260 = arith.cmpi ult, %c1024_i64, %259 : i64
-    %c92_i8_87 = arith.constant 92 : i8
-    cf.cond_br %260, ^bb1(%c92_i8_87 : i8), ^bb39
+    %c0_i256_87 = arith.constant 0 : i256
+    %258 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %259 = llvm.load %258 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_87, %259 : i256, !llvm.ptr
+    %260 = llvm.getelementptr %259[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %260, %258 : !llvm.ptr, !llvm.ptr
+    %261 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_88 = arith.constant 1 : i64
+    %262 = arith.addi %261, %c1_i64_88 : i64
+    llvm.store %262, %9 : i64, !llvm.ptr
+    %263 = arith.cmpi ult, %c1024_i64, %262 : i64
+    %c92_i8_89 = arith.constant 92 : i8
+    cf.cond_br %263, ^bb1(%c92_i8_89 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %c0_i256_88 = arith.constant 0 : i256
-    %261 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %262 = llvm.load %261 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_88, %262 : i256, !llvm.ptr
-    %263 = llvm.getelementptr %262[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %263, %261 : !llvm.ptr, !llvm.ptr
-    %264 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_89 = arith.constant 1 : i64
-    %265 = arith.addi %264, %c1_i64_89 : i64
-    llvm.store %265, %9 : i64, !llvm.ptr
-    %266 = arith.cmpi ult, %c1024_i64, %265 : i64
-    %c92_i8_90 = arith.constant 92 : i8
-    cf.cond_br %266, ^bb1(%c92_i8_90 : i8), ^bb40
-  ^bb40:  // pred: ^bb39
-    %267 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %268 = llvm.load %267 : !llvm.ptr -> !llvm.ptr
-    %269 = llvm.getelementptr %268[-4] : (!llvm.ptr) -> !llvm.ptr, i256
-    %270 = llvm.load %269 : !llvm.ptr -> i256
-    %271 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %272 = llvm.load %271 : !llvm.ptr -> !llvm.ptr
-    llvm.store %270, %272 : i256, !llvm.ptr
-    %273 = llvm.getelementptr %272[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %273, %271 : !llvm.ptr, !llvm.ptr
-    %274 = llvm.load %9 : !llvm.ptr -> i64
+    %264 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %265 = llvm.load %264 : !llvm.ptr -> !llvm.ptr
+    %266 = llvm.getelementptr %265[-4] : (!llvm.ptr) -> !llvm.ptr, i256
+    %267 = llvm.load %266 : !llvm.ptr -> i256
+    %268 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %269 = llvm.load %268 : !llvm.ptr -> !llvm.ptr
+    llvm.store %267, %269 : i256, !llvm.ptr
+    %270 = llvm.getelementptr %269[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %270, %268 : !llvm.ptr, !llvm.ptr
+    %271 = llvm.load %9 : !llvm.ptr -> i64
     %c-4_i64 = arith.constant -4 : i64
-    %275 = arith.addi %274, %c-4_i64 : i64
-    llvm.store %275, %9 : i64, !llvm.ptr
+    %272 = arith.addi %271, %c-4_i64 : i64
+    llvm.store %272, %9 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %276 = arith.cmpi ult, %274, %c4_i64 : i64
-    %c91_i8_91 = arith.constant 91 : i8
-    cf.cond_br %276, ^bb1(%c91_i8_91 : i8), ^bb41
+    %273 = arith.cmpi ult, %271, %c4_i64 : i64
+    %c91_i8_90 = arith.constant 91 : i8
+    cf.cond_br %273, ^bb1(%c91_i8_90 : i8), ^bb40
+  ^bb40:  // pred: ^bb39
+    %274 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %275 = llvm.load %274 : !llvm.ptr -> !llvm.ptr
+    %276 = llvm.getelementptr %275[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %277 = llvm.load %276 : !llvm.ptr -> i256
+    llvm.store %276, %274 : !llvm.ptr, !llvm.ptr
+    %278 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %279 = llvm.load %278 : !llvm.ptr -> !llvm.ptr
+    %280 = llvm.getelementptr %279[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %281 = llvm.load %280 : !llvm.ptr -> i256
+    llvm.store %280, %278 : !llvm.ptr, !llvm.ptr
+    %282 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %283 = llvm.load %282 : !llvm.ptr -> !llvm.ptr
+    %284 = llvm.getelementptr %283[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %285 = llvm.load %284 : !llvm.ptr -> i256
+    llvm.store %284, %282 : !llvm.ptr, !llvm.ptr
+    %286 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %287 = llvm.load %286 : !llvm.ptr -> !llvm.ptr
+    %288 = llvm.getelementptr %287[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %289 = llvm.load %288 : !llvm.ptr -> i256
+    llvm.store %288, %286 : !llvm.ptr, !llvm.ptr
+    %290 = arith.trunci %285 : i256 to i64
+    %c0_i64_91 = arith.constant 0 : i64
+    %291 = arith.cmpi slt, %290, %c0_i64_91 : i64
+    %c84_i8_92 = arith.constant 84 : i8
+    cf.cond_br %291, ^bb1(%c84_i8_92 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %277 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %278 = llvm.load %277 : !llvm.ptr -> !llvm.ptr
-    %279 = llvm.getelementptr %278[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %280 = llvm.load %279 : !llvm.ptr -> i256
-    llvm.store %279, %277 : !llvm.ptr, !llvm.ptr
-    %281 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %282 = llvm.load %281 : !llvm.ptr -> !llvm.ptr
-    %283 = llvm.getelementptr %282[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %284 = llvm.load %283 : !llvm.ptr -> i256
-    llvm.store %283, %281 : !llvm.ptr, !llvm.ptr
-    %285 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %286 = llvm.load %285 : !llvm.ptr -> !llvm.ptr
-    %287 = llvm.getelementptr %286[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %288 = llvm.load %287 : !llvm.ptr -> i256
-    llvm.store %287, %285 : !llvm.ptr, !llvm.ptr
-    %289 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %290 = llvm.load %289 : !llvm.ptr -> !llvm.ptr
-    %291 = llvm.getelementptr %290[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %292 = llvm.load %291 : !llvm.ptr -> i256
-    llvm.store %291, %289 : !llvm.ptr, !llvm.ptr
-    %293 = arith.trunci %288 : i256 to i64
-    %c0_i64_92 = arith.constant 0 : i64
-    %294 = arith.cmpi slt, %293, %c0_i64_92 : i64
-    %c84_i8_93 = arith.constant 84 : i8
-    cf.cond_br %294, ^bb1(%c84_i8_93 : i8), ^bb42
+    %292 = arith.trunci %289 : i256 to i64
+    %c0_i64_93 = arith.constant 0 : i64
+    %293 = arith.cmpi slt, %292, %c0_i64_93 : i64
+    %c84_i8_94 = arith.constant 84 : i8
+    cf.cond_br %293, ^bb1(%c84_i8_94 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %295 = arith.trunci %292 : i256 to i64
-    %c0_i64_94 = arith.constant 0 : i64
-    %296 = arith.cmpi slt, %295, %c0_i64_94 : i64
-    %c84_i8_95 = arith.constant 84 : i8
-    cf.cond_br %296, ^bb1(%c84_i8_95 : i8), ^bb43
+    %294 = arith.trunci %281 : i256 to i64
+    %c0_i64_95 = arith.constant 0 : i64
+    %295 = arith.cmpi slt, %294, %c0_i64_95 : i64
+    %c84_i8_96 = arith.constant 84 : i8
+    cf.cond_br %295, ^bb1(%c84_i8_96 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %297 = arith.trunci %284 : i256 to i64
-    %c0_i64_96 = arith.constant 0 : i64
-    %298 = arith.cmpi slt, %297, %c0_i64_96 : i64
-    %c84_i8_97 = arith.constant 84 : i8
-    cf.cond_br %298, ^bb1(%c84_i8_97 : i8), ^bb44
+    %c1_i256_97 = arith.constant 1 : i256
+    %296 = llvm.alloca %c1_i256_97 x i256 : (i256) -> !llvm.ptr
+    llvm.store %277, %296 {alignment = 1 : i64} : i256, !llvm.ptr
+    %297 = arith.addi %294, %292 : i64
+    %c0_i64_98 = arith.constant 0 : i64
+    %298 = arith.cmpi slt, %297, %c0_i64_98 : i64
+    %c84_i8_99 = arith.constant 84 : i8
+    cf.cond_br %298, ^bb1(%c84_i8_99 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c1_i256_98 = arith.constant 1 : i256
-    %299 = llvm.alloca %c1_i256_98 x i256 : (i256) -> !llvm.ptr
-    llvm.store %280, %299 {alignment = 1 : i64} : i256, !llvm.ptr
-    %300 = arith.addi %297, %295 : i64
-    %c0_i64_99 = arith.constant 0 : i64
-    %301 = arith.cmpi slt, %300, %c0_i64_99 : i64
-    %c84_i8_100 = arith.constant 84 : i8
-    cf.cond_br %301, ^bb1(%c84_i8_100 : i8), ^bb45
+    %c31_i64_100 = arith.constant 31 : i64
+    %c32_i64_101 = arith.constant 32 : i64
+    %299 = arith.addi %297, %c31_i64_100 : i64
+    %300 = arith.divui %299, %c32_i64_101 : i64
+    %301 = arith.muli %300, %c32_i64_101 : i64
+    %302 = call @dora_fn_extend_memory(%arg0, %301) : (!llvm.ptr, i64) -> !llvm.ptr
+    %303 = llvm.getelementptr %302[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %304 = llvm.load %303 : !llvm.ptr -> !llvm.ptr
+    %305 = llvm.getelementptr %302[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %306 = llvm.load %305 : !llvm.ptr -> i8
+    %c0_i8_102 = arith.constant 0 : i8
+    %307 = arith.cmpi ne, %306, %c0_i8_102 : i8
+    cf.cond_br %307, ^bb1(%306 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %c31_i64_101 = arith.constant 31 : i64
-    %c32_i64_102 = arith.constant 32 : i64
-    %302 = arith.addi %300, %c31_i64_101 : i64
-    %303 = arith.divui %302, %c32_i64_102 : i64
-    %304 = arith.muli %303, %c32_i64_102 : i64
-    %305 = call @dora_fn_extend_memory(%arg0, %304) : (!llvm.ptr, i64) -> !llvm.ptr
-    %306 = llvm.getelementptr %305[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %307 = llvm.load %306 : !llvm.ptr -> !llvm.ptr
-    %308 = llvm.getelementptr %305[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %309 = llvm.load %308 : !llvm.ptr -> i8
-    %c0_i8_103 = arith.constant 0 : i8
-    %310 = arith.cmpi ne, %309, %c0_i8_103 : i8
-    cf.cond_br %310, ^bb1(%309 : i8), ^bb46
+    %308 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %304, %308 : !llvm.ptr, !llvm.ptr
+    %309 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %301, %309 : i64, !llvm.ptr
+    %310 = call @dora_fn_ext_code_copy(%arg0, %296, %290, %292, %294) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    cf.br ^bb46
   ^bb46:  // pred: ^bb45
-    %311 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %307, %311 : !llvm.ptr, !llvm.ptr
-    %312 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %304, %312 : i64, !llvm.ptr
-    %313 = call @dora_fn_ext_code_copy(%arg0, %299, %293, %295, %297) : (!llvm.ptr, !llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    cf.br ^bb47
-  ^bb47:  // pred: ^bb46
-    %c0_i64_104 = arith.constant 0 : i64
+    %c0_i64_103 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %314 = call @dora_fn_write_result(%arg0, %c0_i64_104, %c0_i64_104, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %311 = call @dora_fn_write_result(%arg0, %c0_i64_103, %c0_i64_103, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 18 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18
+  ^bb1(%13: i8):  // 17 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -278,54 +278,47 @@ module {
     %108 = llvm.alloca %c1_i64_27 x i64 : (i64) -> !llvm.ptr
     llvm.store %107, %108 {alignment = 1 : i64} : i64, !llvm.ptr
     %109 = call @dora_fn_create(%arg0, %90, %88, %105, %108) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %110 = llvm.getelementptr %109[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %110 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %111 = llvm.load %110 : !llvm.ptr -> i8
-    %112 = llvm.getelementptr %109[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %113 = llvm.load %112 : !llvm.ptr -> i8
     %c0_i8_28 = arith.constant 0 : i8
-    %114 = arith.cmpi ne, %113, %c0_i8_28 : i8
-    cf.cond_br %114, ^bb1(%113 : i8), ^bb17
+    %112 = arith.cmpi ne, %111, %c0_i8_28 : i8
+    cf.cond_br %112, ^bb1(%111 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i8_29 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %c0_i8_29, %111 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %115, ^bb1(%c94_i8 : i8), ^bb18
+    %113 = llvm.load %105 : !llvm.ptr -> i256
+    %114 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %115 = llvm.load %114 : !llvm.ptr -> !llvm.ptr
+    llvm.store %113, %115 : i256, !llvm.ptr
+    %116 = llvm.getelementptr %115[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %116, %114 : !llvm.ptr, !llvm.ptr
+    %117 = llvm.load %9 : !llvm.ptr -> i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %118 = arith.addi %117, %c0_i64_29 : i64
+    llvm.store %118, %9 : i64, !llvm.ptr
+    %c1_i64_30 = arith.constant 1 : i64
+    %119 = arith.cmpi ult, %117, %c1_i64_30 : i64
+    %c91_i8_31 = arith.constant 91 : i8
+    cf.cond_br %119, ^bb1(%c91_i8_31 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %116 = llvm.load %105 : !llvm.ptr -> i256
-    %117 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %118 = llvm.load %117 : !llvm.ptr -> !llvm.ptr
-    llvm.store %116, %118 : i256, !llvm.ptr
-    %119 = llvm.getelementptr %118[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %119, %117 : !llvm.ptr, !llvm.ptr
-    %120 = llvm.load %9 : !llvm.ptr -> i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %121 = arith.addi %120, %c0_i64_30 : i64
-    llvm.store %121, %9 : i64, !llvm.ptr
-    %c1_i64_31 = arith.constant 1 : i64
-    %122 = arith.cmpi ult, %120, %c1_i64_31 : i64
-    %c91_i8_32 = arith.constant 91 : i8
-    cf.cond_br %122, ^bb1(%c91_i8_32 : i8), ^bb19
+    %120 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %121 = llvm.load %120 : !llvm.ptr -> !llvm.ptr
+    %122 = llvm.getelementptr %121[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %123 = llvm.load %122 : !llvm.ptr -> i256
+    llvm.store %122, %120 : !llvm.ptr, !llvm.ptr
+    %c1_i256_32 = arith.constant 1 : i256
+    %124 = llvm.alloca %c1_i256_32 x i256 : (i256) -> !llvm.ptr
+    llvm.store %123, %124 {alignment = 1 : i64} : i256, !llvm.ptr
+    %125 = call @dora_fn_ext_code_hash(%arg0, %124) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %126 = llvm.load %124 : !llvm.ptr -> i256
+    %127 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %128 = llvm.load %127 : !llvm.ptr -> !llvm.ptr
+    llvm.store %126, %128 : i256, !llvm.ptr
+    %129 = llvm.getelementptr %128[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %129, %127 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb19
   ^bb19:  // pred: ^bb18
-    %123 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %124 = llvm.load %123 : !llvm.ptr -> !llvm.ptr
-    %125 = llvm.getelementptr %124[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %126 = llvm.load %125 : !llvm.ptr -> i256
-    llvm.store %125, %123 : !llvm.ptr, !llvm.ptr
-    %c1_i256_33 = arith.constant 1 : i256
-    %127 = llvm.alloca %c1_i256_33 x i256 : (i256) -> !llvm.ptr
-    llvm.store %126, %127 {alignment = 1 : i64} : i256, !llvm.ptr
-    %128 = call @dora_fn_ext_code_hash(%arg0, %127) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %129 = llvm.load %127 : !llvm.ptr -> i256
-    %130 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %131 = llvm.load %130 : !llvm.ptr -> !llvm.ptr
-    llvm.store %129, %131 : i256, !llvm.ptr
-    %132 = llvm.getelementptr %131[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %132, %130 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb20
-  ^bb20:  // pred: ^bb19
-    %c0_i64_34 = arith.constant 0 : i64
+    %c0_i64_33 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %133 = call @dora_fn_write_result(%arg0, %c0_i64_34, %c0_i64_34, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %130 = call @dora_fn_write_result(%arg0, %c0_i64_33, %c0_i64_33, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 24 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24
+  ^bb1(%13: i8):  // 23 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -361,56 +361,49 @@ module {
     %150 = llvm.alloca %c1_i64_43 x i64 : (i64) -> !llvm.ptr
     llvm.store %149, %150 {alignment = 1 : i64} : i64, !llvm.ptr
     %151 = call @dora_fn_create(%arg0, %132, %130, %147, %150) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %152 = llvm.getelementptr %151[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %152 = llvm.getelementptr %151[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %153 = llvm.load %152 : !llvm.ptr -> i8
-    %154 = llvm.getelementptr %151[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %155 = llvm.load %154 : !llvm.ptr -> i8
     %c0_i8_44 = arith.constant 0 : i8
-    %156 = arith.cmpi ne, %155, %c0_i8_44 : i8
-    cf.cond_br %156, ^bb1(%155 : i8), ^bb23
+    %154 = arith.cmpi ne, %153, %c0_i8_44 : i8
+    cf.cond_br %154, ^bb1(%153 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i8_45 = arith.constant 0 : i8
-    %157 = arith.cmpi ne, %c0_i8_45, %153 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %157, ^bb1(%c94_i8 : i8), ^bb24
+    %155 = llvm.load %147 : !llvm.ptr -> i256
+    %156 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %157 = llvm.load %156 : !llvm.ptr -> !llvm.ptr
+    llvm.store %155, %157 : i256, !llvm.ptr
+    %158 = llvm.getelementptr %157[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %158, %156 : !llvm.ptr, !llvm.ptr
+    %159 = llvm.load %9 : !llvm.ptr -> i64
+    %c0_i64_45 = arith.constant 0 : i64
+    %160 = arith.addi %159, %c0_i64_45 : i64
+    llvm.store %160, %9 : i64, !llvm.ptr
+    %c1_i64_46 = arith.constant 1 : i64
+    %161 = arith.cmpi ult, %159, %c1_i64_46 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %161, ^bb1(%c91_i8_47 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %158 = llvm.load %147 : !llvm.ptr -> i256
-    %159 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %160 = llvm.load %159 : !llvm.ptr -> !llvm.ptr
-    llvm.store %158, %160 : i256, !llvm.ptr
-    %161 = llvm.getelementptr %160[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %161, %159 : !llvm.ptr, !llvm.ptr
-    %162 = llvm.load %9 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
-    %163 = arith.addi %162, %c0_i64_46 : i64
-    llvm.store %163, %9 : i64, !llvm.ptr
-    %c1_i64_47 = arith.constant 1 : i64
-    %164 = arith.cmpi ult, %162, %c1_i64_47 : i64
-    %c91_i8_48 = arith.constant 91 : i8
-    cf.cond_br %164, ^bb1(%c91_i8_48 : i8), ^bb25
+    %162 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %163 = llvm.load %162 : !llvm.ptr -> !llvm.ptr
+    %164 = llvm.getelementptr %163[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %165 = llvm.load %164 : !llvm.ptr -> i256
+    llvm.store %164, %162 : !llvm.ptr, !llvm.ptr
+    %c1_i256_48 = arith.constant 1 : i256
+    %166 = llvm.alloca %c1_i256_48 x i256 : (i256) -> !llvm.ptr
+    llvm.store %165, %166 {alignment = 1 : i64} : i256, !llvm.ptr
+    %167 = call @dora_fn_extcodesize(%arg0, %166) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %168 = llvm.getelementptr %167[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %169 = llvm.load %168 : !llvm.ptr -> i64
+    %170 = arith.extui %169 : i64 to i256
+    %171 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %172 = llvm.load %171 : !llvm.ptr -> !llvm.ptr
+    llvm.store %170, %172 : i256, !llvm.ptr
+    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %173, %171 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb25
   ^bb25:  // pred: ^bb24
-    %165 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> !llvm.ptr
-    %167 = llvm.getelementptr %166[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %168 = llvm.load %167 : !llvm.ptr -> i256
-    llvm.store %167, %165 : !llvm.ptr, !llvm.ptr
-    %c1_i256_49 = arith.constant 1 : i256
-    %169 = llvm.alloca %c1_i256_49 x i256 : (i256) -> !llvm.ptr
-    llvm.store %168, %169 {alignment = 1 : i64} : i256, !llvm.ptr
-    %170 = call @dora_fn_extcodesize(%arg0, %169) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %171 = llvm.getelementptr %170[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %172 = llvm.load %171 : !llvm.ptr -> i64
-    %173 = arith.extui %172 : i64 to i256
-    %174 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %175 = llvm.load %174 : !llvm.ptr -> !llvm.ptr
-    llvm.store %173, %175 : i256, !llvm.ptr
-    %176 = llvm.getelementptr %175[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %176, %174 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb26
-  ^bb26:  // pred: ^bb25
-    %c0_i64_50 = arith.constant 0 : i64
+    %c0_i64_49 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %177 = call @dora_fn_write_result(%arg0, %c0_i64_50, %c0_i64_50, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %174 = call @dora_fn_write_result(%arg0, %c0_i64_49, %c0_i64_49, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 73 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49, ^bb50, ^bb51, ^bb52, ^bb53, ^bb54, ^bb55, ^bb56, ^bb57, ^bb58, ^bb59, ^bb60, ^bb61, ^bb62, ^bb63, ^bb64, ^bb65, ^bb66, ^bb67, ^bb68, ^bb69, ^bb70, ^bb71, ^bb72, ^bb73
+  ^bb1(%13: i8):  // 72 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49, ^bb50, ^bb51, ^bb52, ^bb53, ^bb54, ^bb55, ^bb56, ^bb57, ^bb58, ^bb59, ^bb60, ^bb61, ^bb62, ^bb63, ^bb64, ^bb65, ^bb66, ^bb67, ^bb68, ^bb69, ^bb70, ^bb71, ^bb72
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -444,627 +444,620 @@ module {
     %192 = llvm.alloca %c1_i64_57 x i64 : (i64) -> !llvm.ptr
     llvm.store %191, %192 {alignment = 1 : i64} : i64, !llvm.ptr
     %193 = call @dora_fn_create(%arg0, %174, %172, %189, %192) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %194 = llvm.getelementptr %193[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %194 = llvm.getelementptr %193[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %195 = llvm.load %194 : !llvm.ptr -> i8
-    %196 = llvm.getelementptr %193[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %197 = llvm.load %196 : !llvm.ptr -> i8
     %c0_i8_58 = arith.constant 0 : i8
-    %198 = arith.cmpi ne, %197, %c0_i8_58 : i8
-    cf.cond_br %198, ^bb1(%197 : i8), ^bb29
+    %196 = arith.cmpi ne, %195, %c0_i8_58 : i8
+    cf.cond_br %196, ^bb1(%195 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i8_59 = arith.constant 0 : i8
-    %199 = arith.cmpi ne, %c0_i8_59, %195 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %199, ^bb1(%c94_i8 : i8), ^bb30
+    %197 = llvm.load %189 : !llvm.ptr -> i256
+    %198 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %199 = llvm.load %198 : !llvm.ptr -> !llvm.ptr
+    llvm.store %197, %199 : i256, !llvm.ptr
+    %200 = llvm.getelementptr %199[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %200, %198 : !llvm.ptr, !llvm.ptr
+    %201 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_59 = arith.constant 1 : i64
+    %202 = arith.addi %201, %c1_i64_59 : i64
+    llvm.store %202, %9 : i64, !llvm.ptr
+    %203 = arith.cmpi ult, %c1024_i64, %202 : i64
+    %c92_i8_60 = arith.constant 92 : i8
+    cf.cond_br %203, ^bb1(%c92_i8_60 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %200 = llvm.load %189 : !llvm.ptr -> i256
-    %201 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %202 = llvm.load %201 : !llvm.ptr -> !llvm.ptr
-    llvm.store %200, %202 : i256, !llvm.ptr
-    %203 = llvm.getelementptr %202[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %203, %201 : !llvm.ptr, !llvm.ptr
-    %204 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_60 = arith.constant 1 : i64
-    %205 = arith.addi %204, %c1_i64_60 : i64
-    llvm.store %205, %9 : i64, !llvm.ptr
-    %206 = arith.cmpi ult, %c1024_i64, %205 : i64
-    %c92_i8_61 = arith.constant 92 : i8
-    cf.cond_br %206, ^bb1(%c92_i8_61 : i8), ^bb31
+    %c0_i256_61 = arith.constant 0 : i256
+    %204 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %205 = llvm.load %204 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_61, %205 : i256, !llvm.ptr
+    %206 = llvm.getelementptr %205[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %206, %204 : !llvm.ptr, !llvm.ptr
+    %207 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_62 = arith.constant 1 : i64
+    %208 = arith.addi %207, %c1_i64_62 : i64
+    llvm.store %208, %9 : i64, !llvm.ptr
+    %209 = arith.cmpi ult, %c1024_i64, %208 : i64
+    %c92_i8_63 = arith.constant 92 : i8
+    cf.cond_br %209, ^bb1(%c92_i8_63 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i256_62 = arith.constant 0 : i256
-    %207 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %208 = llvm.load %207 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_62, %208 : i256, !llvm.ptr
-    %209 = llvm.getelementptr %208[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %209, %207 : !llvm.ptr, !llvm.ptr
-    %210 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_63 = arith.constant 1 : i64
-    %211 = arith.addi %210, %c1_i64_63 : i64
-    llvm.store %211, %9 : i64, !llvm.ptr
-    %212 = arith.cmpi ult, %c1024_i64, %211 : i64
-    %c92_i8_64 = arith.constant 92 : i8
-    cf.cond_br %212, ^bb1(%c92_i8_64 : i8), ^bb32
+    %c0_i256_64 = arith.constant 0 : i256
+    %210 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %211 = llvm.load %210 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_64, %211 : i256, !llvm.ptr
+    %212 = llvm.getelementptr %211[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %212, %210 : !llvm.ptr, !llvm.ptr
+    %213 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_65 = arith.constant 1 : i64
+    %214 = arith.addi %213, %c1_i64_65 : i64
+    llvm.store %214, %9 : i64, !llvm.ptr
+    %215 = arith.cmpi ult, %c1024_i64, %214 : i64
+    %c92_i8_66 = arith.constant 92 : i8
+    cf.cond_br %215, ^bb1(%c92_i8_66 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i256_65 = arith.constant 0 : i256
-    %213 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %214 = llvm.load %213 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_65, %214 : i256, !llvm.ptr
-    %215 = llvm.getelementptr %214[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %215, %213 : !llvm.ptr, !llvm.ptr
-    %216 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_66 = arith.constant 1 : i64
-    %217 = arith.addi %216, %c1_i64_66 : i64
-    llvm.store %217, %9 : i64, !llvm.ptr
-    %218 = arith.cmpi ult, %c1024_i64, %217 : i64
-    %c92_i8_67 = arith.constant 92 : i8
-    cf.cond_br %218, ^bb1(%c92_i8_67 : i8), ^bb33
+    %c0_i256_67 = arith.constant 0 : i256
+    %216 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_67, %217 : i256, !llvm.ptr
+    %218 = llvm.getelementptr %217[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %218, %216 : !llvm.ptr, !llvm.ptr
+    %219 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_68 = arith.constant 1 : i64
+    %220 = arith.addi %219, %c1_i64_68 : i64
+    llvm.store %220, %9 : i64, !llvm.ptr
+    %221 = arith.cmpi ult, %c1024_i64, %220 : i64
+    %c92_i8_69 = arith.constant 92 : i8
+    cf.cond_br %221, ^bb1(%c92_i8_69 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %c0_i256_68 = arith.constant 0 : i256
-    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_68, %220 : i256, !llvm.ptr
-    %221 = llvm.getelementptr %220[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
-    %222 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_69 = arith.constant 1 : i64
-    %223 = arith.addi %222, %c1_i64_69 : i64
-    llvm.store %223, %9 : i64, !llvm.ptr
-    %224 = arith.cmpi ult, %c1024_i64, %223 : i64
-    %c92_i8_70 = arith.constant 92 : i8
-    cf.cond_br %224, ^bb1(%c92_i8_70 : i8), ^bb34
+    %c0_i256_70 = arith.constant 0 : i256
+    %222 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %223 = llvm.load %222 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_70, %223 : i256, !llvm.ptr
+    %224 = llvm.getelementptr %223[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %224, %222 : !llvm.ptr, !llvm.ptr
+    %225 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_71 = arith.constant 1 : i64
+    %226 = arith.addi %225, %c1_i64_71 : i64
+    llvm.store %226, %9 : i64, !llvm.ptr
+    %227 = arith.cmpi ult, %c1024_i64, %226 : i64
+    %c92_i8_72 = arith.constant 92 : i8
+    cf.cond_br %227, ^bb1(%c92_i8_72 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %c0_i256_71 = arith.constant 0 : i256
-    %225 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %226 = llvm.load %225 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_71, %226 : i256, !llvm.ptr
-    %227 = llvm.getelementptr %226[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %227, %225 : !llvm.ptr, !llvm.ptr
-    %228 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %229 = arith.addi %228, %c1_i64_72 : i64
-    llvm.store %229, %9 : i64, !llvm.ptr
-    %230 = arith.cmpi ult, %c1024_i64, %229 : i64
-    %c92_i8_73 = arith.constant 92 : i8
-    cf.cond_br %230, ^bb1(%c92_i8_73 : i8), ^bb35
+    %228 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %229 = llvm.load %228 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    %232 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %233 = llvm.load %232 : !llvm.ptr -> !llvm.ptr
+    llvm.store %231, %233 : i256, !llvm.ptr
+    %234 = llvm.getelementptr %233[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %234, %232 : !llvm.ptr, !llvm.ptr
+    %235 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_73 = arith.constant 1 : i64
+    %236 = arith.addi %235, %c1_i64_73 : i64
+    llvm.store %236, %9 : i64, !llvm.ptr
+    %237 = arith.cmpi ult, %c1024_i64, %236 : i64
+    %c92_i8_74 = arith.constant 92 : i8
+    cf.cond_br %237, ^bb1(%c92_i8_74 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %231 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %232 = llvm.load %231 : !llvm.ptr -> !llvm.ptr
-    %233 = llvm.getelementptr %232[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %234 = llvm.load %233 : !llvm.ptr -> i256
-    %235 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %236 = llvm.load %235 : !llvm.ptr -> !llvm.ptr
-    llvm.store %234, %236 : i256, !llvm.ptr
-    %237 = llvm.getelementptr %236[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %237, %235 : !llvm.ptr, !llvm.ptr
-    %238 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_74 = arith.constant 1 : i64
-    %239 = arith.addi %238, %c1_i64_74 : i64
-    llvm.store %239, %9 : i64, !llvm.ptr
-    %240 = arith.cmpi ult, %c1024_i64, %239 : i64
-    %c92_i8_75 = arith.constant 92 : i8
-    cf.cond_br %240, ^bb1(%c92_i8_75 : i8), ^bb36
-  ^bb36:  // pred: ^bb35
     %c4294967295_i256 = arith.constant 4294967295 : i256
-    %241 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %242 = llvm.load %241 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c4294967295_i256, %242 : i256, !llvm.ptr
-    %243 = llvm.getelementptr %242[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %243, %241 : !llvm.ptr, !llvm.ptr
-    %244 = llvm.load %9 : !llvm.ptr -> i64
+    %238 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %239 = llvm.load %238 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4294967295_i256, %239 : i256, !llvm.ptr
+    %240 = llvm.getelementptr %239[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %240, %238 : !llvm.ptr, !llvm.ptr
+    %241 = llvm.load %9 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %245 = arith.addi %244, %c-5_i64 : i64
-    llvm.store %245, %9 : i64, !llvm.ptr
+    %242 = arith.addi %241, %c-5_i64 : i64
+    llvm.store %242, %9 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %246 = arith.cmpi ult, %244, %c6_i64 : i64
-    %c91_i8_76 = arith.constant 91 : i8
-    cf.cond_br %246, ^bb1(%c91_i8_76 : i8), ^bb37
+    %243 = arith.cmpi ult, %241, %c6_i64 : i64
+    %c91_i8_75 = arith.constant 91 : i8
+    cf.cond_br %243, ^bb1(%c91_i8_75 : i8), ^bb36
+  ^bb36:  // pred: ^bb35
+    %244 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %245 = llvm.load %244 : !llvm.ptr -> !llvm.ptr
+    %246 = llvm.getelementptr %245[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %247 = llvm.load %246 : !llvm.ptr -> i256
+    llvm.store %246, %244 : !llvm.ptr, !llvm.ptr
+    %248 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %249 = llvm.load %248 : !llvm.ptr -> !llvm.ptr
+    %250 = llvm.getelementptr %249[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %251 = llvm.load %250 : !llvm.ptr -> i256
+    llvm.store %250, %248 : !llvm.ptr, !llvm.ptr
+    %252 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %253 = llvm.load %252 : !llvm.ptr -> !llvm.ptr
+    %254 = llvm.getelementptr %253[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %255 = llvm.load %254 : !llvm.ptr -> i256
+    llvm.store %254, %252 : !llvm.ptr, !llvm.ptr
+    %256 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %257 = llvm.load %256 : !llvm.ptr -> !llvm.ptr
+    %258 = llvm.getelementptr %257[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %259 = llvm.load %258 : !llvm.ptr -> i256
+    llvm.store %258, %256 : !llvm.ptr, !llvm.ptr
+    %260 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %261 = llvm.load %260 : !llvm.ptr -> !llvm.ptr
+    %262 = llvm.getelementptr %261[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %263 = llvm.load %262 : !llvm.ptr -> i256
+    llvm.store %262, %260 : !llvm.ptr, !llvm.ptr
+    %264 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %265 = llvm.load %264 : !llvm.ptr -> !llvm.ptr
+    %266 = llvm.getelementptr %265[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %267 = llvm.load %266 : !llvm.ptr -> i256
+    llvm.store %266, %264 : !llvm.ptr, !llvm.ptr
+    %c0_i256_76 = arith.constant 0 : i256
+    %268 = arith.trunci %247 : i256 to i64
+    %269 = arith.trunci %255 : i256 to i64
+    %c0_i64_77 = arith.constant 0 : i64
+    %270 = arith.cmpi slt, %269, %c0_i64_77 : i64
+    %c84_i8_78 = arith.constant 84 : i8
+    cf.cond_br %270, ^bb1(%c84_i8_78 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %247 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %248 = llvm.load %247 : !llvm.ptr -> !llvm.ptr
-    %249 = llvm.getelementptr %248[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %250 = llvm.load %249 : !llvm.ptr -> i256
-    llvm.store %249, %247 : !llvm.ptr, !llvm.ptr
-    %251 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %252 = llvm.load %251 : !llvm.ptr -> !llvm.ptr
-    %253 = llvm.getelementptr %252[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %254 = llvm.load %253 : !llvm.ptr -> i256
-    llvm.store %253, %251 : !llvm.ptr, !llvm.ptr
-    %255 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-    %257 = llvm.getelementptr %256[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %258 = llvm.load %257 : !llvm.ptr -> i256
-    llvm.store %257, %255 : !llvm.ptr, !llvm.ptr
-    %259 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %260 = llvm.load %259 : !llvm.ptr -> !llvm.ptr
-    %261 = llvm.getelementptr %260[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %262 = llvm.load %261 : !llvm.ptr -> i256
-    llvm.store %261, %259 : !llvm.ptr, !llvm.ptr
-    %263 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %264 = llvm.load %263 : !llvm.ptr -> !llvm.ptr
-    %265 = llvm.getelementptr %264[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %266 = llvm.load %265 : !llvm.ptr -> i256
-    llvm.store %265, %263 : !llvm.ptr, !llvm.ptr
-    %267 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %268 = llvm.load %267 : !llvm.ptr -> !llvm.ptr
-    %269 = llvm.getelementptr %268[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %270 = llvm.load %269 : !llvm.ptr -> i256
-    llvm.store %269, %267 : !llvm.ptr, !llvm.ptr
-    %c0_i256_77 = arith.constant 0 : i256
-    %271 = arith.trunci %250 : i256 to i64
-    %272 = arith.trunci %258 : i256 to i64
-    %c0_i64_78 = arith.constant 0 : i64
-    %273 = arith.cmpi slt, %272, %c0_i64_78 : i64
-    %c84_i8_79 = arith.constant 84 : i8
-    cf.cond_br %273, ^bb1(%c84_i8_79 : i8), ^bb38
+    %271 = arith.trunci %259 : i256 to i64
+    %c0_i64_79 = arith.constant 0 : i64
+    %272 = arith.cmpi slt, %271, %c0_i64_79 : i64
+    %c84_i8_80 = arith.constant 84 : i8
+    cf.cond_br %272, ^bb1(%c84_i8_80 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %274 = arith.trunci %262 : i256 to i64
-    %c0_i64_80 = arith.constant 0 : i64
-    %275 = arith.cmpi slt, %274, %c0_i64_80 : i64
-    %c84_i8_81 = arith.constant 84 : i8
-    cf.cond_br %275, ^bb1(%c84_i8_81 : i8), ^bb39
+    %273 = arith.trunci %263 : i256 to i64
+    %c0_i64_81 = arith.constant 0 : i64
+    %274 = arith.cmpi slt, %273, %c0_i64_81 : i64
+    %c84_i8_82 = arith.constant 84 : i8
+    cf.cond_br %274, ^bb1(%c84_i8_82 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %276 = arith.trunci %266 : i256 to i64
-    %c0_i64_82 = arith.constant 0 : i64
-    %277 = arith.cmpi slt, %276, %c0_i64_82 : i64
-    %c84_i8_83 = arith.constant 84 : i8
-    cf.cond_br %277, ^bb1(%c84_i8_83 : i8), ^bb40
+    %275 = arith.trunci %267 : i256 to i64
+    %c0_i64_83 = arith.constant 0 : i64
+    %276 = arith.cmpi slt, %275, %c0_i64_83 : i64
+    %c84_i8_84 = arith.constant 84 : i8
+    cf.cond_br %276, ^bb1(%c84_i8_84 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %278 = arith.trunci %270 : i256 to i64
-    %c0_i64_84 = arith.constant 0 : i64
-    %279 = arith.cmpi slt, %278, %c0_i64_84 : i64
-    %c84_i8_85 = arith.constant 84 : i8
-    cf.cond_br %279, ^bb1(%c84_i8_85 : i8), ^bb41
+    %277 = arith.addi %269, %271 : i64
+    %278 = arith.addi %273, %275 : i64
+    %279 = arith.maxui %277, %278 : i64
+    %c0_i64_85 = arith.constant 0 : i64
+    %280 = arith.cmpi slt, %279, %c0_i64_85 : i64
+    %c84_i8_86 = arith.constant 84 : i8
+    cf.cond_br %280, ^bb1(%c84_i8_86 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %280 = arith.addi %272, %274 : i64
-    %281 = arith.addi %276, %278 : i64
-    %282 = arith.maxui %280, %281 : i64
-    %c0_i64_86 = arith.constant 0 : i64
-    %283 = arith.cmpi slt, %282, %c0_i64_86 : i64
-    %c84_i8_87 = arith.constant 84 : i8
-    cf.cond_br %283, ^bb1(%c84_i8_87 : i8), ^bb42
+    %c31_i64_87 = arith.constant 31 : i64
+    %c32_i64_88 = arith.constant 32 : i64
+    %281 = arith.addi %279, %c31_i64_87 : i64
+    %282 = arith.divui %281, %c32_i64_88 : i64
+    %283 = arith.muli %282, %c32_i64_88 : i64
+    %284 = call @dora_fn_extend_memory(%arg0, %283) : (!llvm.ptr, i64) -> !llvm.ptr
+    %285 = llvm.getelementptr %284[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %286 = llvm.load %285 : !llvm.ptr -> !llvm.ptr
+    %287 = llvm.getelementptr %284[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %288 = llvm.load %287 : !llvm.ptr -> i8
+    %c0_i8_89 = arith.constant 0 : i8
+    %289 = arith.cmpi ne, %288, %c0_i8_89 : i8
+    cf.cond_br %289, ^bb1(%288 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %c31_i64_88 = arith.constant 31 : i64
-    %c32_i64_89 = arith.constant 32 : i64
-    %284 = arith.addi %282, %c31_i64_88 : i64
-    %285 = arith.divui %284, %c32_i64_89 : i64
-    %286 = arith.muli %285, %c32_i64_89 : i64
-    %287 = call @dora_fn_extend_memory(%arg0, %286) : (!llvm.ptr, i64) -> !llvm.ptr
-    %288 = llvm.getelementptr %287[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %289 = llvm.load %288 : !llvm.ptr -> !llvm.ptr
-    %290 = llvm.getelementptr %287[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %291 = llvm.load %290 : !llvm.ptr -> i8
-    %c0_i8_90 = arith.constant 0 : i8
-    %292 = arith.cmpi ne, %291, %c0_i8_90 : i8
-    cf.cond_br %292, ^bb1(%291 : i8), ^bb43
-  ^bb43:  // pred: ^bb42
-    %293 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %289, %293 : !llvm.ptr, !llvm.ptr
-    %294 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %286, %294 : i64, !llvm.ptr
-    %295 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %296 = llvm.load %295 : !llvm.ptr -> i64
+    %290 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %286, %290 : !llvm.ptr, !llvm.ptr
+    %291 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %283, %291 : i64, !llvm.ptr
+    %292 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %293 = llvm.load %292 : !llvm.ptr -> i64
+    %c1_i256_90 = arith.constant 1 : i256
+    %294 = llvm.alloca %c1_i256_90 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_76, %294 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_91 = arith.constant 1 : i256
-    %297 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_77, %297 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_92 = arith.constant 1 : i256
-    %298 = llvm.alloca %c1_i256_92 x i256 : (i256) -> !llvm.ptr
-    llvm.store %254, %298 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_93 = arith.constant 1 : i64
-    %299 = llvm.alloca %c1_i64_93 x i64 : (i64) -> !llvm.ptr
+    %295 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
+    llvm.store %251, %295 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_92 = arith.constant 1 : i64
+    %296 = llvm.alloca %c1_i64_92 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_93 = arith.constant 0 : i8
+    %297 = call @dora_fn_call(%arg0, %268, %295, %294, %269, %271, %273, %275, %293, %296, %c0_i8_93) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %298 = llvm.getelementptr %297[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %299 = llvm.load %298 : !llvm.ptr -> i8
+    %300 = llvm.getelementptr %297[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %301 = llvm.load %300 : !llvm.ptr -> i8
     %c0_i8_94 = arith.constant 0 : i8
-    %300 = call @dora_fn_call(%arg0, %271, %298, %297, %272, %274, %276, %278, %296, %299, %c0_i8_94) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %301 = llvm.getelementptr %300[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %302 = llvm.load %301 : !llvm.ptr -> i8
-    %303 = llvm.getelementptr %300[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %304 = llvm.load %303 : !llvm.ptr -> i8
-    %c0_i8_95 = arith.constant 0 : i8
-    %305 = arith.cmpi ne, %304, %c0_i8_95 : i8
-    cf.cond_br %305, ^bb1(%304 : i8), ^bb44
-  ^bb44:  // pred: ^bb43
-    %306 = llvm.load %299 : !llvm.ptr -> i64
-    %307 = arith.extui %302 : i8 to i256
-    %308 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %309 = llvm.load %308 : !llvm.ptr -> !llvm.ptr
-    llvm.store %307, %309 : i256, !llvm.ptr
-    %310 = llvm.getelementptr %309[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %310, %308 : !llvm.ptr, !llvm.ptr
-    %311 = llvm.load %9 : !llvm.ptr -> i64
+    %302 = arith.cmpi ne, %301, %c0_i8_94 : i8
+    cf.cond_br %302, ^bb1(%301 : i8), ^bb43
+  ^bb43:  // pred: ^bb42
+    %303 = llvm.load %296 : !llvm.ptr -> i64
+    %304 = arith.extui %299 : i8 to i256
+    %305 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %306 = llvm.load %305 : !llvm.ptr -> !llvm.ptr
+    llvm.store %304, %306 : i256, !llvm.ptr
+    %307 = llvm.getelementptr %306[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %307, %305 : !llvm.ptr, !llvm.ptr
+    %308 = llvm.load %9 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %312 = arith.addi %311, %c-1_i64 : i64
-    llvm.store %312, %9 : i64, !llvm.ptr
-    %c1_i64_96 = arith.constant 1 : i64
-    %313 = arith.cmpi ult, %311, %c1_i64_96 : i64
-    %c91_i8_97 = arith.constant 91 : i8
-    cf.cond_br %313, ^bb1(%c91_i8_97 : i8), ^bb45
+    %309 = arith.addi %308, %c-1_i64 : i64
+    llvm.store %309, %9 : i64, !llvm.ptr
+    %c1_i64_95 = arith.constant 1 : i64
+    %310 = arith.cmpi ult, %308, %c1_i64_95 : i64
+    %c91_i8_96 = arith.constant 91 : i8
+    cf.cond_br %310, ^bb1(%c91_i8_96 : i8), ^bb44
+  ^bb44:  // pred: ^bb43
+    %311 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %312 = llvm.load %311 : !llvm.ptr -> !llvm.ptr
+    %313 = llvm.getelementptr %312[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %314 = llvm.load %313 : !llvm.ptr -> i256
+    llvm.store %313, %311 : !llvm.ptr, !llvm.ptr
+    %315 = llvm.load %9 : !llvm.ptr -> i64
+    %c-1_i64_97 = arith.constant -1 : i64
+    %316 = arith.addi %315, %c-1_i64_97 : i64
+    llvm.store %316, %9 : i64, !llvm.ptr
+    %c1_i64_98 = arith.constant 1 : i64
+    %317 = arith.cmpi ult, %315, %c1_i64_98 : i64
+    %c91_i8_99 = arith.constant 91 : i8
+    cf.cond_br %317, ^bb1(%c91_i8_99 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %314 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %315 = llvm.load %314 : !llvm.ptr -> !llvm.ptr
-    %316 = llvm.getelementptr %315[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %317 = llvm.load %316 : !llvm.ptr -> i256
-    llvm.store %316, %314 : !llvm.ptr, !llvm.ptr
-    %318 = llvm.load %9 : !llvm.ptr -> i64
-    %c-1_i64_98 = arith.constant -1 : i64
-    %319 = arith.addi %318, %c-1_i64_98 : i64
-    llvm.store %319, %9 : i64, !llvm.ptr
-    %c1_i64_99 = arith.constant 1 : i64
-    %320 = arith.cmpi ult, %318, %c1_i64_99 : i64
-    %c91_i8_100 = arith.constant 91 : i8
-    cf.cond_br %320, ^bb1(%c91_i8_100 : i8), ^bb46
+    %318 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %319 = llvm.load %318 : !llvm.ptr -> !llvm.ptr
+    %320 = llvm.getelementptr %319[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %321 = llvm.load %320 : !llvm.ptr -> i256
+    llvm.store %320, %318 : !llvm.ptr, !llvm.ptr
+    %322 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_100 = arith.constant 1 : i64
+    %323 = arith.addi %322, %c1_i64_100 : i64
+    llvm.store %323, %9 : i64, !llvm.ptr
+    %324 = arith.cmpi ult, %c1024_i64, %323 : i64
+    %c92_i8_101 = arith.constant 92 : i8
+    cf.cond_br %324, ^bb1(%c92_i8_101 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %321 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %322 = llvm.load %321 : !llvm.ptr -> !llvm.ptr
-    %323 = llvm.getelementptr %322[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %324 = llvm.load %323 : !llvm.ptr -> i256
-    llvm.store %323, %321 : !llvm.ptr, !llvm.ptr
-    %325 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_101 = arith.constant 1 : i64
-    %326 = arith.addi %325, %c1_i64_101 : i64
-    llvm.store %326, %9 : i64, !llvm.ptr
-    %327 = arith.cmpi ult, %c1024_i64, %326 : i64
-    %c92_i8_102 = arith.constant 92 : i8
-    cf.cond_br %327, ^bb1(%c92_i8_102 : i8), ^bb47
+    %c0_i256_102 = arith.constant 0 : i256
+    %325 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %326 = llvm.load %325 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_102, %326 : i256, !llvm.ptr
+    %327 = llvm.getelementptr %326[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %327, %325 : !llvm.ptr, !llvm.ptr
+    %328 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_103 = arith.constant 1 : i64
+    %329 = arith.addi %328, %c1_i64_103 : i64
+    llvm.store %329, %9 : i64, !llvm.ptr
+    %330 = arith.cmpi ult, %c1024_i64, %329 : i64
+    %c92_i8_104 = arith.constant 92 : i8
+    cf.cond_br %330, ^bb1(%c92_i8_104 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %c0_i256_103 = arith.constant 0 : i256
-    %328 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %329 = llvm.load %328 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_103, %329 : i256, !llvm.ptr
-    %330 = llvm.getelementptr %329[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %330, %328 : !llvm.ptr, !llvm.ptr
-    %331 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_104 = arith.constant 1 : i64
-    %332 = arith.addi %331, %c1_i64_104 : i64
-    llvm.store %332, %9 : i64, !llvm.ptr
-    %333 = arith.cmpi ult, %c1024_i64, %332 : i64
-    %c92_i8_105 = arith.constant 92 : i8
-    cf.cond_br %333, ^bb1(%c92_i8_105 : i8), ^bb48
+    %c0_i256_105 = arith.constant 0 : i256
+    %331 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %332 = llvm.load %331 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_105, %332 : i256, !llvm.ptr
+    %333 = llvm.getelementptr %332[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %333, %331 : !llvm.ptr, !llvm.ptr
+    %334 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_106 = arith.constant -2 : i64
+    %335 = arith.addi %334, %c-2_i64_106 : i64
+    llvm.store %335, %9 : i64, !llvm.ptr
+    %c2_i64_107 = arith.constant 2 : i64
+    %336 = arith.cmpi ult, %334, %c2_i64_107 : i64
+    %c91_i8_108 = arith.constant 91 : i8
+    cf.cond_br %336, ^bb1(%c91_i8_108 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %c0_i256_106 = arith.constant 0 : i256
-    %334 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %335 = llvm.load %334 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_106, %335 : i256, !llvm.ptr
-    %336 = llvm.getelementptr %335[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %336, %334 : !llvm.ptr, !llvm.ptr
-    %337 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_107 = arith.constant -2 : i64
-    %338 = arith.addi %337, %c-2_i64_107 : i64
-    llvm.store %338, %9 : i64, !llvm.ptr
-    %c2_i64_108 = arith.constant 2 : i64
-    %339 = arith.cmpi ult, %337, %c2_i64_108 : i64
-    %c91_i8_109 = arith.constant 91 : i8
-    cf.cond_br %339, ^bb1(%c91_i8_109 : i8), ^bb49
+    %337 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %338 = llvm.load %337 : !llvm.ptr -> !llvm.ptr
+    %339 = llvm.getelementptr %338[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %340 = llvm.load %339 : !llvm.ptr -> i256
+    llvm.store %339, %337 : !llvm.ptr, !llvm.ptr
+    %341 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %342 = llvm.load %341 : !llvm.ptr -> !llvm.ptr
+    %343 = llvm.getelementptr %342[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %344 = llvm.load %343 : !llvm.ptr -> i256
+    llvm.store %343, %341 : !llvm.ptr, !llvm.ptr
+    %345 = arith.trunci %340 : i256 to i64
+    %c0_i64_109 = arith.constant 0 : i64
+    %346 = arith.cmpi slt, %345, %c0_i64_109 : i64
+    %c84_i8_110 = arith.constant 84 : i8
+    cf.cond_br %346, ^bb1(%c84_i8_110 : i8), ^bb49
   ^bb49:  // pred: ^bb48
-    %340 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %341 = llvm.load %340 : !llvm.ptr -> !llvm.ptr
-    %342 = llvm.getelementptr %341[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %343 = llvm.load %342 : !llvm.ptr -> i256
-    llvm.store %342, %340 : !llvm.ptr, !llvm.ptr
-    %344 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %345 = llvm.load %344 : !llvm.ptr -> !llvm.ptr
-    %346 = llvm.getelementptr %345[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %347 = llvm.load %346 : !llvm.ptr -> i256
-    llvm.store %346, %344 : !llvm.ptr, !llvm.ptr
-    %348 = arith.trunci %343 : i256 to i64
-    %c0_i64_110 = arith.constant 0 : i64
-    %349 = arith.cmpi slt, %348, %c0_i64_110 : i64
-    %c84_i8_111 = arith.constant 84 : i8
-    cf.cond_br %349, ^bb1(%c84_i8_111 : i8), ^bb50
+    %c32_i64_111 = arith.constant 32 : i64
+    %347 = arith.addi %345, %c32_i64_111 : i64
+    %c0_i64_112 = arith.constant 0 : i64
+    %348 = arith.cmpi slt, %347, %c0_i64_112 : i64
+    %c84_i8_113 = arith.constant 84 : i8
+    cf.cond_br %348, ^bb1(%c84_i8_113 : i8), ^bb50
   ^bb50:  // pred: ^bb49
-    %c32_i64_112 = arith.constant 32 : i64
-    %350 = arith.addi %348, %c32_i64_112 : i64
-    %c0_i64_113 = arith.constant 0 : i64
-    %351 = arith.cmpi slt, %350, %c0_i64_113 : i64
-    %c84_i8_114 = arith.constant 84 : i8
-    cf.cond_br %351, ^bb1(%c84_i8_114 : i8), ^bb51
+    %c31_i64_114 = arith.constant 31 : i64
+    %c32_i64_115 = arith.constant 32 : i64
+    %349 = arith.addi %347, %c31_i64_114 : i64
+    %350 = arith.divui %349, %c32_i64_115 : i64
+    %351 = arith.muli %350, %c32_i64_115 : i64
+    %352 = call @dora_fn_extend_memory(%arg0, %351) : (!llvm.ptr, i64) -> !llvm.ptr
+    %353 = llvm.getelementptr %352[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %354 = llvm.load %353 : !llvm.ptr -> !llvm.ptr
+    %355 = llvm.getelementptr %352[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %356 = llvm.load %355 : !llvm.ptr -> i8
+    %c0_i8_116 = arith.constant 0 : i8
+    %357 = arith.cmpi ne, %356, %c0_i8_116 : i8
+    cf.cond_br %357, ^bb1(%356 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %c31_i64_115 = arith.constant 31 : i64
-    %c32_i64_116 = arith.constant 32 : i64
-    %352 = arith.addi %350, %c31_i64_115 : i64
-    %353 = arith.divui %352, %c32_i64_116 : i64
-    %354 = arith.muli %353, %c32_i64_116 : i64
-    %355 = call @dora_fn_extend_memory(%arg0, %354) : (!llvm.ptr, i64) -> !llvm.ptr
-    %356 = llvm.getelementptr %355[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %357 = llvm.load %356 : !llvm.ptr -> !llvm.ptr
-    %358 = llvm.getelementptr %355[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %359 = llvm.load %358 : !llvm.ptr -> i8
-    %c0_i8_117 = arith.constant 0 : i8
-    %360 = arith.cmpi ne, %359, %c0_i8_117 : i8
-    cf.cond_br %360, ^bb1(%359 : i8), ^bb52
+    %358 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %354, %358 : !llvm.ptr, !llvm.ptr
+    %359 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %351, %359 : i64, !llvm.ptr
+    %360 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %361 = llvm.load %360 : !llvm.ptr -> !llvm.ptr
+    %362 = llvm.getelementptr %361[%345] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %363 = llvm.intr.bswap(%344)  : (i256) -> i256
+    llvm.store %363, %362 {alignment = 1 : i64} : i256, !llvm.ptr
+    %364 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_117 = arith.constant 1 : i64
+    %365 = arith.addi %364, %c1_i64_117 : i64
+    llvm.store %365, %9 : i64, !llvm.ptr
+    %366 = arith.cmpi ult, %c1024_i64, %365 : i64
+    %c92_i8_118 = arith.constant 92 : i8
+    cf.cond_br %366, ^bb1(%c92_i8_118 : i8), ^bb52
   ^bb52:  // pred: ^bb51
-    %361 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %357, %361 : !llvm.ptr, !llvm.ptr
-    %362 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %354, %362 : i64, !llvm.ptr
-    %363 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %364 = llvm.load %363 : !llvm.ptr -> !llvm.ptr
-    %365 = llvm.getelementptr %364[%348] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %366 = llvm.intr.bswap(%347)  : (i256) -> i256
-    llvm.store %366, %365 {alignment = 1 : i64} : i256, !llvm.ptr
-    %367 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_118 = arith.constant 1 : i64
-    %368 = arith.addi %367, %c1_i64_118 : i64
-    llvm.store %368, %9 : i64, !llvm.ptr
-    %369 = arith.cmpi ult, %c1024_i64, %368 : i64
-    %c92_i8_119 = arith.constant 92 : i8
-    cf.cond_br %369, ^bb1(%c92_i8_119 : i8), ^bb53
+    %c0_i256_119 = arith.constant 0 : i256
+    %367 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %368 = llvm.load %367 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_119, %368 : i256, !llvm.ptr
+    %369 = llvm.getelementptr %368[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %369, %367 : !llvm.ptr, !llvm.ptr
+    %370 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_120 = arith.constant 1 : i64
+    %371 = arith.addi %370, %c1_i64_120 : i64
+    llvm.store %371, %9 : i64, !llvm.ptr
+    %372 = arith.cmpi ult, %c1024_i64, %371 : i64
+    %c92_i8_121 = arith.constant 92 : i8
+    cf.cond_br %372, ^bb1(%c92_i8_121 : i8), ^bb53
   ^bb53:  // pred: ^bb52
-    %c0_i256_120 = arith.constant 0 : i256
-    %370 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %371 = llvm.load %370 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_120, %371 : i256, !llvm.ptr
-    %372 = llvm.getelementptr %371[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %372, %370 : !llvm.ptr, !llvm.ptr
-    %373 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_121 = arith.constant 1 : i64
-    %374 = arith.addi %373, %c1_i64_121 : i64
-    llvm.store %374, %9 : i64, !llvm.ptr
-    %375 = arith.cmpi ult, %c1024_i64, %374 : i64
-    %c92_i8_122 = arith.constant 92 : i8
-    cf.cond_br %375, ^bb1(%c92_i8_122 : i8), ^bb54
+    %c32_i256_122 = arith.constant 32 : i256
+    %373 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %374 = llvm.load %373 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_122, %374 : i256, !llvm.ptr
+    %375 = llvm.getelementptr %374[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %375, %373 : !llvm.ptr, !llvm.ptr
+    %376 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_123 = arith.constant -2 : i64
+    %377 = arith.addi %376, %c-2_i64_123 : i64
+    llvm.store %377, %9 : i64, !llvm.ptr
+    %c2_i64_124 = arith.constant 2 : i64
+    %378 = arith.cmpi ult, %376, %c2_i64_124 : i64
+    %c91_i8_125 = arith.constant 91 : i8
+    cf.cond_br %378, ^bb1(%c91_i8_125 : i8), ^bb54
   ^bb54:  // pred: ^bb53
-    %c32_i256_123 = arith.constant 32 : i256
-    %376 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %377 = llvm.load %376 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_123, %377 : i256, !llvm.ptr
-    %378 = llvm.getelementptr %377[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %378, %376 : !llvm.ptr, !llvm.ptr
-    %379 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_124 = arith.constant -2 : i64
-    %380 = arith.addi %379, %c-2_i64_124 : i64
-    llvm.store %380, %9 : i64, !llvm.ptr
-    %c2_i64_125 = arith.constant 2 : i64
-    %381 = arith.cmpi ult, %379, %c2_i64_125 : i64
-    %c91_i8_126 = arith.constant 91 : i8
-    cf.cond_br %381, ^bb1(%c91_i8_126 : i8), ^bb55
+    %379 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %380 = llvm.load %379 : !llvm.ptr -> !llvm.ptr
+    %381 = llvm.getelementptr %380[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %382 = llvm.load %381 : !llvm.ptr -> i256
+    llvm.store %381, %379 : !llvm.ptr, !llvm.ptr
+    %383 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %384 = llvm.load %383 : !llvm.ptr -> !llvm.ptr
+    %385 = llvm.getelementptr %384[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %386 = llvm.load %385 : !llvm.ptr -> i256
+    llvm.store %385, %383 : !llvm.ptr, !llvm.ptr
+    %387 = arith.trunci %382 : i256 to i64
+    %c0_i64_126 = arith.constant 0 : i64
+    %388 = arith.cmpi slt, %387, %c0_i64_126 : i64
+    %c84_i8_127 = arith.constant 84 : i8
+    cf.cond_br %388, ^bb1(%c84_i8_127 : i8), ^bb55
   ^bb55:  // pred: ^bb54
-    %382 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %383 = llvm.load %382 : !llvm.ptr -> !llvm.ptr
-    %384 = llvm.getelementptr %383[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %385 = llvm.load %384 : !llvm.ptr -> i256
-    llvm.store %384, %382 : !llvm.ptr, !llvm.ptr
-    %386 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %387 = llvm.load %386 : !llvm.ptr -> !llvm.ptr
-    %388 = llvm.getelementptr %387[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %389 = llvm.load %388 : !llvm.ptr -> i256
-    llvm.store %388, %386 : !llvm.ptr, !llvm.ptr
-    %390 = arith.trunci %385 : i256 to i64
-    %c0_i64_127 = arith.constant 0 : i64
-    %391 = arith.cmpi slt, %390, %c0_i64_127 : i64
-    %c84_i8_128 = arith.constant 84 : i8
-    cf.cond_br %391, ^bb1(%c84_i8_128 : i8), ^bb56
+    %c32_i64_128 = arith.constant 32 : i64
+    %389 = arith.addi %387, %c32_i64_128 : i64
+    %c0_i64_129 = arith.constant 0 : i64
+    %390 = arith.cmpi slt, %389, %c0_i64_129 : i64
+    %c84_i8_130 = arith.constant 84 : i8
+    cf.cond_br %390, ^bb1(%c84_i8_130 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %c32_i64_129 = arith.constant 32 : i64
-    %392 = arith.addi %390, %c32_i64_129 : i64
-    %c0_i64_130 = arith.constant 0 : i64
-    %393 = arith.cmpi slt, %392, %c0_i64_130 : i64
-    %c84_i8_131 = arith.constant 84 : i8
-    cf.cond_br %393, ^bb1(%c84_i8_131 : i8), ^bb57
+    %c31_i64_131 = arith.constant 31 : i64
+    %c32_i64_132 = arith.constant 32 : i64
+    %391 = arith.addi %389, %c31_i64_131 : i64
+    %392 = arith.divui %391, %c32_i64_132 : i64
+    %393 = arith.muli %392, %c32_i64_132 : i64
+    %394 = call @dora_fn_extend_memory(%arg0, %393) : (!llvm.ptr, i64) -> !llvm.ptr
+    %395 = llvm.getelementptr %394[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %396 = llvm.load %395 : !llvm.ptr -> !llvm.ptr
+    %397 = llvm.getelementptr %394[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %398 = llvm.load %397 : !llvm.ptr -> i8
+    %c0_i8_133 = arith.constant 0 : i8
+    %399 = arith.cmpi ne, %398, %c0_i8_133 : i8
+    cf.cond_br %399, ^bb1(%398 : i8), ^bb57
   ^bb57:  // pred: ^bb56
-    %c31_i64_132 = arith.constant 31 : i64
-    %c32_i64_133 = arith.constant 32 : i64
-    %394 = arith.addi %392, %c31_i64_132 : i64
-    %395 = arith.divui %394, %c32_i64_133 : i64
-    %396 = arith.muli %395, %c32_i64_133 : i64
-    %397 = call @dora_fn_extend_memory(%arg0, %396) : (!llvm.ptr, i64) -> !llvm.ptr
-    %398 = llvm.getelementptr %397[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %399 = llvm.load %398 : !llvm.ptr -> !llvm.ptr
-    %400 = llvm.getelementptr %397[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %401 = llvm.load %400 : !llvm.ptr -> i8
-    %c0_i8_134 = arith.constant 0 : i8
-    %402 = arith.cmpi ne, %401, %c0_i8_134 : i8
-    cf.cond_br %402, ^bb1(%401 : i8), ^bb58
+    %400 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %396, %400 : !llvm.ptr, !llvm.ptr
+    %401 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %393, %401 : i64, !llvm.ptr
+    %402 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %403 = llvm.load %402 : !llvm.ptr -> !llvm.ptr
+    %404 = llvm.getelementptr %403[%387] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %405 = llvm.intr.bswap(%386)  : (i256) -> i256
+    llvm.store %405, %404 {alignment = 1 : i64} : i256, !llvm.ptr
+    %406 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_134 = arith.constant 1 : i64
+    %407 = arith.addi %406, %c1_i64_134 : i64
+    llvm.store %407, %9 : i64, !llvm.ptr
+    %408 = arith.cmpi ult, %c1024_i64, %407 : i64
+    %c92_i8_135 = arith.constant 92 : i8
+    cf.cond_br %408, ^bb1(%c92_i8_135 : i8), ^bb58
   ^bb58:  // pred: ^bb57
-    %403 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %399, %403 : !llvm.ptr, !llvm.ptr
-    %404 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %396, %404 : i64, !llvm.ptr
-    %405 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %406 = llvm.load %405 : !llvm.ptr -> !llvm.ptr
-    %407 = llvm.getelementptr %406[%390] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %408 = llvm.intr.bswap(%389)  : (i256) -> i256
-    llvm.store %408, %407 {alignment = 1 : i64} : i256, !llvm.ptr
-    %409 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_135 = arith.constant 1 : i64
-    %410 = arith.addi %409, %c1_i64_135 : i64
-    llvm.store %410, %9 : i64, !llvm.ptr
-    %411 = arith.cmpi ult, %c1024_i64, %410 : i64
-    %c92_i8_136 = arith.constant 92 : i8
-    cf.cond_br %411, ^bb1(%c92_i8_136 : i8), ^bb59
+    %c0_i256_136 = arith.constant 0 : i256
+    %409 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %410 = llvm.load %409 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_136, %410 : i256, !llvm.ptr
+    %411 = llvm.getelementptr %410[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %411, %409 : !llvm.ptr, !llvm.ptr
+    %412 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_137 = arith.constant 1 : i64
+    %413 = arith.addi %412, %c1_i64_137 : i64
+    llvm.store %413, %9 : i64, !llvm.ptr
+    %414 = arith.cmpi ult, %c1024_i64, %413 : i64
+    %c92_i8_138 = arith.constant 92 : i8
+    cf.cond_br %414, ^bb1(%c92_i8_138 : i8), ^bb59
   ^bb59:  // pred: ^bb58
-    %c0_i256_137 = arith.constant 0 : i256
-    %412 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %413 = llvm.load %412 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_137, %413 : i256, !llvm.ptr
-    %414 = llvm.getelementptr %413[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %414, %412 : !llvm.ptr, !llvm.ptr
-    %415 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_138 = arith.constant 1 : i64
-    %416 = arith.addi %415, %c1_i64_138 : i64
-    llvm.store %416, %9 : i64, !llvm.ptr
-    %417 = arith.cmpi ult, %c1024_i64, %416 : i64
-    %c92_i8_139 = arith.constant 92 : i8
-    cf.cond_br %417, ^bb1(%c92_i8_139 : i8), ^bb60
+    %c64_i256_139 = arith.constant 64 : i256
+    %415 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %416 = llvm.load %415 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_139, %416 : i256, !llvm.ptr
+    %417 = llvm.getelementptr %416[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %417, %415 : !llvm.ptr, !llvm.ptr
+    %418 = llvm.load %9 : !llvm.ptr -> i64
+    %c-2_i64_140 = arith.constant -2 : i64
+    %419 = arith.addi %418, %c-2_i64_140 : i64
+    llvm.store %419, %9 : i64, !llvm.ptr
+    %c2_i64_141 = arith.constant 2 : i64
+    %420 = arith.cmpi ult, %418, %c2_i64_141 : i64
+    %c91_i8_142 = arith.constant 91 : i8
+    cf.cond_br %420, ^bb1(%c91_i8_142 : i8), ^bb60
   ^bb60:  // pred: ^bb59
-    %c64_i256_140 = arith.constant 64 : i256
-    %418 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %419 = llvm.load %418 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c64_i256_140, %419 : i256, !llvm.ptr
-    %420 = llvm.getelementptr %419[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %420, %418 : !llvm.ptr, !llvm.ptr
-    %421 = llvm.load %9 : !llvm.ptr -> i64
-    %c-2_i64_141 = arith.constant -2 : i64
-    %422 = arith.addi %421, %c-2_i64_141 : i64
-    llvm.store %422, %9 : i64, !llvm.ptr
-    %c2_i64_142 = arith.constant 2 : i64
-    %423 = arith.cmpi ult, %421, %c2_i64_142 : i64
-    %c91_i8_143 = arith.constant 91 : i8
-    cf.cond_br %423, ^bb1(%c91_i8_143 : i8), ^bb61
+    %421 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %422 = llvm.load %421 : !llvm.ptr -> !llvm.ptr
+    %423 = llvm.getelementptr %422[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %424 = llvm.load %423 : !llvm.ptr -> i256
+    llvm.store %423, %421 : !llvm.ptr, !llvm.ptr
+    %425 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %426 = llvm.load %425 : !llvm.ptr -> !llvm.ptr
+    %427 = llvm.getelementptr %426[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %428 = llvm.load %427 : !llvm.ptr -> i256
+    llvm.store %427, %425 : !llvm.ptr, !llvm.ptr
+    %429 = arith.trunci %424 : i256 to i64
+    %c0_i64_143 = arith.constant 0 : i64
+    %430 = arith.cmpi slt, %429, %c0_i64_143 : i64
+    %c84_i8_144 = arith.constant 84 : i8
+    cf.cond_br %430, ^bb1(%c84_i8_144 : i8), ^bb61
   ^bb61:  // pred: ^bb60
-    %424 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %425 = llvm.load %424 : !llvm.ptr -> !llvm.ptr
-    %426 = llvm.getelementptr %425[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %427 = llvm.load %426 : !llvm.ptr -> i256
-    llvm.store %426, %424 : !llvm.ptr, !llvm.ptr
-    %428 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %429 = llvm.load %428 : !llvm.ptr -> !llvm.ptr
-    %430 = llvm.getelementptr %429[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %431 = llvm.load %430 : !llvm.ptr -> i256
-    llvm.store %430, %428 : !llvm.ptr, !llvm.ptr
-    %432 = arith.trunci %427 : i256 to i64
-    %c0_i64_144 = arith.constant 0 : i64
-    %433 = arith.cmpi slt, %432, %c0_i64_144 : i64
-    %c84_i8_145 = arith.constant 84 : i8
-    cf.cond_br %433, ^bb1(%c84_i8_145 : i8), ^bb62
+    %c32_i64_145 = arith.constant 32 : i64
+    %431 = arith.addi %429, %c32_i64_145 : i64
+    %c0_i64_146 = arith.constant 0 : i64
+    %432 = arith.cmpi slt, %431, %c0_i64_146 : i64
+    %c84_i8_147 = arith.constant 84 : i8
+    cf.cond_br %432, ^bb1(%c84_i8_147 : i8), ^bb62
   ^bb62:  // pred: ^bb61
-    %c32_i64_146 = arith.constant 32 : i64
-    %434 = arith.addi %432, %c32_i64_146 : i64
-    %c0_i64_147 = arith.constant 0 : i64
-    %435 = arith.cmpi slt, %434, %c0_i64_147 : i64
-    %c84_i8_148 = arith.constant 84 : i8
-    cf.cond_br %435, ^bb1(%c84_i8_148 : i8), ^bb63
+    %c31_i64_148 = arith.constant 31 : i64
+    %c32_i64_149 = arith.constant 32 : i64
+    %433 = arith.addi %431, %c31_i64_148 : i64
+    %434 = arith.divui %433, %c32_i64_149 : i64
+    %435 = arith.muli %434, %c32_i64_149 : i64
+    %436 = call @dora_fn_extend_memory(%arg0, %435) : (!llvm.ptr, i64) -> !llvm.ptr
+    %437 = llvm.getelementptr %436[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %438 = llvm.load %437 : !llvm.ptr -> !llvm.ptr
+    %439 = llvm.getelementptr %436[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %440 = llvm.load %439 : !llvm.ptr -> i8
+    %c0_i8_150 = arith.constant 0 : i8
+    %441 = arith.cmpi ne, %440, %c0_i8_150 : i8
+    cf.cond_br %441, ^bb1(%440 : i8), ^bb63
   ^bb63:  // pred: ^bb62
-    %c31_i64_149 = arith.constant 31 : i64
-    %c32_i64_150 = arith.constant 32 : i64
-    %436 = arith.addi %434, %c31_i64_149 : i64
-    %437 = arith.divui %436, %c32_i64_150 : i64
-    %438 = arith.muli %437, %c32_i64_150 : i64
-    %439 = call @dora_fn_extend_memory(%arg0, %438) : (!llvm.ptr, i64) -> !llvm.ptr
-    %440 = llvm.getelementptr %439[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %441 = llvm.load %440 : !llvm.ptr -> !llvm.ptr
-    %442 = llvm.getelementptr %439[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %443 = llvm.load %442 : !llvm.ptr -> i8
-    %c0_i8_151 = arith.constant 0 : i8
-    %444 = arith.cmpi ne, %443, %c0_i8_151 : i8
-    cf.cond_br %444, ^bb1(%443 : i8), ^bb64
+    %442 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %438, %442 : !llvm.ptr, !llvm.ptr
+    %443 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %435, %443 : i64, !llvm.ptr
+    %444 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    %445 = llvm.load %444 : !llvm.ptr -> !llvm.ptr
+    %446 = llvm.getelementptr %445[%429] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %447 = llvm.intr.bswap(%428)  : (i256) -> i256
+    llvm.store %447, %446 {alignment = 1 : i64} : i256, !llvm.ptr
+    %448 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_151 = arith.constant 1 : i64
+    %449 = arith.addi %448, %c1_i64_151 : i64
+    llvm.store %449, %9 : i64, !llvm.ptr
+    %450 = arith.cmpi ult, %c1024_i64, %449 : i64
+    %c92_i8_152 = arith.constant 92 : i8
+    cf.cond_br %450, ^bb1(%c92_i8_152 : i8), ^bb64
   ^bb64:  // pred: ^bb63
-    %445 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %441, %445 : !llvm.ptr, !llvm.ptr
-    %446 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %438, %446 : i64, !llvm.ptr
-    %447 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    %448 = llvm.load %447 : !llvm.ptr -> !llvm.ptr
-    %449 = llvm.getelementptr %448[%432] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %450 = llvm.intr.bswap(%431)  : (i256) -> i256
-    llvm.store %450, %449 {alignment = 1 : i64} : i256, !llvm.ptr
-    %451 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_152 = arith.constant 1 : i64
-    %452 = arith.addi %451, %c1_i64_152 : i64
-    llvm.store %452, %9 : i64, !llvm.ptr
-    %453 = arith.cmpi ult, %c1024_i64, %452 : i64
-    %c92_i8_153 = arith.constant 92 : i8
-    cf.cond_br %453, ^bb1(%c92_i8_153 : i8), ^bb65
+    %c32_i256_153 = arith.constant 32 : i256
+    %451 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %452 = llvm.load %451 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_153, %452 : i256, !llvm.ptr
+    %453 = llvm.getelementptr %452[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %453, %451 : !llvm.ptr, !llvm.ptr
+    %454 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_154 = arith.constant 1 : i64
+    %455 = arith.addi %454, %c1_i64_154 : i64
+    llvm.store %455, %9 : i64, !llvm.ptr
+    %456 = arith.cmpi ult, %c1024_i64, %455 : i64
+    %c92_i8_155 = arith.constant 92 : i8
+    cf.cond_br %456, ^bb1(%c92_i8_155 : i8), ^bb65
   ^bb65:  // pred: ^bb64
-    %c32_i256_154 = arith.constant 32 : i256
-    %454 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %455 = llvm.load %454 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c32_i256_154, %455 : i256, !llvm.ptr
-    %456 = llvm.getelementptr %455[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %456, %454 : !llvm.ptr, !llvm.ptr
-    %457 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_155 = arith.constant 1 : i64
-    %458 = arith.addi %457, %c1_i64_155 : i64
-    llvm.store %458, %9 : i64, !llvm.ptr
-    %459 = arith.cmpi ult, %c1024_i64, %458 : i64
-    %c92_i8_156 = arith.constant 92 : i8
-    cf.cond_br %459, ^bb1(%c92_i8_156 : i8), ^bb66
+    %c0_i256_156 = arith.constant 0 : i256
+    %457 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %458 = llvm.load %457 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_156, %458 : i256, !llvm.ptr
+    %459 = llvm.getelementptr %458[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %459, %457 : !llvm.ptr, !llvm.ptr
+    %460 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_157 = arith.constant 1 : i64
+    %461 = arith.addi %460, %c1_i64_157 : i64
+    llvm.store %461, %9 : i64, !llvm.ptr
+    %462 = arith.cmpi ult, %c1024_i64, %461 : i64
+    %c92_i8_158 = arith.constant 92 : i8
+    cf.cond_br %462, ^bb1(%c92_i8_158 : i8), ^bb66
   ^bb66:  // pred: ^bb65
-    %c0_i256_157 = arith.constant 0 : i256
-    %460 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %461 = llvm.load %460 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_157, %461 : i256, !llvm.ptr
-    %462 = llvm.getelementptr %461[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %462, %460 : !llvm.ptr, !llvm.ptr
-    %463 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_158 = arith.constant 1 : i64
-    %464 = arith.addi %463, %c1_i64_158 : i64
-    llvm.store %464, %9 : i64, !llvm.ptr
-    %465 = arith.cmpi ult, %c1024_i64, %464 : i64
-    %c92_i8_159 = arith.constant 92 : i8
-    cf.cond_br %465, ^bb1(%c92_i8_159 : i8), ^bb67
-  ^bb67:  // pred: ^bb66
-    %c0_i256_160 = arith.constant 0 : i256
-    %466 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %467 = llvm.load %466 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_160, %467 : i256, !llvm.ptr
-    %468 = llvm.getelementptr %467[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %468, %466 : !llvm.ptr, !llvm.ptr
-    %469 = llvm.load %9 : !llvm.ptr -> i64
+    %c0_i256_159 = arith.constant 0 : i256
+    %463 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %464 = llvm.load %463 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_159, %464 : i256, !llvm.ptr
+    %465 = llvm.getelementptr %464[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %465, %463 : !llvm.ptr, !llvm.ptr
+    %466 = llvm.load %9 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %470 = arith.addi %469, %c-3_i64 : i64
-    llvm.store %470, %9 : i64, !llvm.ptr
-    %c3_i64_161 = arith.constant 3 : i64
-    %471 = arith.cmpi ult, %469, %c3_i64_161 : i64
-    %c91_i8_162 = arith.constant 91 : i8
-    cf.cond_br %471, ^bb1(%c91_i8_162 : i8), ^bb68
+    %467 = arith.addi %466, %c-3_i64 : i64
+    llvm.store %467, %9 : i64, !llvm.ptr
+    %c3_i64_160 = arith.constant 3 : i64
+    %468 = arith.cmpi ult, %466, %c3_i64_160 : i64
+    %c91_i8_161 = arith.constant 91 : i8
+    cf.cond_br %468, ^bb1(%c91_i8_161 : i8), ^bb67
+  ^bb67:  // pred: ^bb66
+    %469 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %470 = llvm.load %469 : !llvm.ptr -> !llvm.ptr
+    %471 = llvm.getelementptr %470[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %472 = llvm.load %471 : !llvm.ptr -> i256
+    llvm.store %471, %469 : !llvm.ptr, !llvm.ptr
+    %473 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %474 = llvm.load %473 : !llvm.ptr -> !llvm.ptr
+    %475 = llvm.getelementptr %474[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %476 = llvm.load %475 : !llvm.ptr -> i256
+    llvm.store %475, %473 : !llvm.ptr, !llvm.ptr
+    %477 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %478 = llvm.load %477 : !llvm.ptr -> !llvm.ptr
+    %479 = llvm.getelementptr %478[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %480 = llvm.load %479 : !llvm.ptr -> i256
+    llvm.store %479, %477 : !llvm.ptr, !llvm.ptr
+    %481 = arith.trunci %472 : i256 to i64
+    %c0_i64_162 = arith.constant 0 : i64
+    %482 = arith.cmpi slt, %481, %c0_i64_162 : i64
+    %c84_i8_163 = arith.constant 84 : i8
+    cf.cond_br %482, ^bb1(%c84_i8_163 : i8), ^bb68
   ^bb68:  // pred: ^bb67
-    %472 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %473 = llvm.load %472 : !llvm.ptr -> !llvm.ptr
-    %474 = llvm.getelementptr %473[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %475 = llvm.load %474 : !llvm.ptr -> i256
-    llvm.store %474, %472 : !llvm.ptr, !llvm.ptr
-    %476 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %477 = llvm.load %476 : !llvm.ptr -> !llvm.ptr
-    %478 = llvm.getelementptr %477[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %479 = llvm.load %478 : !llvm.ptr -> i256
-    llvm.store %478, %476 : !llvm.ptr, !llvm.ptr
-    %480 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %481 = llvm.load %480 : !llvm.ptr -> !llvm.ptr
-    %482 = llvm.getelementptr %481[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %483 = llvm.load %482 : !llvm.ptr -> i256
-    llvm.store %482, %480 : !llvm.ptr, !llvm.ptr
-    %484 = arith.trunci %475 : i256 to i64
-    %c0_i64_163 = arith.constant 0 : i64
-    %485 = arith.cmpi slt, %484, %c0_i64_163 : i64
-    %c84_i8_164 = arith.constant 84 : i8
-    cf.cond_br %485, ^bb1(%c84_i8_164 : i8), ^bb69
+    %483 = arith.trunci %476 : i256 to i64
+    %c0_i64_164 = arith.constant 0 : i64
+    %484 = arith.cmpi slt, %483, %c0_i64_164 : i64
+    %c84_i8_165 = arith.constant 84 : i8
+    cf.cond_br %484, ^bb1(%c84_i8_165 : i8), ^bb69
   ^bb69:  // pred: ^bb68
-    %486 = arith.trunci %479 : i256 to i64
-    %c0_i64_165 = arith.constant 0 : i64
-    %487 = arith.cmpi slt, %486, %c0_i64_165 : i64
-    %c84_i8_166 = arith.constant 84 : i8
-    cf.cond_br %487, ^bb1(%c84_i8_166 : i8), ^bb70
+    %485 = arith.trunci %480 : i256 to i64
+    %c0_i64_166 = arith.constant 0 : i64
+    %486 = arith.cmpi slt, %485, %c0_i64_166 : i64
+    %c84_i8_167 = arith.constant 84 : i8
+    cf.cond_br %486, ^bb1(%c84_i8_167 : i8), ^bb70
   ^bb70:  // pred: ^bb69
-    %488 = arith.trunci %483 : i256 to i64
-    %c0_i64_167 = arith.constant 0 : i64
-    %489 = arith.cmpi slt, %488, %c0_i64_167 : i64
-    %c84_i8_168 = arith.constant 84 : i8
-    cf.cond_br %489, ^bb1(%c84_i8_168 : i8), ^bb71
+    %487 = arith.addi %481, %485 : i64
+    %c0_i64_168 = arith.constant 0 : i64
+    %488 = arith.cmpi slt, %487, %c0_i64_168 : i64
+    %c84_i8_169 = arith.constant 84 : i8
+    cf.cond_br %488, ^bb1(%c84_i8_169 : i8), ^bb71
   ^bb71:  // pred: ^bb70
-    %490 = arith.addi %484, %488 : i64
-    %c0_i64_169 = arith.constant 0 : i64
-    %491 = arith.cmpi slt, %490, %c0_i64_169 : i64
-    %c84_i8_170 = arith.constant 84 : i8
-    cf.cond_br %491, ^bb1(%c84_i8_170 : i8), ^bb72
+    %c31_i64_170 = arith.constant 31 : i64
+    %c32_i64_171 = arith.constant 32 : i64
+    %489 = arith.addi %487, %c31_i64_170 : i64
+    %490 = arith.divui %489, %c32_i64_171 : i64
+    %491 = arith.muli %490, %c32_i64_171 : i64
+    %492 = call @dora_fn_extend_memory(%arg0, %491) : (!llvm.ptr, i64) -> !llvm.ptr
+    %493 = llvm.getelementptr %492[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %494 = llvm.load %493 : !llvm.ptr -> !llvm.ptr
+    %495 = llvm.getelementptr %492[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %496 = llvm.load %495 : !llvm.ptr -> i8
+    %c0_i8_172 = arith.constant 0 : i8
+    %497 = arith.cmpi ne, %496, %c0_i8_172 : i8
+    cf.cond_br %497, ^bb1(%496 : i8), ^bb72
   ^bb72:  // pred: ^bb71
-    %c31_i64_171 = arith.constant 31 : i64
-    %c32_i64_172 = arith.constant 32 : i64
-    %492 = arith.addi %490, %c31_i64_171 : i64
-    %493 = arith.divui %492, %c32_i64_172 : i64
-    %494 = arith.muli %493, %c32_i64_172 : i64
-    %495 = call @dora_fn_extend_memory(%arg0, %494) : (!llvm.ptr, i64) -> !llvm.ptr
-    %496 = llvm.getelementptr %495[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %497 = llvm.load %496 : !llvm.ptr -> !llvm.ptr
-    %498 = llvm.getelementptr %495[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %499 = llvm.load %498 : !llvm.ptr -> i8
+    %498 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %494, %498 : !llvm.ptr, !llvm.ptr
+    %499 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %491, %499 : i64, !llvm.ptr
+    %500 = call @dora_fn_return_data_copy(%arg0, %481, %483, %485) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+    %501 = llvm.getelementptr %500[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %502 = llvm.load %501 : !llvm.ptr -> i8
     %c0_i8_173 = arith.constant 0 : i8
-    %500 = arith.cmpi ne, %499, %c0_i8_173 : i8
-    cf.cond_br %500, ^bb1(%499 : i8), ^bb73
+    %503 = arith.cmpi ne, %502, %c0_i8_173 : i8
+    cf.cond_br %503, ^bb1(%502 : i8), ^bb73
   ^bb73:  // pred: ^bb72
-    %501 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %497, %501 : !llvm.ptr, !llvm.ptr
-    %502 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %494, %502 : i64, !llvm.ptr
-    %503 = call @dora_fn_return_data_copy(%arg0, %484, %486, %488) : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-    %504 = llvm.getelementptr %503[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %505 = llvm.load %504 : !llvm.ptr -> i8
-    %c0_i8_174 = arith.constant 0 : i8
-    %506 = arith.cmpi ne, %505, %c0_i8_174 : i8
-    cf.cond_br %506, ^bb1(%505 : i8), ^bb74
+    cf.br ^bb74
   ^bb74:  // pred: ^bb73
-    cf.br ^bb75
-  ^bb75:  // pred: ^bb74
-    %c0_i64_175 = arith.constant 0 : i64
+    %c0_i64_174 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %507 = call @dora_fn_write_result(%arg0, %c0_i64_175, %c0_i64_175, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %504 = call @dora_fn_write_result(%arg0, %c0_i64_174, %c0_i64_174, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
@@ -82,7 +82,7 @@ module {
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
-  ^bb1(%13: i8):  // 44 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43, ^bb44
+  ^bb1(%13: i8):  // 43 preds: ^bb0, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9, ^bb10, ^bb11, ^bb12, ^bb13, ^bb14, ^bb15, ^bb16, ^bb17, ^bb18, ^bb19, ^bb20, ^bb21, ^bb22, ^bb23, ^bb24, ^bb25, ^bb26, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb36, ^bb37, ^bb38, ^bb39, ^bb40, ^bb41, ^bb42, ^bb43
     %c0_i64_1 = arith.constant 0 : i64
     %14 = call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %c0_i64_1, %13) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %13 : i8
@@ -444,252 +444,245 @@ module {
     %192 = llvm.alloca %c1_i64_57 x i64 : (i64) -> !llvm.ptr
     llvm.store %191, %192 {alignment = 1 : i64} : i64, !llvm.ptr
     %193 = call @dora_fn_create(%arg0, %174, %172, %189, %192) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %194 = llvm.getelementptr %193[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %194 = llvm.getelementptr %193[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %195 = llvm.load %194 : !llvm.ptr -> i8
-    %196 = llvm.getelementptr %193[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %197 = llvm.load %196 : !llvm.ptr -> i8
     %c0_i8_58 = arith.constant 0 : i8
-    %198 = arith.cmpi ne, %197, %c0_i8_58 : i8
-    cf.cond_br %198, ^bb1(%197 : i8), ^bb29
+    %196 = arith.cmpi ne, %195, %c0_i8_58 : i8
+    cf.cond_br %196, ^bb1(%195 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i8_59 = arith.constant 0 : i8
-    %199 = arith.cmpi ne, %c0_i8_59, %195 : i8
-    %c94_i8 = arith.constant 94 : i8
-    cf.cond_br %199, ^bb1(%c94_i8 : i8), ^bb30
+    %197 = llvm.load %189 : !llvm.ptr -> i256
+    %198 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %199 = llvm.load %198 : !llvm.ptr -> !llvm.ptr
+    llvm.store %197, %199 : i256, !llvm.ptr
+    %200 = llvm.getelementptr %199[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %200, %198 : !llvm.ptr, !llvm.ptr
+    %201 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_59 = arith.constant 1 : i64
+    %202 = arith.addi %201, %c1_i64_59 : i64
+    llvm.store %202, %9 : i64, !llvm.ptr
+    %203 = arith.cmpi ult, %c1024_i64, %202 : i64
+    %c92_i8_60 = arith.constant 92 : i8
+    cf.cond_br %203, ^bb1(%c92_i8_60 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %200 = llvm.load %189 : !llvm.ptr -> i256
-    %201 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %202 = llvm.load %201 : !llvm.ptr -> !llvm.ptr
-    llvm.store %200, %202 : i256, !llvm.ptr
-    %203 = llvm.getelementptr %202[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %203, %201 : !llvm.ptr, !llvm.ptr
-    %204 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_60 = arith.constant 1 : i64
-    %205 = arith.addi %204, %c1_i64_60 : i64
-    llvm.store %205, %9 : i64, !llvm.ptr
-    %206 = arith.cmpi ult, %c1024_i64, %205 : i64
-    %c92_i8_61 = arith.constant 92 : i8
-    cf.cond_br %206, ^bb1(%c92_i8_61 : i8), ^bb31
+    %c0_i256_61 = arith.constant 0 : i256
+    %204 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %205 = llvm.load %204 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_61, %205 : i256, !llvm.ptr
+    %206 = llvm.getelementptr %205[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %206, %204 : !llvm.ptr, !llvm.ptr
+    %207 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_62 = arith.constant 1 : i64
+    %208 = arith.addi %207, %c1_i64_62 : i64
+    llvm.store %208, %9 : i64, !llvm.ptr
+    %209 = arith.cmpi ult, %c1024_i64, %208 : i64
+    %c92_i8_63 = arith.constant 92 : i8
+    cf.cond_br %209, ^bb1(%c92_i8_63 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i256_62 = arith.constant 0 : i256
-    %207 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %208 = llvm.load %207 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_62, %208 : i256, !llvm.ptr
-    %209 = llvm.getelementptr %208[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %209, %207 : !llvm.ptr, !llvm.ptr
-    %210 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_63 = arith.constant 1 : i64
-    %211 = arith.addi %210, %c1_i64_63 : i64
-    llvm.store %211, %9 : i64, !llvm.ptr
-    %212 = arith.cmpi ult, %c1024_i64, %211 : i64
-    %c92_i8_64 = arith.constant 92 : i8
-    cf.cond_br %212, ^bb1(%c92_i8_64 : i8), ^bb32
+    %c0_i256_64 = arith.constant 0 : i256
+    %210 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %211 = llvm.load %210 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_64, %211 : i256, !llvm.ptr
+    %212 = llvm.getelementptr %211[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %212, %210 : !llvm.ptr, !llvm.ptr
+    %213 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_65 = arith.constant 1 : i64
+    %214 = arith.addi %213, %c1_i64_65 : i64
+    llvm.store %214, %9 : i64, !llvm.ptr
+    %215 = arith.cmpi ult, %c1024_i64, %214 : i64
+    %c92_i8_66 = arith.constant 92 : i8
+    cf.cond_br %215, ^bb1(%c92_i8_66 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i256_65 = arith.constant 0 : i256
-    %213 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %214 = llvm.load %213 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_65, %214 : i256, !llvm.ptr
-    %215 = llvm.getelementptr %214[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %215, %213 : !llvm.ptr, !llvm.ptr
-    %216 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_66 = arith.constant 1 : i64
-    %217 = arith.addi %216, %c1_i64_66 : i64
-    llvm.store %217, %9 : i64, !llvm.ptr
-    %218 = arith.cmpi ult, %c1024_i64, %217 : i64
-    %c92_i8_67 = arith.constant 92 : i8
-    cf.cond_br %218, ^bb1(%c92_i8_67 : i8), ^bb33
+    %c0_i256_67 = arith.constant 0 : i256
+    %216 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %217 = llvm.load %216 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_67, %217 : i256, !llvm.ptr
+    %218 = llvm.getelementptr %217[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %218, %216 : !llvm.ptr, !llvm.ptr
+    %219 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_68 = arith.constant 1 : i64
+    %220 = arith.addi %219, %c1_i64_68 : i64
+    llvm.store %220, %9 : i64, !llvm.ptr
+    %221 = arith.cmpi ult, %c1024_i64, %220 : i64
+    %c92_i8_69 = arith.constant 92 : i8
+    cf.cond_br %221, ^bb1(%c92_i8_69 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %c0_i256_68 = arith.constant 0 : i256
-    %219 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %220 = llvm.load %219 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_68, %220 : i256, !llvm.ptr
-    %221 = llvm.getelementptr %220[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %221, %219 : !llvm.ptr, !llvm.ptr
-    %222 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_69 = arith.constant 1 : i64
-    %223 = arith.addi %222, %c1_i64_69 : i64
-    llvm.store %223, %9 : i64, !llvm.ptr
-    %224 = arith.cmpi ult, %c1024_i64, %223 : i64
-    %c92_i8_70 = arith.constant 92 : i8
-    cf.cond_br %224, ^bb1(%c92_i8_70 : i8), ^bb34
+    %c0_i256_70 = arith.constant 0 : i256
+    %222 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %223 = llvm.load %222 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_70, %223 : i256, !llvm.ptr
+    %224 = llvm.getelementptr %223[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %224, %222 : !llvm.ptr, !llvm.ptr
+    %225 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_71 = arith.constant 1 : i64
+    %226 = arith.addi %225, %c1_i64_71 : i64
+    llvm.store %226, %9 : i64, !llvm.ptr
+    %227 = arith.cmpi ult, %c1024_i64, %226 : i64
+    %c92_i8_72 = arith.constant 92 : i8
+    cf.cond_br %227, ^bb1(%c92_i8_72 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %c0_i256_71 = arith.constant 0 : i256
-    %225 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %226 = llvm.load %225 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c0_i256_71, %226 : i256, !llvm.ptr
-    %227 = llvm.getelementptr %226[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %227, %225 : !llvm.ptr, !llvm.ptr
-    %228 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %229 = arith.addi %228, %c1_i64_72 : i64
-    llvm.store %229, %9 : i64, !llvm.ptr
-    %230 = arith.cmpi ult, %c1024_i64, %229 : i64
-    %c92_i8_73 = arith.constant 92 : i8
-    cf.cond_br %230, ^bb1(%c92_i8_73 : i8), ^bb35
+    %228 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %229 = llvm.load %228 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    %232 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %233 = llvm.load %232 : !llvm.ptr -> !llvm.ptr
+    llvm.store %231, %233 : i256, !llvm.ptr
+    %234 = llvm.getelementptr %233[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %234, %232 : !llvm.ptr, !llvm.ptr
+    %235 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_73 = arith.constant 1 : i64
+    %236 = arith.addi %235, %c1_i64_73 : i64
+    llvm.store %236, %9 : i64, !llvm.ptr
+    %237 = arith.cmpi ult, %c1024_i64, %236 : i64
+    %c92_i8_74 = arith.constant 92 : i8
+    cf.cond_br %237, ^bb1(%c92_i8_74 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %231 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %232 = llvm.load %231 : !llvm.ptr -> !llvm.ptr
-    %233 = llvm.getelementptr %232[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %234 = llvm.load %233 : !llvm.ptr -> i256
-    %235 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %236 = llvm.load %235 : !llvm.ptr -> !llvm.ptr
-    llvm.store %234, %236 : i256, !llvm.ptr
-    %237 = llvm.getelementptr %236[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %237, %235 : !llvm.ptr, !llvm.ptr
-    %238 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_74 = arith.constant 1 : i64
-    %239 = arith.addi %238, %c1_i64_74 : i64
-    llvm.store %239, %9 : i64, !llvm.ptr
-    %240 = arith.cmpi ult, %c1024_i64, %239 : i64
-    %c92_i8_75 = arith.constant 92 : i8
-    cf.cond_br %240, ^bb1(%c92_i8_75 : i8), ^bb36
-  ^bb36:  // pred: ^bb35
     %c4294967295_i256 = arith.constant 4294967295 : i256
-    %241 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %242 = llvm.load %241 : !llvm.ptr -> !llvm.ptr
-    llvm.store %c4294967295_i256, %242 : i256, !llvm.ptr
-    %243 = llvm.getelementptr %242[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %243, %241 : !llvm.ptr, !llvm.ptr
-    %244 = llvm.load %9 : !llvm.ptr -> i64
+    %238 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %239 = llvm.load %238 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4294967295_i256, %239 : i256, !llvm.ptr
+    %240 = llvm.getelementptr %239[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %240, %238 : !llvm.ptr, !llvm.ptr
+    %241 = llvm.load %9 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %245 = arith.addi %244, %c-5_i64 : i64
-    llvm.store %245, %9 : i64, !llvm.ptr
+    %242 = arith.addi %241, %c-5_i64 : i64
+    llvm.store %242, %9 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %246 = arith.cmpi ult, %244, %c6_i64 : i64
-    %c91_i8_76 = arith.constant 91 : i8
-    cf.cond_br %246, ^bb1(%c91_i8_76 : i8), ^bb37
+    %243 = arith.cmpi ult, %241, %c6_i64 : i64
+    %c91_i8_75 = arith.constant 91 : i8
+    cf.cond_br %243, ^bb1(%c91_i8_75 : i8), ^bb36
+  ^bb36:  // pred: ^bb35
+    %244 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %245 = llvm.load %244 : !llvm.ptr -> !llvm.ptr
+    %246 = llvm.getelementptr %245[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %247 = llvm.load %246 : !llvm.ptr -> i256
+    llvm.store %246, %244 : !llvm.ptr, !llvm.ptr
+    %248 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %249 = llvm.load %248 : !llvm.ptr -> !llvm.ptr
+    %250 = llvm.getelementptr %249[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %251 = llvm.load %250 : !llvm.ptr -> i256
+    llvm.store %250, %248 : !llvm.ptr, !llvm.ptr
+    %252 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %253 = llvm.load %252 : !llvm.ptr -> !llvm.ptr
+    %254 = llvm.getelementptr %253[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %255 = llvm.load %254 : !llvm.ptr -> i256
+    llvm.store %254, %252 : !llvm.ptr, !llvm.ptr
+    %256 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %257 = llvm.load %256 : !llvm.ptr -> !llvm.ptr
+    %258 = llvm.getelementptr %257[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %259 = llvm.load %258 : !llvm.ptr -> i256
+    llvm.store %258, %256 : !llvm.ptr, !llvm.ptr
+    %260 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %261 = llvm.load %260 : !llvm.ptr -> !llvm.ptr
+    %262 = llvm.getelementptr %261[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %263 = llvm.load %262 : !llvm.ptr -> i256
+    llvm.store %262, %260 : !llvm.ptr, !llvm.ptr
+    %264 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %265 = llvm.load %264 : !llvm.ptr -> !llvm.ptr
+    %266 = llvm.getelementptr %265[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %267 = llvm.load %266 : !llvm.ptr -> i256
+    llvm.store %266, %264 : !llvm.ptr, !llvm.ptr
+    %c0_i256_76 = arith.constant 0 : i256
+    %268 = arith.trunci %247 : i256 to i64
+    %269 = arith.trunci %255 : i256 to i64
+    %c0_i64_77 = arith.constant 0 : i64
+    %270 = arith.cmpi slt, %269, %c0_i64_77 : i64
+    %c84_i8_78 = arith.constant 84 : i8
+    cf.cond_br %270, ^bb1(%c84_i8_78 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %247 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %248 = llvm.load %247 : !llvm.ptr -> !llvm.ptr
-    %249 = llvm.getelementptr %248[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %250 = llvm.load %249 : !llvm.ptr -> i256
-    llvm.store %249, %247 : !llvm.ptr, !llvm.ptr
-    %251 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %252 = llvm.load %251 : !llvm.ptr -> !llvm.ptr
-    %253 = llvm.getelementptr %252[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %254 = llvm.load %253 : !llvm.ptr -> i256
-    llvm.store %253, %251 : !llvm.ptr, !llvm.ptr
-    %255 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %256 = llvm.load %255 : !llvm.ptr -> !llvm.ptr
-    %257 = llvm.getelementptr %256[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %258 = llvm.load %257 : !llvm.ptr -> i256
-    llvm.store %257, %255 : !llvm.ptr, !llvm.ptr
-    %259 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %260 = llvm.load %259 : !llvm.ptr -> !llvm.ptr
-    %261 = llvm.getelementptr %260[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %262 = llvm.load %261 : !llvm.ptr -> i256
-    llvm.store %261, %259 : !llvm.ptr, !llvm.ptr
-    %263 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %264 = llvm.load %263 : !llvm.ptr -> !llvm.ptr
-    %265 = llvm.getelementptr %264[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %266 = llvm.load %265 : !llvm.ptr -> i256
-    llvm.store %265, %263 : !llvm.ptr, !llvm.ptr
-    %267 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %268 = llvm.load %267 : !llvm.ptr -> !llvm.ptr
-    %269 = llvm.getelementptr %268[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %270 = llvm.load %269 : !llvm.ptr -> i256
-    llvm.store %269, %267 : !llvm.ptr, !llvm.ptr
-    %c0_i256_77 = arith.constant 0 : i256
-    %271 = arith.trunci %250 : i256 to i64
-    %272 = arith.trunci %258 : i256 to i64
-    %c0_i64_78 = arith.constant 0 : i64
-    %273 = arith.cmpi slt, %272, %c0_i64_78 : i64
-    %c84_i8_79 = arith.constant 84 : i8
-    cf.cond_br %273, ^bb1(%c84_i8_79 : i8), ^bb38
+    %271 = arith.trunci %259 : i256 to i64
+    %c0_i64_79 = arith.constant 0 : i64
+    %272 = arith.cmpi slt, %271, %c0_i64_79 : i64
+    %c84_i8_80 = arith.constant 84 : i8
+    cf.cond_br %272, ^bb1(%c84_i8_80 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %274 = arith.trunci %262 : i256 to i64
-    %c0_i64_80 = arith.constant 0 : i64
-    %275 = arith.cmpi slt, %274, %c0_i64_80 : i64
-    %c84_i8_81 = arith.constant 84 : i8
-    cf.cond_br %275, ^bb1(%c84_i8_81 : i8), ^bb39
+    %273 = arith.trunci %263 : i256 to i64
+    %c0_i64_81 = arith.constant 0 : i64
+    %274 = arith.cmpi slt, %273, %c0_i64_81 : i64
+    %c84_i8_82 = arith.constant 84 : i8
+    cf.cond_br %274, ^bb1(%c84_i8_82 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %276 = arith.trunci %266 : i256 to i64
-    %c0_i64_82 = arith.constant 0 : i64
-    %277 = arith.cmpi slt, %276, %c0_i64_82 : i64
-    %c84_i8_83 = arith.constant 84 : i8
-    cf.cond_br %277, ^bb1(%c84_i8_83 : i8), ^bb40
+    %275 = arith.trunci %267 : i256 to i64
+    %c0_i64_83 = arith.constant 0 : i64
+    %276 = arith.cmpi slt, %275, %c0_i64_83 : i64
+    %c84_i8_84 = arith.constant 84 : i8
+    cf.cond_br %276, ^bb1(%c84_i8_84 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %278 = arith.trunci %270 : i256 to i64
-    %c0_i64_84 = arith.constant 0 : i64
-    %279 = arith.cmpi slt, %278, %c0_i64_84 : i64
-    %c84_i8_85 = arith.constant 84 : i8
-    cf.cond_br %279, ^bb1(%c84_i8_85 : i8), ^bb41
+    %277 = arith.addi %269, %271 : i64
+    %278 = arith.addi %273, %275 : i64
+    %279 = arith.maxui %277, %278 : i64
+    %c0_i64_85 = arith.constant 0 : i64
+    %280 = arith.cmpi slt, %279, %c0_i64_85 : i64
+    %c84_i8_86 = arith.constant 84 : i8
+    cf.cond_br %280, ^bb1(%c84_i8_86 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %280 = arith.addi %272, %274 : i64
-    %281 = arith.addi %276, %278 : i64
-    %282 = arith.maxui %280, %281 : i64
-    %c0_i64_86 = arith.constant 0 : i64
-    %283 = arith.cmpi slt, %282, %c0_i64_86 : i64
-    %c84_i8_87 = arith.constant 84 : i8
-    cf.cond_br %283, ^bb1(%c84_i8_87 : i8), ^bb42
+    %c31_i64_87 = arith.constant 31 : i64
+    %c32_i64_88 = arith.constant 32 : i64
+    %281 = arith.addi %279, %c31_i64_87 : i64
+    %282 = arith.divui %281, %c32_i64_88 : i64
+    %283 = arith.muli %282, %c32_i64_88 : i64
+    %284 = call @dora_fn_extend_memory(%arg0, %283) : (!llvm.ptr, i64) -> !llvm.ptr
+    %285 = llvm.getelementptr %284[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %286 = llvm.load %285 : !llvm.ptr -> !llvm.ptr
+    %287 = llvm.getelementptr %284[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %288 = llvm.load %287 : !llvm.ptr -> i8
+    %c0_i8_89 = arith.constant 0 : i8
+    %289 = arith.cmpi ne, %288, %c0_i8_89 : i8
+    cf.cond_br %289, ^bb1(%288 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %c31_i64_88 = arith.constant 31 : i64
-    %c32_i64_89 = arith.constant 32 : i64
-    %284 = arith.addi %282, %c31_i64_88 : i64
-    %285 = arith.divui %284, %c32_i64_89 : i64
-    %286 = arith.muli %285, %c32_i64_89 : i64
-    %287 = call @dora_fn_extend_memory(%arg0, %286) : (!llvm.ptr, i64) -> !llvm.ptr
-    %288 = llvm.getelementptr %287[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %289 = llvm.load %288 : !llvm.ptr -> !llvm.ptr
-    %290 = llvm.getelementptr %287[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %291 = llvm.load %290 : !llvm.ptr -> i8
-    %c0_i8_90 = arith.constant 0 : i8
-    %292 = arith.cmpi ne, %291, %c0_i8_90 : i8
-    cf.cond_br %292, ^bb1(%291 : i8), ^bb43
-  ^bb43:  // pred: ^bb42
-    %293 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
-    llvm.store %289, %293 : !llvm.ptr, !llvm.ptr
-    %294 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
-    llvm.store %286, %294 : i64, !llvm.ptr
-    %295 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
-    %296 = llvm.load %295 : !llvm.ptr -> i64
+    %290 = llvm.mlir.addressof @dora_global_memory_ptr : !llvm.ptr
+    llvm.store %286, %290 : !llvm.ptr, !llvm.ptr
+    %291 = llvm.mlir.addressof @dora_global_memory_size : !llvm.ptr
+    llvm.store %283, %291 : i64, !llvm.ptr
+    %292 = llvm.mlir.addressof @dora_global_gas_counter : !llvm.ptr
+    %293 = llvm.load %292 : !llvm.ptr -> i64
+    %c1_i256_90 = arith.constant 1 : i256
+    %294 = llvm.alloca %c1_i256_90 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_76, %294 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i256_91 = arith.constant 1 : i256
-    %297 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_77, %297 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_92 = arith.constant 1 : i256
-    %298 = llvm.alloca %c1_i256_92 x i256 : (i256) -> !llvm.ptr
-    llvm.store %254, %298 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i64_93 = arith.constant 1 : i64
-    %299 = llvm.alloca %c1_i64_93 x i64 : (i64) -> !llvm.ptr
+    %295 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
+    llvm.store %251, %295 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i64_92 = arith.constant 1 : i64
+    %296 = llvm.alloca %c1_i64_92 x i64 : (i64) -> !llvm.ptr
+    %c0_i8_93 = arith.constant 0 : i8
+    %297 = call @dora_fn_call(%arg0, %268, %295, %294, %269, %271, %273, %275, %293, %296, %c0_i8_93) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
+    %298 = llvm.getelementptr %297[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %299 = llvm.load %298 : !llvm.ptr -> i8
+    %300 = llvm.getelementptr %297[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %301 = llvm.load %300 : !llvm.ptr -> i8
     %c0_i8_94 = arith.constant 0 : i8
-    %300 = call @dora_fn_call(%arg0, %271, %298, %297, %272, %274, %276, %278, %296, %299, %c0_i8_94) : (!llvm.ptr, i64, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, !llvm.ptr, i8) -> !llvm.ptr
-    %301 = llvm.getelementptr %300[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %302 = llvm.load %301 : !llvm.ptr -> i8
-    %303 = llvm.getelementptr %300[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %304 = llvm.load %303 : !llvm.ptr -> i8
-    %c0_i8_95 = arith.constant 0 : i8
-    %305 = arith.cmpi ne, %304, %c0_i8_95 : i8
-    cf.cond_br %305, ^bb1(%304 : i8), ^bb44
+    %302 = arith.cmpi ne, %301, %c0_i8_94 : i8
+    cf.cond_br %302, ^bb1(%301 : i8), ^bb43
+  ^bb43:  // pred: ^bb42
+    %303 = llvm.load %296 : !llvm.ptr -> i64
+    %304 = arith.extui %299 : i8 to i256
+    %305 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %306 = llvm.load %305 : !llvm.ptr -> !llvm.ptr
+    llvm.store %304, %306 : i256, !llvm.ptr
+    %307 = llvm.getelementptr %306[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %307, %305 : !llvm.ptr, !llvm.ptr
+    %308 = llvm.load %9 : !llvm.ptr -> i64
+    %c1_i64_95 = arith.constant 1 : i64
+    %309 = arith.addi %308, %c1_i64_95 : i64
+    llvm.store %309, %9 : i64, !llvm.ptr
+    %310 = arith.cmpi ult, %c1024_i64, %309 : i64
+    %c92_i8_96 = arith.constant 92 : i8
+    cf.cond_br %310, ^bb1(%c92_i8_96 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %306 = llvm.load %299 : !llvm.ptr -> i64
-    %307 = arith.extui %302 : i8 to i256
-    %308 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %309 = llvm.load %308 : !llvm.ptr -> !llvm.ptr
-    llvm.store %307, %309 : i256, !llvm.ptr
-    %310 = llvm.getelementptr %309[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %310, %308 : !llvm.ptr, !llvm.ptr
-    %311 = llvm.load %9 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %312 = arith.addi %311, %c1_i64_96 : i64
-    llvm.store %312, %9 : i64, !llvm.ptr
-    %313 = arith.cmpi ult, %c1024_i64, %312 : i64
-    %c92_i8_97 = arith.constant 92 : i8
-    cf.cond_br %313, ^bb1(%c92_i8_97 : i8), ^bb45
+    %311 = call @dora_fn_return_data_size(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %312 = llvm.getelementptr %311[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %313 = llvm.load %312 : !llvm.ptr -> i64
+    %314 = arith.extui %313 : i64 to i256
+    %315 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
+    %316 = llvm.load %315 : !llvm.ptr -> !llvm.ptr
+    llvm.store %314, %316 : i256, !llvm.ptr
+    %317 = llvm.getelementptr %316[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %317, %315 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb45
   ^bb45:  // pred: ^bb44
-    %314 = call @dora_fn_return_data_size(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %315 = llvm.getelementptr %314[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %316 = llvm.load %315 : !llvm.ptr -> i64
-    %317 = arith.extui %316 : i64 to i256
-    %318 = llvm.mlir.addressof @dora_global_stack_ptr : !llvm.ptr
-    %319 = llvm.load %318 : !llvm.ptr -> !llvm.ptr
-    llvm.store %317, %319 : i256, !llvm.ptr
-    %320 = llvm.getelementptr %319[1] : (!llvm.ptr) -> !llvm.ptr, i256
-    llvm.store %320, %318 : !llvm.ptr, !llvm.ptr
-    cf.br ^bb46
-  ^bb46:  // pred: ^bb45
-    %c0_i64_98 = arith.constant 0 : i64
+    %c0_i64_97 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %321 = call @dora_fn_write_result(%arg0, %c0_i64_98, %c0_i64_98, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
+    %318 = call @dora_fn_write_result(%arg0, %c0_i64_97, %c0_i64_97, %arg1, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> !llvm.ptr
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-runtime/src/context.rs
+++ b/crates/dora-runtime/src/context.rs
@@ -12,7 +12,6 @@ use crate::result::{
 };
 use crate::transaction::Transaction;
 use crate::{symbols, ExitStatusCode};
-use anyhow::bail;
 use bytes::Bytes;
 use dora_primitives::spec::SpecId;
 use dora_primitives::{Bytes32, EVMAddress as Address, B256, H160, U256};
@@ -1230,13 +1229,11 @@ impl<DB: Database> RuntimeContext<DB> {
         remaining_gas: &mut u64,
         value: U256,
         salt: Option<&Bytes32>,
-    ) -> anyhow::Result<Address> {
+    ) -> core::result::Result<Address, ExitStatusCode> {
         // Check the call depth
         if self.inner_context.depth > CALL_STACK_LIMIT {
-            bail!(
-                "call depth {} is too deep and exceed the limit {CALL_STACK_LIMIT}",
-                self.inner_context.depth
-            );
+            self.inner_context.exit_status = Some(ExitStatusCode::CallTooDeep);
+            return Err(ExitStatusCode::CallTooDeep);
         }
 
         let host = self.host.read().unwrap();
@@ -1244,10 +1241,8 @@ impl<DB: Database> RuntimeContext<DB> {
 
         // Check the create init code size limit
         if size > 2 * MAX_CODE_SIZE {
-            bail!(
-                "create init code size {size} exceed the limit {}",
-                2 * MAX_CODE_SIZE
-            )
+            self.inner_context.exit_status = Some(ExitStatusCode::CreateInitCodeSizeLimit);
+            return Err(ExitStatusCode::CreateInitCodeSizeLimit);
         }
 
         let minimum_word_size = ((size + 31) / 32) as u64;
@@ -1268,7 +1263,8 @@ impl<DB: Database> RuntimeContext<DB> {
         };
         // Check if there is already a contract stored in dest_address
         if let Ok(Some(_)) = db.basic(dest_addr) {
-            bail!("account {} already exists", dest_addr);
+            self.inner_context.exit_status = Some(ExitStatusCode::CreateCollision);
+            return Err(ExitStatusCode::CreateCollision);
         }
         drop(host);
         // Create sub context for the initialization code
@@ -1341,7 +1337,7 @@ impl<DB: Database> RuntimeContext<DB> {
                 value.copy_from(&addr);
                 Box::into_raw(Box::new(Result::success(0)))
             }
-            Err(_) => Box::into_raw(Box::new(Result::success(1))),
+            Err(err_code) => Box::into_raw(Box::new(Result::error(err_code.to_u8(), 1))),
         }
     }
 

--- a/crates/dora-tools/bins/ethertest/main.rs
+++ b/crates/dora-tools/bins/ethertest/main.rs
@@ -532,13 +532,13 @@ fn execute_test(path: &Path) -> Result<(), TestError> {
                     //     });
                     // }
                 }
-                Err(_) => {
+                Err(error) => {
                     if test_case.expect_exception.is_none() {
                         return Err(TestError {
                             name: name.to_string(),
                             kind: TestErrorKind::UnexpectedException {
                                 expected_exception: test_case.expect_exception.clone(),
-                                got_exception: None,
+                                got_exception: Some(error.to_string()),
                             },
                         });
                     }

--- a/crates/dora/src/lib.rs
+++ b/crates/dora/src/lib.rs
@@ -68,7 +68,8 @@ pub fn run_with_context<DB: Database>(
         let value = env.tx.value;
         let data = env.tx.data.clone();
         drop(host);
-        runtime_context.create_contract(&data, &mut remaining_gas, value, None)?;
+        // Here we get the conrtact create error from the runtime context.
+        let _ = runtime_context.create_contract(&data, &mut remaining_gas, value, None);
     } else {
         // Fetch the bytecode artifact if exists
         let db = runtime_context.db.read().unwrap();

--- a/crates/dora/src/tests/operations.rs
+++ b/crates/dora/src/tests/operations.rs
@@ -2851,6 +2851,24 @@ fn create2_with_large_salt() {
 }
 
 #[test]
+fn create_too_init_code_size_limit_halt() {
+    let operations = vec![
+        Operation::Push((4_u8, BigUint::from(0x16000_u32))),
+        Operation::Push((1_u8, BigUint::from(0_u8))),
+        Operation::Push((1_u8, BigUint::from(0_u8))),
+        Operation::Create,
+        // Return result
+        Operation::Push0,
+        Operation::Mstore,
+        Operation::Push((1, 32_u8.into())),
+        Operation::Push0,
+        Operation::Return,
+    ];
+    let (env, mut db) = default_env_and_db_setup(operations);
+    run_program_assert_halt(env, db);
+}
+
+#[test]
 fn log0() {
     let operations = vec![
         Operation::Push((1_u8, BigUint::from(0x40_u8))),


### PR DESCRIPTION
+ refactor: record contract create error to the runtime context error.
+ chore: bump runtime create_contract function error to the unified runtime error code.