### PR TITLE
chore: disable eof format before the osaka spec

### DIFF
--- a/crates/dora-compiler/Cargo.toml
+++ b/crates/dora-compiler/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.10.8"
 anyhow = "1.0.86"
 smallvec = "1.6"
 hex = "0.4.3"
+hex-literal = "0.4.1"
 tracing = "0.1.40"
 scopeguard = "1.2.0"
 revmc = { version = "0.1.0", default-features = false }

--- a/crates/dora-tools/bins/ethertest/main.rs
+++ b/crates/dora-tools/bins/ethertest/main.rs
@@ -379,8 +379,7 @@ fn should_skip(path: &Path) -> bool {
         "ValueOverflowParis.json"
     ) ||// Temporarily skip EOF test suites: https://github.com/dp-labs/dora/issues/5
         path_str.contains("stEOF")
-        // Temporarily skip out of gas error test suites: https://github.com/dp-labs/dora/issues/91
-        || path_str.contains("stRevertTest/costRevert.json")
+        // Temporarily skip stack overflow error test suites
         || path_str.contains("Pyspecs/cancun/eip1153_tstore/run_until_out_of_gas.json")
 }
 

--- a/crates/dora/src/lib.rs
+++ b/crates/dora/src/lib.rs
@@ -88,7 +88,10 @@ pub fn run_with_context<DB: Database>(
     initial_gas: u64,
 ) -> anyhow::Result<DB::Artifact> {
     // Compile the contract code
-    let program = Program::from_opcode(&runtime_context.contract.code);
+    let program = Program::from_opcodes(
+        &runtime_context.contract.code,
+        runtime_context.inner.spec_id,
+    );
     let context = Context::new();
     let compiler = EVMCompiler::new(&context);
     let mut module = compiler.compile(

--- a/tests/bench/benches/bench.rs
+++ b/tests/bench/benches/bench.rs
@@ -33,7 +33,7 @@ fn run_bench(c: &mut Criterion, bench: &Bench) {
     let spec_id = SpecId::CANCUN;
     let context = Context::new();
     let compiler = EVMCompiler::new(&context);
-    let program = Program::from_opcode(bytecode);
+    let program = Program::from_opcodes(bytecode, spec_id);
     let mut module = compiler
         .compile(
             &program,


### PR DESCRIPTION
chore: disable eof format before the osaka spec

re #77