### PR TITLE
perf: use the stack top ptr to optimize stack access

### DIFF
--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = call @dora_fn_address(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %4 = llvm.load %3 : !llvm.ptr -> i160
-    %5 = llvm.intr.bswap(%4)  : (i160) -> i160
-    %6 = arith.extui %5 : i160 to i256
-    %7 = llvm.load %arg3 : !llvm.ptr -> i64
-    %8 = llvm.getelementptr %arg2[%7] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %9 = arith.addi %7, %c1_i64 : i64
-    llvm.store %9, %arg3 : i64, !llvm.ptr
-    llvm.store %6, %8 : i256, !llvm.ptr
+    %4 = call @dora_fn_address(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %5 = llvm.load %4 : !llvm.ptr -> i160
+    %6 = llvm.intr.bswap(%5)  : (i160) -> i160
+    %7 = arith.extui %6 : i160 to i256
+    %8 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %7, %8 : i256, !llvm.ptr
+    %9 = llvm.getelementptr %8[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %9, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %10 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %11 = arith.addi %10, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %11 = arith.addi %10, %c1_i64 : i64
+    llvm.store %11, %arg3 : i64, !llvm.ptr
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address_balance.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__address_balance.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = call @dora_fn_address(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %4 = llvm.load %3 : !llvm.ptr -> i160
-    %5 = llvm.intr.bswap(%4)  : (i160) -> i160
-    %6 = arith.extui %5 : i160 to i256
-    %7 = llvm.load %arg3 : !llvm.ptr -> i64
-    %8 = llvm.getelementptr %arg2[%7] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %9 = arith.addi %7, %c1_i64 : i64
-    llvm.store %9, %arg3 : i64, !llvm.ptr
-    llvm.store %6, %8 : i256, !llvm.ptr
+    %4 = call @dora_fn_address(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %5 = llvm.load %4 : !llvm.ptr -> i160
+    %6 = llvm.intr.bswap(%5)  : (i160) -> i160
+    %7 = arith.extui %6 : i160 to i256
+    %8 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %7, %8 : i256, !llvm.ptr
+    %9 = llvm.getelementptr %8[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %9, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %10 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %11 = arith.addi %10, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %11 = arith.addi %10, %c1_i64 : i64
+    llvm.store %11, %arg3 : i64, !llvm.ptr
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3
@@ -96,61 +98,58 @@ module {
     llvm.store %15, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %17 = arith.subi %16, %c1_i64_1 : i64
-    %18 = llvm.getelementptr %arg2[%17] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %17, %arg3 : i64, !llvm.ptr
-    %19 = llvm.load %18 : !llvm.ptr -> i256
+    %16 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %17 = llvm.getelementptr %16[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %18 = llvm.load %17 : !llvm.ptr -> i256
+    llvm.store %17, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %20 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %19, %20 {alignment = 1 : i64} : i256, !llvm.ptr
-    %21 = call @dora_fn_store_in_balance(%arg0, %20) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %22 = llvm.getelementptr %21[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %23 = llvm.load %22 : !llvm.ptr -> i64
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    %25 = arith.cmpi ult, %24, %23 : i64
-    scf.if %25 {
+    %19 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %18, %19 {alignment = 1 : i64} : i256, !llvm.ptr
+    %20 = call @dora_fn_store_in_balance(%arg0, %19) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %21 = llvm.getelementptr %20[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %22 = llvm.load %21 : !llvm.ptr -> i64
+    %23 = llvm.load %arg1 : !llvm.ptr -> i64
+    %24 = arith.cmpi ult, %23, %22 : i64
+    scf.if %24 {
     } else {
-      %37 = arith.subi %24, %23 : i64
-      llvm.store %37, %arg1 : i64, !llvm.ptr
+      %35 = arith.subi %23, %22 : i64
+      llvm.store %35, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %25, ^bb1(%c80_i8_2 : i8), ^bb8
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %24, ^bb1(%c80_i8_1 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %26 = llvm.load %20 : !llvm.ptr -> i256
-    %27 = llvm.load %arg3 : !llvm.ptr -> i64
-    %28 = llvm.getelementptr %arg2[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %29 = arith.addi %27, %c1_i64_3 : i64
-    llvm.store %29, %arg3 : i64, !llvm.ptr
-    llvm.store %26, %28 : i256, !llvm.ptr
+    %25 = llvm.load %19 : !llvm.ptr -> i256
+    %26 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %25, %26 : i256, !llvm.ptr
+    %27 = llvm.getelementptr %26[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %27, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %31 = arith.addi %30, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %32 = arith.cmpi ult, %30, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %28 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %29 = arith.addi %28, %c0_i64_3 : i64
+    llvm.store %29, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %30 = arith.cmpi ult, %28, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %30, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_7 = arith.constant 0 : i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c0_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb11, ^bb1(%c80_i8_8 : i8)
+    %32 = arith.cmpi uge, %31, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %32, ^bb11, ^bb1(%c80_i8_6 : i8)
   ^bb11:  // pred: ^bb10
-    %35 = arith.subi %33, %c0_i64_7 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %33 = arith.subi %31, %c0_i64_5 : i64
+    llvm.store %33, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %34, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__basefee.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__basefee.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_store_in_basefee_ptr(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_store_in_basefee_ptr(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobbasefee.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobbasefee.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_store_in_blobbasefee_ptr(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_store_in_blobbasefee_ptr(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobhash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blobhash.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c21000_i256 = arith.constant 21000 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c21000_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,49 +95,46 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_blob_hash(%arg0, %16) : (!llvm.ptr, !llvm.ptr) -> ()
-    %17 = llvm.load %16 : !llvm.ptr -> i256
-    %18 = llvm.load %arg3 : !llvm.ptr -> i64
-    %19 = llvm.getelementptr %arg2[%18] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %20 = arith.addi %18, %c1_i64_2 : i64
-    llvm.store %20, %arg3 : i64, !llvm.ptr
-    llvm.store %17, %19 : i256, !llvm.ptr
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_blob_hash(%arg0, %15) : (!llvm.ptr, !llvm.ptr) -> ()
+    %16 = llvm.load %15 : !llvm.ptr -> i256
+    %17 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %16, %17 : i256, !llvm.ptr
+    %18 = llvm.getelementptr %17[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %18, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_4 = arith.constant 0 : i64
-    %22 = arith.addi %21, %c0_i64_4 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %23 = arith.cmpi ult, %21, %c1_i64_5 : i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %19 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %20 = arith.addi %19, %c0_i64_2 : i64
+    llvm.store %20, %arg3 : i64, !llvm.ptr
+    %c1_i64_3 = arith.constant 1 : i64
+    %21 = arith.cmpi ult, %19, %c1_i64_3 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %23, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %21, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %22 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %25 = arith.cmpi uge, %24, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %25, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %23 = arith.cmpi uge, %22, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %23, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %26 = arith.subi %24, %c3_i64_6 : i64
-    llvm.store %26, %arg1 : i64, !llvm.ptr
+    %24 = arith.subi %22, %c3_i64_4 : i64
+    llvm.store %24, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %27, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %25, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blockhash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__blockhash.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c599423545_i256 = arith.constant 599423545 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c599423545_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,49 +95,46 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    %17 = call @dora_fn_block_hash(%arg0, %16) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %18 = llvm.load %16 : !llvm.ptr -> i256
-    %19 = llvm.load %arg3 : !llvm.ptr -> i64
-    %20 = llvm.getelementptr %arg2[%19] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %21 = arith.addi %19, %c1_i64_2 : i64
-    llvm.store %21, %arg3 : i64, !llvm.ptr
-    llvm.store %18, %20 : i256, !llvm.ptr
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    %16 = call @dora_fn_block_hash(%arg0, %15) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %17 = llvm.load %15 : !llvm.ptr -> i256
+    %18 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %17, %18 : i256, !llvm.ptr
+    %19 = llvm.getelementptr %18[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %19, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_4 = arith.constant 0 : i64
-    %23 = arith.addi %22, %c0_i64_4 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.cmpi ult, %22, %c1_i64_5 : i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %20 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %21 = arith.addi %20, %c0_i64_2 : i64
+    llvm.store %21, %arg3 : i64, !llvm.ptr
+    %c1_i64_3 = arith.constant 1 : i64
+    %22 = arith.cmpi ult, %20, %c1_i64_3 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %24, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %22, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %23 = llvm.load %arg1 : !llvm.ptr -> i64
     %c20_i64 = arith.constant 20 : i64
     call @dora_fn_nop() : () -> ()
-    %26 = arith.cmpi uge, %25, %c20_i64 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %26, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %24 = arith.cmpi uge, %23, %c20_i64 : i64
+    %c80_i8_4 = arith.constant 80 : i8
+    cf.cond_br %24, ^bb10, ^bb1(%c80_i8_4 : i8)
   ^bb10:  // pred: ^bb9
-    %27 = arith.subi %25, %c20_i64 : i64
-    llvm.store %27, %arg1 : i64, !llvm.ptr
+    %25 = arith.subi %23, %c20_i64 : i64
+    llvm.store %25, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_7 = arith.constant 0 : i64
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %28, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %26, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__caller.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__caller.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_caller(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_caller(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__callvalue.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__callvalue.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_callvalue(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_callvalue(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__chainid.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__chainid.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = call @dora_fn_chainid(%arg0) : (!llvm.ptr) -> i64
-    %4 = arith.extui %3 : i64 to i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = call @dora_fn_chainid(%arg0) : (!llvm.ptr) -> i64
+    %5 = arith.extui %4 : i64 to i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__codesize_edge_case_empty.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__codesize_edge_case_empty.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__coinbase.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__coinbase.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = call @dora_fn_coinbase(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %4 = llvm.load %3 : !llvm.ptr -> i160
-    %5 = llvm.intr.bswap(%4)  : (i160) -> i160
-    %6 = arith.extui %5 : i160 to i256
-    %7 = llvm.load %arg3 : !llvm.ptr -> i64
-    %8 = llvm.getelementptr %arg2[%7] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %9 = arith.addi %7, %c1_i64 : i64
-    llvm.store %9, %arg3 : i64, !llvm.ptr
-    llvm.store %6, %8 : i256, !llvm.ptr
+    %4 = call @dora_fn_coinbase(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %5 = llvm.load %4 : !llvm.ptr -> i160
+    %6 = llvm.intr.bswap(%5)  : (i160) -> i160
+    %7 = arith.extui %6 : i160 to i256
+    %8 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %7, %8 : i256, !llvm.ptr
+    %9 = llvm.getelementptr %8[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %9, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %10 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %11 = arith.addi %10, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %11 = arith.addi %10, %c1_i64 : i64
+    llvm.store %11, %arg3 : i64, !llvm.ptr
     %12 = arith.cmpi ult, %c1024_i64, %11 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %12, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__create_extcodesize.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 69 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb49, ^bb50, ^bb52, ^bb54, ^bb55, ^bb58, ^bb59, ^bb63, ^bb64, ^bb67, ^bb68, ^bb71, ^bb72, ^bb74, ^bb75, ^bb79, ^bb80, ^bb83, ^bb84, ^bb85, ^bb88, ^bb89, ^bb91, ^bb92, ^bb93, ^bb96, ^bb97, ^bb99, ^bb100, ^bb101, ^bb102, ^bb103, ^bb106, ^bb107, ^bb109, ^bb110, ^bb111, ^bb114, ^bb115, ^bb117, ^bb118, ^bb119, ^bb122, ^bb123
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 69 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb49, ^bb50, ^bb52, ^bb54, ^bb55, ^bb58, ^bb59, ^bb63, ^bb64, ^bb67, ^bb68, ^bb71, ^bb72, ^bb74, ^bb75, ^bb79, ^bb80, ^bb83, ^bb84, ^bb85, ^bb88, ^bb89, ^bb91, ^bb92, ^bb93, ^bb96, ^bb97, ^bb99, ^bb100, ^bb101, ^bb102, ^bb103, ^bb106, ^bb107, ^bb109, ^bb110, ^bb111, ^bb114, ^bb115, ^bb117, ^bb118, ^bb119, ^bb122, ^bb123
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c170141183460469231731687303715884105727_i256 = arith.constant 170141183460469231731687303715884105727 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c170141183460469231731687303715884105727_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,954 +96,923 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb83, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb83, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb87
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c170141183460469231731687303715884105727_i256_13 = arith.constant 170141183460469231731687303715884105727 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c170141183460469231731687303715884105727_i256_13, %41 : i256, !llvm.ptr
+    %c170141183460469231731687303715884105727_i256_10 = arith.constant 170141183460469231731687303715884105727 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c170141183460469231731687303715884105727_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c32_i256 = arith.constant 32 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
-    %c32_i64_28 = arith.constant 32 : i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %66 = arith.cmpi ne, %c32_i64_28, %c0_i64_29 : i64
-    cf.cond_br %66, ^bb91, ^bb25
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_21 = arith.constant 32 : i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %59 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
+    cf.cond_br %59, ^bb91, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb95
-    %67 = arith.trunci %61 : i256 to i64
-    %68 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %69 = llvm.getelementptr %68[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %70 = llvm.intr.bswap(%65)  : (i256) -> i256
-    llvm.store %70, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = arith.trunci %55 : i256 to i64
+    %61 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %63 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %63, %62 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb31
   ^bb26:  // pred: ^bb28
-    %c1024_i64_30 = arith.constant 1024 : i64
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_31 = arith.constant -2 : i64
-    %72 = arith.addi %71, %c-2_i64_31 : i64
-    %c2_i64_32 = arith.constant 2 : i64
-    %73 = arith.cmpi ult, %71, %c2_i64_32 : i64
-    %c91_i8_33 = arith.constant 91 : i8
-    cf.cond_br %73, ^bb1(%c91_i8_33 : i8), ^bb24
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_24 = arith.constant -2 : i64
+    %65 = arith.addi %64, %c-2_i64_24 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c2_i64_25 = arith.constant 2 : i64
+    %66 = arith.cmpi ult, %64, %c2_i64_25 : i64
+    %c91_i8_26 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_26 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_34 = arith.constant 3 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_27 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %75 = arith.cmpi uge, %74, %c3_i64_34 : i64
-    %c80_i8_35 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb28, ^bb1(%c80_i8_35 : i8)
+    %68 = arith.cmpi uge, %67, %c3_i64_27 : i64
+    %c80_i8_28 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb28, ^bb1(%c80_i8_28 : i8)
   ^bb28:  // pred: ^bb27
-    %76 = arith.subi %74, %c3_i64_34 : i64
-    llvm.store %76, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c3_i64_27 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb30
     %c41_i256 = arith.constant 41 : i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %78 = llvm.getelementptr %arg2[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_36 = arith.constant 1 : i64
-    %79 = arith.addi %77, %c1_i64_36 : i64
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    llvm.store %c41_i256, %78 : i256, !llvm.ptr
+    %70 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c41_i256, %70 : i256, !llvm.ptr
+    %71 = llvm.getelementptr %70[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %71, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_37 = arith.constant 1024 : i64
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %81 = arith.addi %80, %c1_i64_38 : i64
-    %82 = arith.cmpi ult, %c1024_i64_37, %81 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %82, ^bb1(%c92_i8_39 : i8), ^bb29
+    %c1024_i64_29 = arith.constant 1024 : i64
+    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_30 = arith.constant 1 : i64
+    %73 = arith.addi %72, %c1_i64_30 : i64
+    llvm.store %73, %arg3 : i64, !llvm.ptr
+    %74 = arith.cmpi ult, %c1024_i64_29, %73 : i64
+    %c92_i8_31 = arith.constant 92 : i8
+    cf.cond_br %74, ^bb1(%c92_i8_31 : i8), ^bb29
   ^bb31:  // pred: ^bb25
-    %83 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_40 = arith.constant 3 : i64
+    %75 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_32 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %84 = arith.cmpi uge, %83, %c3_i64_40 : i64
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %84, ^bb32, ^bb1(%c80_i8_41 : i8)
+    %76 = arith.cmpi uge, %75, %c3_i64_32 : i64
+    %c80_i8_33 = arith.constant 80 : i8
+    cf.cond_br %76, ^bb32, ^bb1(%c80_i8_33 : i8)
   ^bb32:  // pred: ^bb31
-    %85 = arith.subi %83, %c3_i64_40 : i64
-    llvm.store %85, %arg1 : i64, !llvm.ptr
+    %77 = arith.subi %75, %c3_i64_32 : i64
+    llvm.store %77, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
-    %c0_i256_42 = arith.constant 0 : i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %87 = llvm.getelementptr %arg2[%86] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_43 = arith.constant 1 : i64
-    %88 = arith.addi %86, %c1_i64_43 : i64
-    llvm.store %88, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_42, %87 : i256, !llvm.ptr
+    %c0_i256_34 = arith.constant 0 : i256
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_34, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb34:  // pred: ^bb36
-    %c1024_i64_44 = arith.constant 1024 : i64
-    %89 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_45 = arith.constant 1 : i64
-    %90 = arith.addi %89, %c1_i64_45 : i64
-    %91 = arith.cmpi ult, %c1024_i64_44, %90 : i64
-    %c92_i8_46 = arith.constant 92 : i8
-    cf.cond_br %91, ^bb1(%c92_i8_46 : i8), ^bb33
+    %c1024_i64_35 = arith.constant 1024 : i64
+    %80 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_36 = arith.constant 1 : i64
+    %81 = arith.addi %80, %c1_i64_36 : i64
+    llvm.store %81, %arg3 : i64, !llvm.ptr
+    %82 = arith.cmpi ult, %c1024_i64_35, %81 : i64
+    %c92_i8_37 = arith.constant 92 : i8
+    cf.cond_br %82, ^bb1(%c92_i8_37 : i8), ^bb33
   ^bb35:  // pred: ^bb29
-    %92 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_47 = arith.constant 3 : i64
+    %83 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_38 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %93 = arith.cmpi uge, %92, %c3_i64_47 : i64
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %93, ^bb36, ^bb1(%c80_i8_48 : i8)
+    %84 = arith.cmpi uge, %83, %c3_i64_38 : i64
+    %c80_i8_39 = arith.constant 80 : i8
+    cf.cond_br %84, ^bb36, ^bb1(%c80_i8_39 : i8)
   ^bb36:  // pred: ^bb35
-    %94 = arith.subi %92, %c3_i64_47 : i64
-    llvm.store %94, %arg1 : i64, !llvm.ptr
+    %85 = arith.subi %83, %c3_i64_38 : i64
+    llvm.store %85, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb38
-    %c0_i256_49 = arith.constant 0 : i256
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
-    %96 = llvm.getelementptr %arg2[%95] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_50 = arith.constant 1 : i64
-    %97 = arith.addi %95, %c1_i64_50 : i64
-    llvm.store %97, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_49, %96 : i256, !llvm.ptr
+    %c0_i256_40 = arith.constant 0 : i256
+    %86 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_40, %86 : i256, !llvm.ptr
+    %87 = llvm.getelementptr %86[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %87, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb50
   ^bb38:  // pred: ^bb40
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %98 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_52 = arith.constant 1 : i64
-    %99 = arith.addi %98, %c1_i64_52 : i64
-    %100 = arith.cmpi ult, %c1024_i64_51, %99 : i64
-    %c92_i8_53 = arith.constant 92 : i8
-    cf.cond_br %100, ^bb1(%c92_i8_53 : i8), ^bb37
+    %c1024_i64_41 = arith.constant 1024 : i64
+    %88 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_42 = arith.constant 1 : i64
+    %89 = arith.addi %88, %c1_i64_42 : i64
+    llvm.store %89, %arg3 : i64, !llvm.ptr
+    %90 = arith.cmpi ult, %c1024_i64_41, %89 : i64
+    %c92_i8_43 = arith.constant 92 : i8
+    cf.cond_br %90, ^bb1(%c92_i8_43 : i8), ^bb37
   ^bb39:  // pred: ^bb33
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_54 = arith.constant 3 : i64
+    %91 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_44 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %102 = arith.cmpi uge, %101, %c3_i64_54 : i64
-    %c80_i8_55 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb40, ^bb1(%c80_i8_55 : i8)
+    %92 = arith.cmpi uge, %91, %c3_i64_44 : i64
+    %c80_i8_45 = arith.constant 80 : i8
+    cf.cond_br %92, ^bb40, ^bb1(%c80_i8_45 : i8)
   ^bb40:  // pred: ^bb39
-    %103 = arith.subi %101, %c3_i64_54 : i64
-    llvm.store %103, %arg1 : i64, !llvm.ptr
+    %93 = arith.subi %91, %c3_i64_44 : i64
+    llvm.store %93, %arg1 : i64, !llvm.ptr
     cf.br ^bb38
   ^bb41:  // pred: ^bb49
-    %104 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_56 = arith.constant 1 : i64
-    %105 = arith.subi %104, %c1_i64_56 : i64
-    %106 = llvm.getelementptr %arg2[%105] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %105, %arg3 : i64, !llvm.ptr
-    %107 = llvm.load %106 : !llvm.ptr -> i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_57 = arith.constant 1 : i64
-    %109 = arith.subi %108, %c1_i64_57 : i64
-    %110 = llvm.getelementptr %arg2[%109] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %109, %arg3 : i64, !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> i256
-    %112 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %113 = arith.subi %112, %c1_i64_58 : i64
-    %114 = llvm.getelementptr %arg2[%113] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %113, %arg3 : i64, !llvm.ptr
-    %115 = llvm.load %114 : !llvm.ptr -> i256
-    %116 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %94 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %95 = llvm.getelementptr %94[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %96 = llvm.load %95 : !llvm.ptr -> i256
+    llvm.store %95, %0 : !llvm.ptr, !llvm.ptr
+    %97 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %98 = llvm.getelementptr %97[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %99 = llvm.load %98 : !llvm.ptr -> i256
+    llvm.store %98, %0 : !llvm.ptr, !llvm.ptr
+    %100 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %101 = llvm.getelementptr %100[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %102 = llvm.load %101 : !llvm.ptr -> i256
+    llvm.store %101, %0 : !llvm.ptr, !llvm.ptr
+    %103 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %117 = arith.cmpi ne, %116, %c0_i8 : i8
+    %104 = arith.cmpi ne, %103, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %117, ^bb1(%c87_i8 : i8), ^bb42
+    cf.cond_br %104, ^bb1(%c87_i8 : i8), ^bb42
   ^bb42:  // pred: ^bb41
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %118 = arith.cmpi sgt, %115, %c18446744073709551615_i256 : i256
+    %105 = arith.cmpi sgt, %102, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8 : i8), ^bb43
+    cf.cond_br %105, ^bb1(%c84_i8 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %119 = arith.trunci %115 : i256 to i64
-    %c0_i64_59 = arith.constant 0 : i64
-    %120 = arith.cmpi slt, %119, %c0_i64_59 : i64
-    %c84_i8_60 = arith.constant 84 : i8
-    cf.cond_br %120, ^bb1(%c84_i8_60 : i8), ^bb44
+    %106 = arith.trunci %102 : i256 to i64
+    %c0_i64_46 = arith.constant 0 : i64
+    %107 = arith.cmpi slt, %106, %c0_i64_46 : i64
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %107, ^bb1(%c84_i8_47 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c0_i64_61 = arith.constant 0 : i64
-    %121 = arith.cmpi ne, %119, %c0_i64_61 : i64
-    cf.cond_br %121, ^bb99, ^bb45
+    %c0_i64_48 = arith.constant 0 : i64
+    %108 = arith.cmpi ne, %106, %c0_i64_48 : i64
+    cf.cond_br %108, ^bb99, ^bb45
   ^bb45:  // 2 preds: ^bb44, ^bb105
     %c32000_i64 = arith.constant 32000 : i64
-    %122 = llvm.load %arg1 : !llvm.ptr -> i64
-    %123 = arith.cmpi ult, %122, %c32000_i64 : i64
-    scf.if %123 {
+    %109 = llvm.load %arg1 : !llvm.ptr -> i64
+    %110 = arith.cmpi ult, %109, %c32000_i64 : i64
+    scf.if %110 {
     } else {
-      %380 = arith.subi %122, %c32000_i64 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %109, %c32000_i64 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %123, ^bb1(%c80_i8_62 : i8), ^bb46
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %110, ^bb1(%c80_i8_49 : i8), ^bb46
   ^bb46:  // pred: ^bb45
     %c1_i256 = arith.constant 1 : i256
-    %124 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %107, %124 {alignment = 1 : i64} : i256, !llvm.ptr
-    %125 = llvm.load %arg1 : !llvm.ptr -> i64
-    %126 = arith.trunci %111 : i256 to i64
-    %127 = call @dora_fn_create(%arg0, %119, %126, %124, %125) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %128 = llvm.getelementptr %127[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %129 = llvm.load %128 : !llvm.ptr -> i8
-    %c0_i8_63 = arith.constant 0 : i8
-    %130 = arith.cmpi ne, %129, %c0_i8_63 : i8
-    cf.cond_br %130, ^bb1(%129 : i8), ^bb47
+    %111 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %96, %111 {alignment = 1 : i64} : i256, !llvm.ptr
+    %112 = llvm.load %arg1 : !llvm.ptr -> i64
+    %113 = arith.trunci %99 : i256 to i64
+    %114 = call @dora_fn_create(%arg0, %106, %113, %111, %112) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %115 = llvm.getelementptr %114[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %116 = llvm.load %115 : !llvm.ptr -> i8
+    %c0_i8_50 = arith.constant 0 : i8
+    %117 = arith.cmpi ne, %116, %c0_i8_50 : i8
+    cf.cond_br %117, ^bb1(%116 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %131 = llvm.getelementptr %127[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %132 = llvm.load %131 : !llvm.ptr -> i64
-    %133 = llvm.load %arg1 : !llvm.ptr -> i64
-    %134 = arith.cmpi ult, %133, %132 : i64
-    scf.if %134 {
+    %118 = llvm.getelementptr %114[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %119 = llvm.load %118 : !llvm.ptr -> i64
+    %120 = llvm.load %arg1 : !llvm.ptr -> i64
+    %121 = arith.cmpi ult, %120, %119 : i64
+    scf.if %121 {
     } else {
-      %380 = arith.subi %133, %132 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %120, %119 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_64 = arith.constant 80 : i8
-    cf.cond_br %134, ^bb1(%c80_i8_64 : i8), ^bb48
+    %c80_i8_51 = arith.constant 80 : i8
+    cf.cond_br %121, ^bb1(%c80_i8_51 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %135 = llvm.load %124 : !llvm.ptr -> i256
-    %136 = llvm.load %arg3 : !llvm.ptr -> i64
-    %137 = llvm.getelementptr %arg2[%136] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_65 = arith.constant 1 : i64
-    %138 = arith.addi %136, %c1_i64_65 : i64
-    llvm.store %138, %arg3 : i64, !llvm.ptr
-    llvm.store %135, %137 : i256, !llvm.ptr
+    %122 = llvm.load %111 : !llvm.ptr -> i256
+    %123 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %122, %123 : i256, !llvm.ptr
+    %124 = llvm.getelementptr %123[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %124, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb55
   ^bb49:  // pred: ^bb51
-    %c1024_i64_66 = arith.constant 1024 : i64
-    %139 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_67 = arith.constant -2 : i64
-    %140 = arith.addi %139, %c-2_i64_67 : i64
-    %c3_i64_68 = arith.constant 3 : i64
-    %141 = arith.cmpi ult, %139, %c3_i64_68 : i64
-    %c91_i8_69 = arith.constant 91 : i8
-    cf.cond_br %141, ^bb1(%c91_i8_69 : i8), ^bb41
+    %c1024_i64_52 = arith.constant 1024 : i64
+    %125 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_53 = arith.constant -2 : i64
+    %126 = arith.addi %125, %c-2_i64_53 : i64
+    llvm.store %126, %arg3 : i64, !llvm.ptr
+    %c3_i64_54 = arith.constant 3 : i64
+    %127 = arith.cmpi ult, %125, %c3_i64_54 : i64
+    %c91_i8_55 = arith.constant 91 : i8
+    cf.cond_br %127, ^bb1(%c91_i8_55 : i8), ^bb41
   ^bb50:  // pred: ^bb37
-    %142 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_70 = arith.constant 0 : i64
+    %128 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_56 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %143 = arith.cmpi uge, %142, %c0_i64_70 : i64
-    %c80_i8_71 = arith.constant 80 : i8
-    cf.cond_br %143, ^bb51, ^bb1(%c80_i8_71 : i8)
+    %129 = arith.cmpi uge, %128, %c0_i64_56 : i64
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %129, ^bb51, ^bb1(%c80_i8_57 : i8)
   ^bb51:  // pred: ^bb50
-    %144 = arith.subi %142, %c0_i64_70 : i64
-    llvm.store %144, %arg1 : i64, !llvm.ptr
+    %130 = arith.subi %128, %c0_i64_56 : i64
+    llvm.store %130, %arg1 : i64, !llvm.ptr
     cf.br ^bb49
   ^bb52:  // pred: ^bb54
-    %145 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %146 = arith.subi %145, %c1_i64_72 : i64
-    %147 = llvm.getelementptr %arg2[%146] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> i256
-    %c1_i256_73 = arith.constant 1 : i256
-    %149 = llvm.alloca %c1_i256_73 x i256 : (i256) -> !llvm.ptr
-    llvm.store %148, %149 {alignment = 1 : i64} : i256, !llvm.ptr
-    %150 = call @dora_fn_extcodesize(%arg0, %149) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %151 = llvm.getelementptr %150[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %152 = llvm.load %151 : !llvm.ptr -> i64
-    %153 = llvm.getelementptr %150[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %154 = llvm.load %153 : !llvm.ptr -> i64
-    %155 = llvm.load %arg1 : !llvm.ptr -> i64
-    %156 = arith.cmpi ult, %155, %154 : i64
-    scf.if %156 {
+    %131 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %132 = llvm.getelementptr %131[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %133 = llvm.load %132 : !llvm.ptr -> i256
+    llvm.store %132, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_58 = arith.constant 1 : i256
+    %134 = llvm.alloca %c1_i256_58 x i256 : (i256) -> !llvm.ptr
+    llvm.store %133, %134 {alignment = 1 : i64} : i256, !llvm.ptr
+    %135 = call @dora_fn_extcodesize(%arg0, %134) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %136 = llvm.getelementptr %135[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %137 = llvm.load %136 : !llvm.ptr -> i64
+    %138 = llvm.getelementptr %135[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %139 = llvm.load %138 : !llvm.ptr -> i64
+    %140 = llvm.load %arg1 : !llvm.ptr -> i64
+    %141 = arith.cmpi ult, %140, %139 : i64
+    scf.if %141 {
     } else {
-      %380 = arith.subi %155, %154 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %140, %139 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_74 = arith.constant 80 : i8
-    cf.cond_br %156, ^bb1(%c80_i8_74 : i8), ^bb53
+    %c80_i8_59 = arith.constant 80 : i8
+    cf.cond_br %141, ^bb1(%c80_i8_59 : i8), ^bb53
   ^bb53:  // pred: ^bb52
-    %157 = arith.extui %152 : i64 to i256
-    %158 = llvm.load %arg3 : !llvm.ptr -> i64
-    %159 = llvm.getelementptr %arg2[%158] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_75 = arith.constant 1 : i64
-    %160 = arith.addi %158, %c1_i64_75 : i64
-    llvm.store %160, %arg3 : i64, !llvm.ptr
-    llvm.store %157, %159 : i256, !llvm.ptr
+    %142 = arith.extui %137 : i64 to i256
+    %143 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %142, %143 : i256, !llvm.ptr
+    %144 = llvm.getelementptr %143[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %144, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb59
   ^bb54:  // pred: ^bb56
-    %c1024_i64_76 = arith.constant 1024 : i64
-    %161 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_77 = arith.constant 0 : i64
-    %162 = arith.addi %161, %c0_i64_77 : i64
-    %c1_i64_78 = arith.constant 1 : i64
-    %163 = arith.cmpi ult, %161, %c1_i64_78 : i64
-    %c91_i8_79 = arith.constant 91 : i8
-    cf.cond_br %163, ^bb1(%c91_i8_79 : i8), ^bb52
+    %c1024_i64_60 = arith.constant 1024 : i64
+    %145 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_61 = arith.constant 0 : i64
+    %146 = arith.addi %145, %c0_i64_61 : i64
+    llvm.store %146, %arg3 : i64, !llvm.ptr
+    %c1_i64_62 = arith.constant 1 : i64
+    %147 = arith.cmpi ult, %145, %c1_i64_62 : i64
+    %c91_i8_63 = arith.constant 91 : i8
+    cf.cond_br %147, ^bb1(%c91_i8_63 : i8), ^bb52
   ^bb55:  // pred: ^bb48
-    %164 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_80 = arith.constant 0 : i64
+    %148 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_64 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %165 = arith.cmpi uge, %164, %c0_i64_80 : i64
-    %c80_i8_81 = arith.constant 80 : i8
-    cf.cond_br %165, ^bb56, ^bb1(%c80_i8_81 : i8)
+    %149 = arith.cmpi uge, %148, %c0_i64_64 : i64
+    %c80_i8_65 = arith.constant 80 : i8
+    cf.cond_br %149, ^bb56, ^bb1(%c80_i8_65 : i8)
   ^bb56:  // pred: ^bb55
-    %166 = arith.subi %164, %c0_i64_80 : i64
-    llvm.store %166, %arg1 : i64, !llvm.ptr
+    %150 = arith.subi %148, %c0_i64_64 : i64
+    llvm.store %150, %arg1 : i64, !llvm.ptr
     cf.br ^bb54
   ^bb57:  // pred: ^bb58
-    %c0_i256_82 = arith.constant 0 : i256
-    %167 = llvm.load %arg3 : !llvm.ptr -> i64
-    %168 = llvm.getelementptr %arg2[%167] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_83 = arith.constant 1 : i64
-    %169 = arith.addi %167, %c1_i64_83 : i64
-    llvm.store %169, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_82, %168 : i256, !llvm.ptr
+    %c0_i256_66 = arith.constant 0 : i256
+    %151 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_66, %151 : i256, !llvm.ptr
+    %152 = llvm.getelementptr %151[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %152, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb64
   ^bb58:  // pred: ^bb60
-    %c1024_i64_84 = arith.constant 1024 : i64
-    %170 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %171 = arith.addi %170, %c1_i64_85 : i64
-    %172 = arith.cmpi ult, %c1024_i64_84, %171 : i64
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %172, ^bb1(%c92_i8_86 : i8), ^bb57
+    %c1024_i64_67 = arith.constant 1024 : i64
+    %153 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_68 = arith.constant 1 : i64
+    %154 = arith.addi %153, %c1_i64_68 : i64
+    llvm.store %154, %arg3 : i64, !llvm.ptr
+    %155 = arith.cmpi ult, %c1024_i64_67, %154 : i64
+    %c92_i8_69 = arith.constant 92 : i8
+    cf.cond_br %155, ^bb1(%c92_i8_69 : i8), ^bb57
   ^bb59:  // pred: ^bb53
-    %173 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_87 = arith.constant 2 : i64
+    %156 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_70 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %174 = arith.cmpi uge, %173, %c2_i64_87 : i64
-    %c80_i8_88 = arith.constant 80 : i8
-    cf.cond_br %174, ^bb60, ^bb1(%c80_i8_88 : i8)
+    %157 = arith.cmpi uge, %156, %c2_i64_70 : i64
+    %c80_i8_71 = arith.constant 80 : i8
+    cf.cond_br %157, ^bb60, ^bb1(%c80_i8_71 : i8)
   ^bb60:  // pred: ^bb59
-    %175 = arith.subi %173, %c2_i64_87 : i64
-    llvm.store %175, %arg1 : i64, !llvm.ptr
+    %158 = arith.subi %156, %c2_i64_70 : i64
+    llvm.store %158, %arg1 : i64, !llvm.ptr
     cf.br ^bb58
   ^bb61:  // pred: ^bb63
-    %176 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_89 = arith.constant 1 : i64
-    %177 = arith.subi %176, %c1_i64_89 : i64
-    %178 = llvm.getelementptr %arg2[%177] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %177, %arg3 : i64, !llvm.ptr
-    %179 = llvm.load %178 : !llvm.ptr -> i256
-    %180 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_90 = arith.constant 1 : i64
-    %181 = arith.subi %180, %c1_i64_90 : i64
-    %182 = llvm.getelementptr %arg2[%181] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %181, %arg3 : i64, !llvm.ptr
-    %183 = llvm.load %182 : !llvm.ptr -> i256
-    %c32_i64_91 = arith.constant 32 : i64
-    %c0_i64_92 = arith.constant 0 : i64
-    %184 = arith.cmpi ne, %c32_i64_91, %c0_i64_92 : i64
-    cf.cond_br %184, ^bb109, ^bb62
+    %159 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %160 = llvm.getelementptr %159[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %161 = llvm.load %160 : !llvm.ptr -> i256
+    llvm.store %160, %0 : !llvm.ptr, !llvm.ptr
+    %162 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %163 = llvm.getelementptr %162[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %164 = llvm.load %163 : !llvm.ptr -> i256
+    llvm.store %163, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_72 = arith.constant 32 : i64
+    %c0_i64_73 = arith.constant 0 : i64
+    %165 = arith.cmpi ne, %c32_i64_72, %c0_i64_73 : i64
+    cf.cond_br %165, ^bb109, ^bb62
   ^bb62:  // 2 preds: ^bb61, ^bb113
-    %185 = arith.trunci %179 : i256 to i64
-    %186 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %187 = llvm.getelementptr %186[%185] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %188 = llvm.intr.bswap(%183)  : (i256) -> i256
-    llvm.store %188, %187 {alignment = 1 : i64} : i256, !llvm.ptr
+    %166 = arith.trunci %161 : i256 to i64
+    %167 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %168 = llvm.getelementptr %167[%166] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %169 = llvm.intr.bswap(%164)  : (i256) -> i256
+    llvm.store %169, %168 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb68
   ^bb63:  // pred: ^bb65
-    %c1024_i64_93 = arith.constant 1024 : i64
-    %189 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_94 = arith.constant -2 : i64
-    %190 = arith.addi %189, %c-2_i64_94 : i64
-    %c2_i64_95 = arith.constant 2 : i64
-    %191 = arith.cmpi ult, %189, %c2_i64_95 : i64
-    %c91_i8_96 = arith.constant 91 : i8
-    cf.cond_br %191, ^bb1(%c91_i8_96 : i8), ^bb61
+    %c1024_i64_74 = arith.constant 1024 : i64
+    %170 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_75 = arith.constant -2 : i64
+    %171 = arith.addi %170, %c-2_i64_75 : i64
+    llvm.store %171, %arg3 : i64, !llvm.ptr
+    %c2_i64_76 = arith.constant 2 : i64
+    %172 = arith.cmpi ult, %170, %c2_i64_76 : i64
+    %c91_i8_77 = arith.constant 91 : i8
+    cf.cond_br %172, ^bb1(%c91_i8_77 : i8), ^bb61
   ^bb64:  // pred: ^bb57
-    %192 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_97 = arith.constant 3 : i64
+    %173 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_78 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %193 = arith.cmpi uge, %192, %c3_i64_97 : i64
-    %c80_i8_98 = arith.constant 80 : i8
-    cf.cond_br %193, ^bb65, ^bb1(%c80_i8_98 : i8)
+    %174 = arith.cmpi uge, %173, %c3_i64_78 : i64
+    %c80_i8_79 = arith.constant 80 : i8
+    cf.cond_br %174, ^bb65, ^bb1(%c80_i8_79 : i8)
   ^bb65:  // pred: ^bb64
-    %194 = arith.subi %192, %c3_i64_97 : i64
-    llvm.store %194, %arg1 : i64, !llvm.ptr
+    %175 = arith.subi %173, %c3_i64_78 : i64
+    llvm.store %175, %arg1 : i64, !llvm.ptr
     cf.br ^bb63
   ^bb66:  // pred: ^bb67
-    %c32_i256_99 = arith.constant 32 : i256
-    %195 = llvm.load %arg3 : !llvm.ptr -> i64
-    %196 = llvm.getelementptr %arg2[%195] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_100 = arith.constant 1 : i64
-    %197 = arith.addi %195, %c1_i64_100 : i64
-    llvm.store %197, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_99, %196 : i256, !llvm.ptr
+    %c32_i256_80 = arith.constant 32 : i256
+    %176 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_80, %176 : i256, !llvm.ptr
+    %177 = llvm.getelementptr %176[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %177, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb72
   ^bb67:  // pred: ^bb69
-    %c1024_i64_101 = arith.constant 1024 : i64
-    %198 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_102 = arith.constant 1 : i64
-    %199 = arith.addi %198, %c1_i64_102 : i64
-    %200 = arith.cmpi ult, %c1024_i64_101, %199 : i64
-    %c92_i8_103 = arith.constant 92 : i8
-    cf.cond_br %200, ^bb1(%c92_i8_103 : i8), ^bb66
+    %c1024_i64_81 = arith.constant 1024 : i64
+    %178 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_82 = arith.constant 1 : i64
+    %179 = arith.addi %178, %c1_i64_82 : i64
+    llvm.store %179, %arg3 : i64, !llvm.ptr
+    %180 = arith.cmpi ult, %c1024_i64_81, %179 : i64
+    %c92_i8_83 = arith.constant 92 : i8
+    cf.cond_br %180, ^bb1(%c92_i8_83 : i8), ^bb66
   ^bb68:  // pred: ^bb62
-    %201 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_104 = arith.constant 3 : i64
+    %181 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_84 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %202 = arith.cmpi uge, %201, %c3_i64_104 : i64
-    %c80_i8_105 = arith.constant 80 : i8
-    cf.cond_br %202, ^bb69, ^bb1(%c80_i8_105 : i8)
+    %182 = arith.cmpi uge, %181, %c3_i64_84 : i64
+    %c80_i8_85 = arith.constant 80 : i8
+    cf.cond_br %182, ^bb69, ^bb1(%c80_i8_85 : i8)
   ^bb69:  // pred: ^bb68
-    %203 = arith.subi %201, %c3_i64_104 : i64
-    llvm.store %203, %arg1 : i64, !llvm.ptr
+    %183 = arith.subi %181, %c3_i64_84 : i64
+    llvm.store %183, %arg1 : i64, !llvm.ptr
     cf.br ^bb67
   ^bb70:  // pred: ^bb71
-    %c0_i256_106 = arith.constant 0 : i256
-    %204 = llvm.load %arg3 : !llvm.ptr -> i64
-    %205 = llvm.getelementptr %arg2[%204] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_107 = arith.constant 1 : i64
-    %206 = arith.addi %204, %c1_i64_107 : i64
-    llvm.store %206, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_106, %205 : i256, !llvm.ptr
+    %c0_i256_86 = arith.constant 0 : i256
+    %184 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_86, %184 : i256, !llvm.ptr
+    %185 = llvm.getelementptr %184[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %185, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb80
   ^bb71:  // pred: ^bb73
-    %c1024_i64_108 = arith.constant 1024 : i64
-    %207 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_109 = arith.constant 1 : i64
-    %208 = arith.addi %207, %c1_i64_109 : i64
-    %209 = arith.cmpi ult, %c1024_i64_108, %208 : i64
-    %c92_i8_110 = arith.constant 92 : i8
-    cf.cond_br %209, ^bb1(%c92_i8_110 : i8), ^bb70
+    %c1024_i64_87 = arith.constant 1024 : i64
+    %186 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_88 = arith.constant 1 : i64
+    %187 = arith.addi %186, %c1_i64_88 : i64
+    llvm.store %187, %arg3 : i64, !llvm.ptr
+    %188 = arith.cmpi ult, %c1024_i64_87, %187 : i64
+    %c92_i8_89 = arith.constant 92 : i8
+    cf.cond_br %188, ^bb1(%c92_i8_89 : i8), ^bb70
   ^bb72:  // pred: ^bb66
-    %210 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_111 = arith.constant 2 : i64
+    %189 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_90 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %211 = arith.cmpi uge, %210, %c2_i64_111 : i64
-    %c80_i8_112 = arith.constant 80 : i8
-    cf.cond_br %211, ^bb73, ^bb1(%c80_i8_112 : i8)
+    %190 = arith.cmpi uge, %189, %c2_i64_90 : i64
+    %c80_i8_91 = arith.constant 80 : i8
+    cf.cond_br %190, ^bb73, ^bb1(%c80_i8_91 : i8)
   ^bb73:  // pred: ^bb72
-    %212 = arith.subi %210, %c2_i64_111 : i64
-    llvm.store %212, %arg1 : i64, !llvm.ptr
+    %191 = arith.subi %189, %c2_i64_90 : i64
+    llvm.store %191, %arg1 : i64, !llvm.ptr
     cf.br ^bb71
   ^bb74:  // pred: ^bb79
-    %213 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_113 = arith.constant 1 : i64
-    %214 = arith.subi %213, %c1_i64_113 : i64
-    %215 = llvm.getelementptr %arg2[%214] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %214, %arg3 : i64, !llvm.ptr
-    %216 = llvm.load %215 : !llvm.ptr -> i256
-    %217 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_114 = arith.constant 1 : i64
-    %218 = arith.subi %217, %c1_i64_114 : i64
-    %219 = llvm.getelementptr %arg2[%218] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %218, %arg3 : i64, !llvm.ptr
-    %220 = llvm.load %219 : !llvm.ptr -> i256
-    %c18446744073709551615_i256_115 = arith.constant 18446744073709551615 : i256
-    %221 = arith.cmpi sgt, %220, %c18446744073709551615_i256_115 : i256
-    %c84_i8_116 = arith.constant 84 : i8
-    cf.cond_br %221, ^bb1(%c84_i8_116 : i8), ^bb75
+    %192 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %193 = llvm.getelementptr %192[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %194 = llvm.load %193 : !llvm.ptr -> i256
+    llvm.store %193, %0 : !llvm.ptr, !llvm.ptr
+    %195 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %196 = llvm.getelementptr %195[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %197 = llvm.load %196 : !llvm.ptr -> i256
+    llvm.store %196, %0 : !llvm.ptr, !llvm.ptr
+    %c18446744073709551615_i256_92 = arith.constant 18446744073709551615 : i256
+    %198 = arith.cmpi sgt, %197, %c18446744073709551615_i256_92 : i256
+    %c84_i8_93 = arith.constant 84 : i8
+    cf.cond_br %198, ^bb1(%c84_i8_93 : i8), ^bb75
   ^bb75:  // pred: ^bb74
-    %222 = arith.trunci %220 : i256 to i64
-    %c0_i64_117 = arith.constant 0 : i64
-    %223 = arith.cmpi slt, %222, %c0_i64_117 : i64
-    %c84_i8_118 = arith.constant 84 : i8
-    cf.cond_br %223, ^bb1(%c84_i8_118 : i8), ^bb76
+    %199 = arith.trunci %197 : i256 to i64
+    %c0_i64_94 = arith.constant 0 : i64
+    %200 = arith.cmpi slt, %199, %c0_i64_94 : i64
+    %c84_i8_95 = arith.constant 84 : i8
+    cf.cond_br %200, ^bb1(%c84_i8_95 : i8), ^bb76
   ^bb76:  // pred: ^bb75
-    %c0_i64_119 = arith.constant 0 : i64
-    %224 = arith.cmpi ne, %222, %c0_i64_119 : i64
-    cf.cond_br %224, ^bb117, ^bb77
+    %c0_i64_96 = arith.constant 0 : i64
+    %201 = arith.cmpi ne, %199, %c0_i64_96 : i64
+    cf.cond_br %201, ^bb117, ^bb77
   ^bb77:  // 2 preds: ^bb76, ^bb121
-    %c0_i8_120 = arith.constant 0 : i8
-    %225 = arith.trunci %216 : i256 to i64
-    %226 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %225, %222, %226, %c0_i8_120) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %c0_i8_120 : i8
+    %c0_i8_97 = arith.constant 0 : i8
+    %202 = arith.trunci %194 : i256 to i64
+    %203 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %202, %199, %203, %c0_i8_97) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %c0_i8_97 : i8
   ^bb78:  // no predecessors
     cf.br ^bb82
   ^bb79:  // pred: ^bb81
-    %c1024_i64_121 = arith.constant 1024 : i64
-    %227 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_122 = arith.constant -2 : i64
-    %228 = arith.addi %227, %c-2_i64_122 : i64
-    %c2_i64_123 = arith.constant 2 : i64
-    %229 = arith.cmpi ult, %227, %c2_i64_123 : i64
-    %c91_i8_124 = arith.constant 91 : i8
-    cf.cond_br %229, ^bb1(%c91_i8_124 : i8), ^bb74
+    %c1024_i64_98 = arith.constant 1024 : i64
+    %204 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_99 = arith.constant -2 : i64
+    %205 = arith.addi %204, %c-2_i64_99 : i64
+    llvm.store %205, %arg3 : i64, !llvm.ptr
+    %c2_i64_100 = arith.constant 2 : i64
+    %206 = arith.cmpi ult, %204, %c2_i64_100 : i64
+    %c91_i8_101 = arith.constant 91 : i8
+    cf.cond_br %206, ^bb1(%c91_i8_101 : i8), ^bb74
   ^bb80:  // pred: ^bb70
-    %230 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_125 = arith.constant 0 : i64
+    %207 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_102 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %231 = arith.cmpi uge, %230, %c0_i64_125 : i64
-    %c80_i8_126 = arith.constant 80 : i8
-    cf.cond_br %231, ^bb81, ^bb1(%c80_i8_126 : i8)
+    %208 = arith.cmpi uge, %207, %c0_i64_102 : i64
+    %c80_i8_103 = arith.constant 80 : i8
+    cf.cond_br %208, ^bb81, ^bb1(%c80_i8_103 : i8)
   ^bb81:  // pred: ^bb80
-    %232 = arith.subi %230, %c0_i64_125 : i64
-    llvm.store %232, %arg1 : i64, !llvm.ptr
+    %209 = arith.subi %207, %c0_i64_102 : i64
+    llvm.store %209, %arg1 : i64, !llvm.ptr
     cf.br ^bb79
   ^bb82:  // pred: ^bb78
-    %c0_i64_127 = arith.constant 0 : i64
+    %c0_i64_104 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %233 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_127, %c0_i64_127, %233, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %210 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_104, %c0_i64_104, %210, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb83:  // pred: ^bb11
-    %c18446744073709551615_i256_128 = arith.constant 18446744073709551615 : i256
-    %234 = arith.cmpi sgt, %24, %c18446744073709551615_i256_128 : i256
-    %c84_i8_129 = arith.constant 84 : i8
-    cf.cond_br %234, ^bb1(%c84_i8_129 : i8), ^bb84
+    %c18446744073709551615_i256_105 = arith.constant 18446744073709551615 : i256
+    %211 = arith.cmpi sgt, %22, %c18446744073709551615_i256_105 : i256
+    %c84_i8_106 = arith.constant 84 : i8
+    cf.cond_br %211, ^bb1(%c84_i8_106 : i8), ^bb84
   ^bb84:  // pred: ^bb83
-    %235 = arith.trunci %24 : i256 to i64
-    %c0_i64_130 = arith.constant 0 : i64
-    %236 = arith.cmpi slt, %235, %c0_i64_130 : i64
-    %c84_i8_131 = arith.constant 84 : i8
-    cf.cond_br %236, ^bb1(%c84_i8_131 : i8), ^bb85
+    %212 = arith.trunci %22 : i256 to i64
+    %c0_i64_107 = arith.constant 0 : i64
+    %213 = arith.cmpi slt, %212, %c0_i64_107 : i64
+    %c84_i8_108 = arith.constant 84 : i8
+    cf.cond_br %213, ^bb1(%c84_i8_108 : i8), ^bb85
   ^bb85:  // pred: ^bb84
-    %237 = arith.addi %235, %c32_i64 : i64
-    %c0_i64_132 = arith.constant 0 : i64
-    %238 = arith.cmpi slt, %237, %c0_i64_132 : i64
-    %c84_i8_133 = arith.constant 84 : i8
-    cf.cond_br %238, ^bb1(%c84_i8_133 : i8), ^bb86
+    %214 = arith.addi %212, %c32_i64 : i64
+    %c0_i64_109 = arith.constant 0 : i64
+    %215 = arith.cmpi slt, %214, %c0_i64_109 : i64
+    %c84_i8_110 = arith.constant 84 : i8
+    cf.cond_br %215, ^bb1(%c84_i8_110 : i8), ^bb86
   ^bb86:  // pred: ^bb85
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_134 = arith.constant 32 : i64
-    %239 = arith.addi %237, %c31_i64 : i64
-    %240 = arith.divui %239, %c32_i64_134 : i64
-    %c32_i64_135 = arith.constant 32 : i64
-    %241 = arith.muli %240, %c32_i64_135 : i64
-    %242 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_136 = arith.constant 31 : i64
-    %c32_i64_137 = arith.constant 32 : i64
-    %243 = arith.addi %242, %c31_i64_136 : i64
-    %244 = arith.divui %243, %c32_i64_137 : i64
-    %245 = arith.muli %244, %c32_i64_135 : i64
-    %246 = arith.cmpi ult, %245, %241 : i64
-    cf.cond_br %246, ^bb88, ^bb87
+    %c32_i64_111 = arith.constant 32 : i64
+    %216 = arith.addi %214, %c31_i64 : i64
+    %217 = arith.divui %216, %c32_i64_111 : i64
+    %c32_i64_112 = arith.constant 32 : i64
+    %218 = arith.muli %217, %c32_i64_112 : i64
+    %219 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_113 = arith.constant 31 : i64
+    %c32_i64_114 = arith.constant 32 : i64
+    %220 = arith.addi %219, %c31_i64_113 : i64
+    %221 = arith.divui %220, %c32_i64_114 : i64
+    %222 = arith.muli %221, %c32_i64_112 : i64
+    %223 = arith.cmpi ult, %222, %218 : i64
+    cf.cond_br %223, ^bb88, ^bb87
   ^bb87:  // 2 preds: ^bb86, ^bb90
     cf.br ^bb12
   ^bb88:  // pred: ^bb86
-    %c3_i64_138 = arith.constant 3 : i64
+    %c3_i64_115 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %247 = arith.muli %244, %244 : i64
-    %248 = arith.divui %247, %c512_i64 : i64
-    %249 = arith.muli %244, %c3_i64_138 : i64
-    %250 = arith.addi %248, %249 : i64
-    %c3_i64_139 = arith.constant 3 : i64
-    %c512_i64_140 = arith.constant 512 : i64
-    %251 = arith.muli %240, %240 : i64
-    %252 = arith.divui %251, %c512_i64_140 : i64
-    %253 = arith.muli %240, %c3_i64_139 : i64
-    %254 = arith.addi %252, %253 : i64
-    %255 = arith.subi %254, %250 : i64
-    %256 = llvm.load %arg1 : !llvm.ptr -> i64
-    %257 = arith.cmpi ult, %256, %255 : i64
-    scf.if %257 {
+    %224 = arith.muli %221, %221 : i64
+    %225 = arith.divui %224, %c512_i64 : i64
+    %226 = arith.muli %221, %c3_i64_115 : i64
+    %227 = arith.addi %225, %226 : i64
+    %c3_i64_116 = arith.constant 3 : i64
+    %c512_i64_117 = arith.constant 512 : i64
+    %228 = arith.muli %217, %217 : i64
+    %229 = arith.divui %228, %c512_i64_117 : i64
+    %230 = arith.muli %217, %c3_i64_116 : i64
+    %231 = arith.addi %229, %230 : i64
+    %232 = arith.subi %231, %227 : i64
+    %233 = llvm.load %arg1 : !llvm.ptr -> i64
+    %234 = arith.cmpi ult, %233, %232 : i64
+    scf.if %234 {
     } else {
-      %380 = arith.subi %256, %255 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %233, %232 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_141 = arith.constant 80 : i8
-    cf.cond_br %257, ^bb1(%c80_i8_141 : i8), ^bb89
+    %c80_i8_118 = arith.constant 80 : i8
+    cf.cond_br %234, ^bb1(%c80_i8_118 : i8), ^bb89
   ^bb89:  // pred: ^bb88
-    %258 = call @dora_fn_extend_memory(%arg0, %241) : (!llvm.ptr, i64) -> !llvm.ptr
-    %259 = llvm.getelementptr %258[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %260 = llvm.load %259 : !llvm.ptr -> i8
-    %c0_i8_142 = arith.constant 0 : i8
-    %261 = arith.cmpi ne, %260, %c0_i8_142 : i8
-    cf.cond_br %261, ^bb1(%260 : i8), ^bb90
+    %235 = call @dora_fn_extend_memory(%arg0, %218) : (!llvm.ptr, i64) -> !llvm.ptr
+    %236 = llvm.getelementptr %235[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %237 = llvm.load %236 : !llvm.ptr -> i8
+    %c0_i8_119 = arith.constant 0 : i8
+    %238 = arith.cmpi ne, %237, %c0_i8_119 : i8
+    cf.cond_br %238, ^bb1(%237 : i8), ^bb90
   ^bb90:  // pred: ^bb89
     cf.br ^bb87
   ^bb91:  // pred: ^bb24
-    %c18446744073709551615_i256_143 = arith.constant 18446744073709551615 : i256
-    %262 = arith.cmpi sgt, %61, %c18446744073709551615_i256_143 : i256
-    %c84_i8_144 = arith.constant 84 : i8
-    cf.cond_br %262, ^bb1(%c84_i8_144 : i8), ^bb92
+    %c18446744073709551615_i256_120 = arith.constant 18446744073709551615 : i256
+    %239 = arith.cmpi sgt, %55, %c18446744073709551615_i256_120 : i256
+    %c84_i8_121 = arith.constant 84 : i8
+    cf.cond_br %239, ^bb1(%c84_i8_121 : i8), ^bb92
   ^bb92:  // pred: ^bb91
-    %263 = arith.trunci %61 : i256 to i64
-    %c0_i64_145 = arith.constant 0 : i64
-    %264 = arith.cmpi slt, %263, %c0_i64_145 : i64
-    %c84_i8_146 = arith.constant 84 : i8
-    cf.cond_br %264, ^bb1(%c84_i8_146 : i8), ^bb93
+    %240 = arith.trunci %55 : i256 to i64
+    %c0_i64_122 = arith.constant 0 : i64
+    %241 = arith.cmpi slt, %240, %c0_i64_122 : i64
+    %c84_i8_123 = arith.constant 84 : i8
+    cf.cond_br %241, ^bb1(%c84_i8_123 : i8), ^bb93
   ^bb93:  // pred: ^bb92
-    %265 = arith.addi %263, %c32_i64_28 : i64
-    %c0_i64_147 = arith.constant 0 : i64
-    %266 = arith.cmpi slt, %265, %c0_i64_147 : i64
-    %c84_i8_148 = arith.constant 84 : i8
-    cf.cond_br %266, ^bb1(%c84_i8_148 : i8), ^bb94
+    %242 = arith.addi %240, %c32_i64_21 : i64
+    %c0_i64_124 = arith.constant 0 : i64
+    %243 = arith.cmpi slt, %242, %c0_i64_124 : i64
+    %c84_i8_125 = arith.constant 84 : i8
+    cf.cond_br %243, ^bb1(%c84_i8_125 : i8), ^bb94
   ^bb94:  // pred: ^bb93
-    %c31_i64_149 = arith.constant 31 : i64
-    %c32_i64_150 = arith.constant 32 : i64
-    %267 = arith.addi %265, %c31_i64_149 : i64
-    %268 = arith.divui %267, %c32_i64_150 : i64
-    %c32_i64_151 = arith.constant 32 : i64
-    %269 = arith.muli %268, %c32_i64_151 : i64
-    %270 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_152 = arith.constant 31 : i64
-    %c32_i64_153 = arith.constant 32 : i64
-    %271 = arith.addi %270, %c31_i64_152 : i64
-    %272 = arith.divui %271, %c32_i64_153 : i64
-    %273 = arith.muli %272, %c32_i64_151 : i64
-    %274 = arith.cmpi ult, %273, %269 : i64
-    cf.cond_br %274, ^bb96, ^bb95
+    %c31_i64_126 = arith.constant 31 : i64
+    %c32_i64_127 = arith.constant 32 : i64
+    %244 = arith.addi %242, %c31_i64_126 : i64
+    %245 = arith.divui %244, %c32_i64_127 : i64
+    %c32_i64_128 = arith.constant 32 : i64
+    %246 = arith.muli %245, %c32_i64_128 : i64
+    %247 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_129 = arith.constant 31 : i64
+    %c32_i64_130 = arith.constant 32 : i64
+    %248 = arith.addi %247, %c31_i64_129 : i64
+    %249 = arith.divui %248, %c32_i64_130 : i64
+    %250 = arith.muli %249, %c32_i64_128 : i64
+    %251 = arith.cmpi ult, %250, %246 : i64
+    cf.cond_br %251, ^bb96, ^bb95
   ^bb95:  // 2 preds: ^bb94, ^bb98
     cf.br ^bb25
   ^bb96:  // pred: ^bb94
-    %c3_i64_154 = arith.constant 3 : i64
-    %c512_i64_155 = arith.constant 512 : i64
-    %275 = arith.muli %272, %272 : i64
-    %276 = arith.divui %275, %c512_i64_155 : i64
-    %277 = arith.muli %272, %c3_i64_154 : i64
-    %278 = arith.addi %276, %277 : i64
-    %c3_i64_156 = arith.constant 3 : i64
-    %c512_i64_157 = arith.constant 512 : i64
-    %279 = arith.muli %268, %268 : i64
-    %280 = arith.divui %279, %c512_i64_157 : i64
-    %281 = arith.muli %268, %c3_i64_156 : i64
-    %282 = arith.addi %280, %281 : i64
-    %283 = arith.subi %282, %278 : i64
-    %284 = llvm.load %arg1 : !llvm.ptr -> i64
-    %285 = arith.cmpi ult, %284, %283 : i64
-    scf.if %285 {
+    %c3_i64_131 = arith.constant 3 : i64
+    %c512_i64_132 = arith.constant 512 : i64
+    %252 = arith.muli %249, %249 : i64
+    %253 = arith.divui %252, %c512_i64_132 : i64
+    %254 = arith.muli %249, %c3_i64_131 : i64
+    %255 = arith.addi %253, %254 : i64
+    %c3_i64_133 = arith.constant 3 : i64
+    %c512_i64_134 = arith.constant 512 : i64
+    %256 = arith.muli %245, %245 : i64
+    %257 = arith.divui %256, %c512_i64_134 : i64
+    %258 = arith.muli %245, %c3_i64_133 : i64
+    %259 = arith.addi %257, %258 : i64
+    %260 = arith.subi %259, %255 : i64
+    %261 = llvm.load %arg1 : !llvm.ptr -> i64
+    %262 = arith.cmpi ult, %261, %260 : i64
+    scf.if %262 {
     } else {
-      %380 = arith.subi %284, %283 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %261, %260 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_158 = arith.constant 80 : i8
-    cf.cond_br %285, ^bb1(%c80_i8_158 : i8), ^bb97
+    %c80_i8_135 = arith.constant 80 : i8
+    cf.cond_br %262, ^bb1(%c80_i8_135 : i8), ^bb97
   ^bb97:  // pred: ^bb96
-    %286 = call @dora_fn_extend_memory(%arg0, %269) : (!llvm.ptr, i64) -> !llvm.ptr
-    %287 = llvm.getelementptr %286[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %288 = llvm.load %287 : !llvm.ptr -> i8
-    %c0_i8_159 = arith.constant 0 : i8
-    %289 = arith.cmpi ne, %288, %c0_i8_159 : i8
-    cf.cond_br %289, ^bb1(%288 : i8), ^bb98
+    %263 = call @dora_fn_extend_memory(%arg0, %246) : (!llvm.ptr, i64) -> !llvm.ptr
+    %264 = llvm.getelementptr %263[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %265 = llvm.load %264 : !llvm.ptr -> i8
+    %c0_i8_136 = arith.constant 0 : i8
+    %266 = arith.cmpi ne, %265, %c0_i8_136 : i8
+    cf.cond_br %266, ^bb1(%265 : i8), ^bb98
   ^bb98:  // pred: ^bb97
     cf.br ^bb95
   ^bb99:  // pred: ^bb44
     %c49152_i64 = arith.constant 49152 : i64
-    %290 = arith.cmpi ugt, %119, %c49152_i64 : i64
+    %267 = arith.cmpi ugt, %106, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %290, ^bb1(%c100_i8 : i8), ^bb100
+    cf.cond_br %267, ^bb1(%c100_i8 : i8), ^bb100
   ^bb100:  // pred: ^bb99
-    %c31_i64_160 = arith.constant 31 : i64
-    %c32_i64_161 = arith.constant 32 : i64
-    %291 = arith.addi %119, %c31_i64_160 : i64
-    %292 = arith.divui %291, %c32_i64_161 : i64
-    %c2_i64_162 = arith.constant 2 : i64
-    %293 = arith.muli %292, %c2_i64_162 : i64
-    %294 = llvm.load %arg1 : !llvm.ptr -> i64
-    %295 = arith.cmpi ult, %294, %293 : i64
-    scf.if %295 {
+    %c31_i64_137 = arith.constant 31 : i64
+    %c32_i64_138 = arith.constant 32 : i64
+    %268 = arith.addi %106, %c31_i64_137 : i64
+    %269 = arith.divui %268, %c32_i64_138 : i64
+    %c2_i64_139 = arith.constant 2 : i64
+    %270 = arith.muli %269, %c2_i64_139 : i64
+    %271 = llvm.load %arg1 : !llvm.ptr -> i64
+    %272 = arith.cmpi ult, %271, %270 : i64
+    scf.if %272 {
     } else {
-      %380 = arith.subi %294, %293 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %271, %270 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_163 = arith.constant 80 : i8
-    cf.cond_br %295, ^bb1(%c80_i8_163 : i8), ^bb101
+    %c80_i8_140 = arith.constant 80 : i8
+    cf.cond_br %272, ^bb1(%c80_i8_140 : i8), ^bb101
   ^bb101:  // pred: ^bb100
-    %c18446744073709551615_i256_164 = arith.constant 18446744073709551615 : i256
-    %296 = arith.cmpi sgt, %111, %c18446744073709551615_i256_164 : i256
-    %c84_i8_165 = arith.constant 84 : i8
-    cf.cond_br %296, ^bb1(%c84_i8_165 : i8), ^bb102
+    %c18446744073709551615_i256_141 = arith.constant 18446744073709551615 : i256
+    %273 = arith.cmpi sgt, %99, %c18446744073709551615_i256_141 : i256
+    %c84_i8_142 = arith.constant 84 : i8
+    cf.cond_br %273, ^bb1(%c84_i8_142 : i8), ^bb102
   ^bb102:  // pred: ^bb101
-    %297 = arith.trunci %111 : i256 to i64
-    %c0_i64_166 = arith.constant 0 : i64
-    %298 = arith.cmpi slt, %297, %c0_i64_166 : i64
-    %c84_i8_167 = arith.constant 84 : i8
-    cf.cond_br %298, ^bb1(%c84_i8_167 : i8), ^bb103
+    %274 = arith.trunci %99 : i256 to i64
+    %c0_i64_143 = arith.constant 0 : i64
+    %275 = arith.cmpi slt, %274, %c0_i64_143 : i64
+    %c84_i8_144 = arith.constant 84 : i8
+    cf.cond_br %275, ^bb1(%c84_i8_144 : i8), ^bb103
   ^bb103:  // pred: ^bb102
-    %299 = arith.addi %297, %119 : i64
-    %c0_i64_168 = arith.constant 0 : i64
-    %300 = arith.cmpi slt, %299, %c0_i64_168 : i64
-    %c84_i8_169 = arith.constant 84 : i8
-    cf.cond_br %300, ^bb1(%c84_i8_169 : i8), ^bb104
+    %276 = arith.addi %274, %106 : i64
+    %c0_i64_145 = arith.constant 0 : i64
+    %277 = arith.cmpi slt, %276, %c0_i64_145 : i64
+    %c84_i8_146 = arith.constant 84 : i8
+    cf.cond_br %277, ^bb1(%c84_i8_146 : i8), ^bb104
   ^bb104:  // pred: ^bb103
-    %c31_i64_170 = arith.constant 31 : i64
-    %c32_i64_171 = arith.constant 32 : i64
-    %301 = arith.addi %299, %c31_i64_170 : i64
-    %302 = arith.divui %301, %c32_i64_171 : i64
-    %c32_i64_172 = arith.constant 32 : i64
-    %303 = arith.muli %302, %c32_i64_172 : i64
-    %304 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_173 = arith.constant 31 : i64
-    %c32_i64_174 = arith.constant 32 : i64
-    %305 = arith.addi %304, %c31_i64_173 : i64
-    %306 = arith.divui %305, %c32_i64_174 : i64
-    %307 = arith.muli %306, %c32_i64_172 : i64
-    %308 = arith.cmpi ult, %307, %303 : i64
-    cf.cond_br %308, ^bb106, ^bb105
+    %c31_i64_147 = arith.constant 31 : i64
+    %c32_i64_148 = arith.constant 32 : i64
+    %278 = arith.addi %276, %c31_i64_147 : i64
+    %279 = arith.divui %278, %c32_i64_148 : i64
+    %c32_i64_149 = arith.constant 32 : i64
+    %280 = arith.muli %279, %c32_i64_149 : i64
+    %281 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_150 = arith.constant 31 : i64
+    %c32_i64_151 = arith.constant 32 : i64
+    %282 = arith.addi %281, %c31_i64_150 : i64
+    %283 = arith.divui %282, %c32_i64_151 : i64
+    %284 = arith.muli %283, %c32_i64_149 : i64
+    %285 = arith.cmpi ult, %284, %280 : i64
+    cf.cond_br %285, ^bb106, ^bb105
   ^bb105:  // 2 preds: ^bb104, ^bb108
     cf.br ^bb45
   ^bb106:  // pred: ^bb104
-    %c3_i64_175 = arith.constant 3 : i64
-    %c512_i64_176 = arith.constant 512 : i64
-    %309 = arith.muli %306, %306 : i64
-    %310 = arith.divui %309, %c512_i64_176 : i64
-    %311 = arith.muli %306, %c3_i64_175 : i64
-    %312 = arith.addi %310, %311 : i64
-    %c3_i64_177 = arith.constant 3 : i64
-    %c512_i64_178 = arith.constant 512 : i64
-    %313 = arith.muli %302, %302 : i64
-    %314 = arith.divui %313, %c512_i64_178 : i64
-    %315 = arith.muli %302, %c3_i64_177 : i64
-    %316 = arith.addi %314, %315 : i64
-    %317 = arith.subi %316, %312 : i64
-    %318 = llvm.load %arg1 : !llvm.ptr -> i64
-    %319 = arith.cmpi ult, %318, %317 : i64
-    scf.if %319 {
+    %c3_i64_152 = arith.constant 3 : i64
+    %c512_i64_153 = arith.constant 512 : i64
+    %286 = arith.muli %283, %283 : i64
+    %287 = arith.divui %286, %c512_i64_153 : i64
+    %288 = arith.muli %283, %c3_i64_152 : i64
+    %289 = arith.addi %287, %288 : i64
+    %c3_i64_154 = arith.constant 3 : i64
+    %c512_i64_155 = arith.constant 512 : i64
+    %290 = arith.muli %279, %279 : i64
+    %291 = arith.divui %290, %c512_i64_155 : i64
+    %292 = arith.muli %279, %c3_i64_154 : i64
+    %293 = arith.addi %291, %292 : i64
+    %294 = arith.subi %293, %289 : i64
+    %295 = llvm.load %arg1 : !llvm.ptr -> i64
+    %296 = arith.cmpi ult, %295, %294 : i64
+    scf.if %296 {
     } else {
-      %380 = arith.subi %318, %317 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %295, %294 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_179 = arith.constant 80 : i8
-    cf.cond_br %319, ^bb1(%c80_i8_179 : i8), ^bb107
+    %c80_i8_156 = arith.constant 80 : i8
+    cf.cond_br %296, ^bb1(%c80_i8_156 : i8), ^bb107
   ^bb107:  // pred: ^bb106
-    %320 = call @dora_fn_extend_memory(%arg0, %303) : (!llvm.ptr, i64) -> !llvm.ptr
-    %321 = llvm.getelementptr %320[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %322 = llvm.load %321 : !llvm.ptr -> i8
-    %c0_i8_180 = arith.constant 0 : i8
-    %323 = arith.cmpi ne, %322, %c0_i8_180 : i8
-    cf.cond_br %323, ^bb1(%322 : i8), ^bb108
+    %297 = call @dora_fn_extend_memory(%arg0, %280) : (!llvm.ptr, i64) -> !llvm.ptr
+    %298 = llvm.getelementptr %297[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %299 = llvm.load %298 : !llvm.ptr -> i8
+    %c0_i8_157 = arith.constant 0 : i8
+    %300 = arith.cmpi ne, %299, %c0_i8_157 : i8
+    cf.cond_br %300, ^bb1(%299 : i8), ^bb108
   ^bb108:  // pred: ^bb107
     cf.br ^bb105
   ^bb109:  // pred: ^bb61
-    %c18446744073709551615_i256_181 = arith.constant 18446744073709551615 : i256
-    %324 = arith.cmpi sgt, %179, %c18446744073709551615_i256_181 : i256
-    %c84_i8_182 = arith.constant 84 : i8
-    cf.cond_br %324, ^bb1(%c84_i8_182 : i8), ^bb110
+    %c18446744073709551615_i256_158 = arith.constant 18446744073709551615 : i256
+    %301 = arith.cmpi sgt, %161, %c18446744073709551615_i256_158 : i256
+    %c84_i8_159 = arith.constant 84 : i8
+    cf.cond_br %301, ^bb1(%c84_i8_159 : i8), ^bb110
   ^bb110:  // pred: ^bb109
-    %325 = arith.trunci %179 : i256 to i64
-    %c0_i64_183 = arith.constant 0 : i64
-    %326 = arith.cmpi slt, %325, %c0_i64_183 : i64
-    %c84_i8_184 = arith.constant 84 : i8
-    cf.cond_br %326, ^bb1(%c84_i8_184 : i8), ^bb111
+    %302 = arith.trunci %161 : i256 to i64
+    %c0_i64_160 = arith.constant 0 : i64
+    %303 = arith.cmpi slt, %302, %c0_i64_160 : i64
+    %c84_i8_161 = arith.constant 84 : i8
+    cf.cond_br %303, ^bb1(%c84_i8_161 : i8), ^bb111
   ^bb111:  // pred: ^bb110
-    %327 = arith.addi %325, %c32_i64_91 : i64
-    %c0_i64_185 = arith.constant 0 : i64
-    %328 = arith.cmpi slt, %327, %c0_i64_185 : i64
-    %c84_i8_186 = arith.constant 84 : i8
-    cf.cond_br %328, ^bb1(%c84_i8_186 : i8), ^bb112
+    %304 = arith.addi %302, %c32_i64_72 : i64
+    %c0_i64_162 = arith.constant 0 : i64
+    %305 = arith.cmpi slt, %304, %c0_i64_162 : i64
+    %c84_i8_163 = arith.constant 84 : i8
+    cf.cond_br %305, ^bb1(%c84_i8_163 : i8), ^bb112
   ^bb112:  // pred: ^bb111
-    %c31_i64_187 = arith.constant 31 : i64
-    %c32_i64_188 = arith.constant 32 : i64
-    %329 = arith.addi %327, %c31_i64_187 : i64
-    %330 = arith.divui %329, %c32_i64_188 : i64
-    %c32_i64_189 = arith.constant 32 : i64
-    %331 = arith.muli %330, %c32_i64_189 : i64
-    %332 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_190 = arith.constant 31 : i64
-    %c32_i64_191 = arith.constant 32 : i64
-    %333 = arith.addi %332, %c31_i64_190 : i64
-    %334 = arith.divui %333, %c32_i64_191 : i64
-    %335 = arith.muli %334, %c32_i64_189 : i64
-    %336 = arith.cmpi ult, %335, %331 : i64
-    cf.cond_br %336, ^bb114, ^bb113
+    %c31_i64_164 = arith.constant 31 : i64
+    %c32_i64_165 = arith.constant 32 : i64
+    %306 = arith.addi %304, %c31_i64_164 : i64
+    %307 = arith.divui %306, %c32_i64_165 : i64
+    %c32_i64_166 = arith.constant 32 : i64
+    %308 = arith.muli %307, %c32_i64_166 : i64
+    %309 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_167 = arith.constant 31 : i64
+    %c32_i64_168 = arith.constant 32 : i64
+    %310 = arith.addi %309, %c31_i64_167 : i64
+    %311 = arith.divui %310, %c32_i64_168 : i64
+    %312 = arith.muli %311, %c32_i64_166 : i64
+    %313 = arith.cmpi ult, %312, %308 : i64
+    cf.cond_br %313, ^bb114, ^bb113
   ^bb113:  // 2 preds: ^bb112, ^bb116
     cf.br ^bb62
   ^bb114:  // pred: ^bb112
-    %c3_i64_192 = arith.constant 3 : i64
-    %c512_i64_193 = arith.constant 512 : i64
-    %337 = arith.muli %334, %334 : i64
-    %338 = arith.divui %337, %c512_i64_193 : i64
-    %339 = arith.muli %334, %c3_i64_192 : i64
-    %340 = arith.addi %338, %339 : i64
-    %c3_i64_194 = arith.constant 3 : i64
-    %c512_i64_195 = arith.constant 512 : i64
-    %341 = arith.muli %330, %330 : i64
-    %342 = arith.divui %341, %c512_i64_195 : i64
-    %343 = arith.muli %330, %c3_i64_194 : i64
-    %344 = arith.addi %342, %343 : i64
-    %345 = arith.subi %344, %340 : i64
-    %346 = llvm.load %arg1 : !llvm.ptr -> i64
-    %347 = arith.cmpi ult, %346, %345 : i64
-    scf.if %347 {
+    %c3_i64_169 = arith.constant 3 : i64
+    %c512_i64_170 = arith.constant 512 : i64
+    %314 = arith.muli %311, %311 : i64
+    %315 = arith.divui %314, %c512_i64_170 : i64
+    %316 = arith.muli %311, %c3_i64_169 : i64
+    %317 = arith.addi %315, %316 : i64
+    %c3_i64_171 = arith.constant 3 : i64
+    %c512_i64_172 = arith.constant 512 : i64
+    %318 = arith.muli %307, %307 : i64
+    %319 = arith.divui %318, %c512_i64_172 : i64
+    %320 = arith.muli %307, %c3_i64_171 : i64
+    %321 = arith.addi %319, %320 : i64
+    %322 = arith.subi %321, %317 : i64
+    %323 = llvm.load %arg1 : !llvm.ptr -> i64
+    %324 = arith.cmpi ult, %323, %322 : i64
+    scf.if %324 {
     } else {
-      %380 = arith.subi %346, %345 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %323, %322 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_196 = arith.constant 80 : i8
-    cf.cond_br %347, ^bb1(%c80_i8_196 : i8), ^bb115
+    %c80_i8_173 = arith.constant 80 : i8
+    cf.cond_br %324, ^bb1(%c80_i8_173 : i8), ^bb115
   ^bb115:  // pred: ^bb114
-    %348 = call @dora_fn_extend_memory(%arg0, %331) : (!llvm.ptr, i64) -> !llvm.ptr
-    %349 = llvm.getelementptr %348[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %350 = llvm.load %349 : !llvm.ptr -> i8
-    %c0_i8_197 = arith.constant 0 : i8
-    %351 = arith.cmpi ne, %350, %c0_i8_197 : i8
-    cf.cond_br %351, ^bb1(%350 : i8), ^bb116
+    %325 = call @dora_fn_extend_memory(%arg0, %308) : (!llvm.ptr, i64) -> !llvm.ptr
+    %326 = llvm.getelementptr %325[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %327 = llvm.load %326 : !llvm.ptr -> i8
+    %c0_i8_174 = arith.constant 0 : i8
+    %328 = arith.cmpi ne, %327, %c0_i8_174 : i8
+    cf.cond_br %328, ^bb1(%327 : i8), ^bb116
   ^bb116:  // pred: ^bb115
     cf.br ^bb113
   ^bb117:  // pred: ^bb76
-    %c18446744073709551615_i256_198 = arith.constant 18446744073709551615 : i256
-    %352 = arith.cmpi sgt, %216, %c18446744073709551615_i256_198 : i256
-    %c84_i8_199 = arith.constant 84 : i8
-    cf.cond_br %352, ^bb1(%c84_i8_199 : i8), ^bb118
+    %c18446744073709551615_i256_175 = arith.constant 18446744073709551615 : i256
+    %329 = arith.cmpi sgt, %194, %c18446744073709551615_i256_175 : i256
+    %c84_i8_176 = arith.constant 84 : i8
+    cf.cond_br %329, ^bb1(%c84_i8_176 : i8), ^bb118
   ^bb118:  // pred: ^bb117
-    %353 = arith.trunci %216 : i256 to i64
-    %c0_i64_200 = arith.constant 0 : i64
-    %354 = arith.cmpi slt, %353, %c0_i64_200 : i64
-    %c84_i8_201 = arith.constant 84 : i8
-    cf.cond_br %354, ^bb1(%c84_i8_201 : i8), ^bb119
+    %330 = arith.trunci %194 : i256 to i64
+    %c0_i64_177 = arith.constant 0 : i64
+    %331 = arith.cmpi slt, %330, %c0_i64_177 : i64
+    %c84_i8_178 = arith.constant 84 : i8
+    cf.cond_br %331, ^bb1(%c84_i8_178 : i8), ^bb119
   ^bb119:  // pred: ^bb118
-    %355 = arith.addi %353, %222 : i64
-    %c0_i64_202 = arith.constant 0 : i64
-    %356 = arith.cmpi slt, %355, %c0_i64_202 : i64
-    %c84_i8_203 = arith.constant 84 : i8
-    cf.cond_br %356, ^bb1(%c84_i8_203 : i8), ^bb120
+    %332 = arith.addi %330, %199 : i64
+    %c0_i64_179 = arith.constant 0 : i64
+    %333 = arith.cmpi slt, %332, %c0_i64_179 : i64
+    %c84_i8_180 = arith.constant 84 : i8
+    cf.cond_br %333, ^bb1(%c84_i8_180 : i8), ^bb120
   ^bb120:  // pred: ^bb119
-    %c31_i64_204 = arith.constant 31 : i64
-    %c32_i64_205 = arith.constant 32 : i64
-    %357 = arith.addi %355, %c31_i64_204 : i64
-    %358 = arith.divui %357, %c32_i64_205 : i64
-    %c32_i64_206 = arith.constant 32 : i64
-    %359 = arith.muli %358, %c32_i64_206 : i64
-    %360 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_207 = arith.constant 31 : i64
-    %c32_i64_208 = arith.constant 32 : i64
-    %361 = arith.addi %360, %c31_i64_207 : i64
-    %362 = arith.divui %361, %c32_i64_208 : i64
-    %363 = arith.muli %362, %c32_i64_206 : i64
-    %364 = arith.cmpi ult, %363, %359 : i64
-    cf.cond_br %364, ^bb122, ^bb121
+    %c31_i64_181 = arith.constant 31 : i64
+    %c32_i64_182 = arith.constant 32 : i64
+    %334 = arith.addi %332, %c31_i64_181 : i64
+    %335 = arith.divui %334, %c32_i64_182 : i64
+    %c32_i64_183 = arith.constant 32 : i64
+    %336 = arith.muli %335, %c32_i64_183 : i64
+    %337 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_184 = arith.constant 31 : i64
+    %c32_i64_185 = arith.constant 32 : i64
+    %338 = arith.addi %337, %c31_i64_184 : i64
+    %339 = arith.divui %338, %c32_i64_185 : i64
+    %340 = arith.muli %339, %c32_i64_183 : i64
+    %341 = arith.cmpi ult, %340, %336 : i64
+    cf.cond_br %341, ^bb122, ^bb121
   ^bb121:  // 2 preds: ^bb120, ^bb124
     cf.br ^bb77
   ^bb122:  // pred: ^bb120
-    %c3_i64_209 = arith.constant 3 : i64
-    %c512_i64_210 = arith.constant 512 : i64
-    %365 = arith.muli %362, %362 : i64
-    %366 = arith.divui %365, %c512_i64_210 : i64
-    %367 = arith.muli %362, %c3_i64_209 : i64
-    %368 = arith.addi %366, %367 : i64
-    %c3_i64_211 = arith.constant 3 : i64
-    %c512_i64_212 = arith.constant 512 : i64
-    %369 = arith.muli %358, %358 : i64
-    %370 = arith.divui %369, %c512_i64_212 : i64
-    %371 = arith.muli %358, %c3_i64_211 : i64
-    %372 = arith.addi %370, %371 : i64
-    %373 = arith.subi %372, %368 : i64
-    %374 = llvm.load %arg1 : !llvm.ptr -> i64
-    %375 = arith.cmpi ult, %374, %373 : i64
-    scf.if %375 {
+    %c3_i64_186 = arith.constant 3 : i64
+    %c512_i64_187 = arith.constant 512 : i64
+    %342 = arith.muli %339, %339 : i64
+    %343 = arith.divui %342, %c512_i64_187 : i64
+    %344 = arith.muli %339, %c3_i64_186 : i64
+    %345 = arith.addi %343, %344 : i64
+    %c3_i64_188 = arith.constant 3 : i64
+    %c512_i64_189 = arith.constant 512 : i64
+    %346 = arith.muli %335, %335 : i64
+    %347 = arith.divui %346, %c512_i64_189 : i64
+    %348 = arith.muli %335, %c3_i64_188 : i64
+    %349 = arith.addi %347, %348 : i64
+    %350 = arith.subi %349, %345 : i64
+    %351 = llvm.load %arg1 : !llvm.ptr -> i64
+    %352 = arith.cmpi ult, %351, %350 : i64
+    scf.if %352 {
     } else {
-      %380 = arith.subi %374, %373 : i64
-      llvm.store %380, %arg1 : i64, !llvm.ptr
+      %357 = arith.subi %351, %350 : i64
+      llvm.store %357, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_213 = arith.constant 80 : i8
-    cf.cond_br %375, ^bb1(%c80_i8_213 : i8), ^bb123
+    %c80_i8_190 = arith.constant 80 : i8
+    cf.cond_br %352, ^bb1(%c80_i8_190 : i8), ^bb123
   ^bb123:  // pred: ^bb122
-    %376 = call @dora_fn_extend_memory(%arg0, %359) : (!llvm.ptr, i64) -> !llvm.ptr
-    %377 = llvm.getelementptr %376[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %378 = llvm.load %377 : !llvm.ptr -> i8
-    %c0_i8_214 = arith.constant 0 : i8
-    %379 = arith.cmpi ne, %378, %c0_i8_214 : i8
-    cf.cond_br %379, ^bb1(%378 : i8), ^bb124
+    %353 = call @dora_fn_extend_memory(%arg0, %336) : (!llvm.ptr, i64) -> !llvm.ptr
+    %354 = llvm.getelementptr %353[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %355 = llvm.load %354 : !llvm.ptr -> i8
+    %c0_i8_191 = arith.constant 0 : i8
+    %356 = arith.cmpi ne, %355, %c0_i8_191 : i8
+    cf.cond_br %356, ^bb1(%355 : i8), ^bb124
   ^bb124:  // pred: ^bb123
     cf.br ^bb121
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c3735928559_i256 = arith.constant 3735928559 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c3735928559_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,61 +95,58 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    %17 = call @dora_fn_ext_code_hash(%arg0, %16) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %18 = llvm.getelementptr %17[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %19 = llvm.load %18 : !llvm.ptr -> i64
-    %20 = llvm.load %arg1 : !llvm.ptr -> i64
-    %21 = arith.cmpi ult, %20, %19 : i64
-    scf.if %21 {
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    %16 = call @dora_fn_ext_code_hash(%arg0, %15) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %17 = llvm.getelementptr %16[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %18 = llvm.load %17 : !llvm.ptr -> i64
+    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %20 = arith.cmpi ult, %19, %18 : i64
+    scf.if %20 {
     } else {
-      %33 = arith.subi %20, %19 : i64
-      llvm.store %33, %arg1 : i64, !llvm.ptr
+      %31 = arith.subi %19, %18 : i64
+      llvm.store %31, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %21, ^bb1(%c80_i8_2 : i8), ^bb8
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %20, ^bb1(%c80_i8_1 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %22 = llvm.load %16 : !llvm.ptr -> i256
-    %23 = llvm.load %arg3 : !llvm.ptr -> i64
-    %24 = llvm.getelementptr %arg2[%23] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %25 = arith.addi %23, %c1_i64_3 : i64
-    llvm.store %25, %arg3 : i64, !llvm.ptr
-    llvm.store %22, %24 : i256, !llvm.ptr
+    %21 = llvm.load %15 : !llvm.ptr -> i256
+    %22 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %21, %22 : i256, !llvm.ptr
+    %23 = llvm.getelementptr %22[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %23, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %26 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %27 = arith.addi %26, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %28 = arith.cmpi ult, %26, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %24 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %25 = arith.addi %24, %c0_i64_3 : i64
+    llvm.store %25, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %26 = arith.cmpi ult, %24, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %28, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %26, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %29 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_7 = arith.constant 0 : i64
+    %27 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %30 = arith.cmpi uge, %29, %c0_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %30, ^bb11, ^bb1(%c80_i8_8 : i8)
+    %28 = arith.cmpi uge, %27, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %28, ^bb11, ^bb1(%c80_i8_6 : i8)
   ^bb11:  // pred: ^bb10
-    %31 = arith.subi %29, %c0_i64_7 : i64
-    llvm.store %31, %arg1 : i64, !llvm.ptr
+    %29 = arith.subi %27, %c0_i64_5 : i64
+    llvm.store %29, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %32 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %32, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %30, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_nonexistent.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__extcodehash_nonexistent.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,61 +95,58 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    %17 = call @dora_fn_ext_code_hash(%arg0, %16) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %18 = llvm.getelementptr %17[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %19 = llvm.load %18 : !llvm.ptr -> i64
-    %20 = llvm.load %arg1 : !llvm.ptr -> i64
-    %21 = arith.cmpi ult, %20, %19 : i64
-    scf.if %21 {
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    %16 = call @dora_fn_ext_code_hash(%arg0, %15) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %17 = llvm.getelementptr %16[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %18 = llvm.load %17 : !llvm.ptr -> i64
+    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %20 = arith.cmpi ult, %19, %18 : i64
+    scf.if %20 {
     } else {
-      %33 = arith.subi %20, %19 : i64
-      llvm.store %33, %arg1 : i64, !llvm.ptr
+      %31 = arith.subi %19, %18 : i64
+      llvm.store %31, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %21, ^bb1(%c80_i8_2 : i8), ^bb8
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %20, ^bb1(%c80_i8_1 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %22 = llvm.load %16 : !llvm.ptr -> i256
-    %23 = llvm.load %arg3 : !llvm.ptr -> i64
-    %24 = llvm.getelementptr %arg2[%23] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %25 = arith.addi %23, %c1_i64_3 : i64
-    llvm.store %25, %arg3 : i64, !llvm.ptr
-    llvm.store %22, %24 : i256, !llvm.ptr
+    %21 = llvm.load %15 : !llvm.ptr -> i256
+    %22 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %21, %22 : i256, !llvm.ptr
+    %23 = llvm.getelementptr %22[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %23, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %26 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %27 = arith.addi %26, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %28 = arith.cmpi ult, %26, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %24 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %25 = arith.addi %24, %c0_i64_3 : i64
+    llvm.store %25, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %26 = arith.cmpi ult, %24, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %28, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %26, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %29 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_7 = arith.constant 0 : i64
+    %27 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %30 = arith.cmpi uge, %29, %c0_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %30, ^bb11, ^bb1(%c80_i8_8 : i8)
+    %28 = arith.cmpi uge, %27, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %28, ^bb11, ^bb1(%c80_i8_6 : i8)
   ^bb11:  // pred: ^bb10
-    %31 = arith.subi %29, %c0_i64_7 : i64
-    llvm.store %31, %arg1 : i64, !llvm.ptr
+    %29 = arith.subi %27, %c0_i64_5 : i64
+    llvm.store %29, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %32 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %32, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %30, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__gasprice.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__gasprice.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_store_in_gasprice_ptr(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_store_in_gasprice_ptr(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__invalid.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__invalid.snap
@@ -53,15 +53,18 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb6
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb3, ^bb6
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb6
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb3, ^bb6
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb5
@@ -71,26 +74,27 @@ module {
     cf.br ^bb8
   ^bb5:  // pred: ^bb7
     %c1024_i64 = arith.constant 1024 : i64
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_0 = arith.constant 0 : i64
-    %4 = arith.addi %3, %c0_i64_0 : i64
+    %4 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_1 = arith.constant 0 : i64
+    %5 = arith.addi %4, %c0_i64_1 : i64
+    llvm.store %5, %arg3 : i64, !llvm.ptr
     cf.br ^bb3
   ^bb6:  // pred: ^bb0
-    %5 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_1 = arith.constant 0 : i64
+    %6 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %6 = arith.cmpi uge, %5, %c0_i64_1 : i64
+    %7 = arith.cmpi uge, %6, %c0_i64_2 : i64
     %c80_i8 = arith.constant 80 : i8
-    cf.cond_br %6, ^bb7, ^bb1(%c80_i8 : i8)
+    cf.cond_br %7, ^bb7, ^bb1(%c80_i8 : i8)
   ^bb7:  // pred: ^bb6
-    %7 = arith.subi %5, %c0_i64_1 : i64
-    llvm.store %7, %arg1 : i64, !llvm.ptr
+    %8 = arith.subi %6, %c0_i64_2 : i64
+    llvm.store %8, %arg1 : i64, !llvm.ptr
     cf.br ^bb5
   ^bb8:  // pred: ^bb4
-    %c0_i64_2 = arith.constant 0 : i64
+    %c0_i64_3 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %8 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_2, %c0_i64_2, %8, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %9 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %9, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_basic.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb18, ^bb21, ^bb22
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb18, ^bb21, ^bb22
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       6: ^bb18
     ]
   ^bb3:  // pred: ^bb4
     %c6_i256 = arith.constant 6 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c6_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,115 +96,113 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb14
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb13
     %c99_i256 = arith.constant 99 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_5 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c99_i256, %23 : i256, !llvm.ptr
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c99_i256, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_6 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_7 : i64
-    %27 = arith.cmpi ult, %c1024_i64_6, %26 : i64
-    %c92_i8_8 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_8 : i8), ^bb12
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_5 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_5 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_4, %24 : i64
+    %c92_i8_6 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_6 : i8), ^bb12
   ^bb14:  // pred: ^bb8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c3_i64_9 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_7 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %32 = arith.addi %31, %c0_i64_12 : i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
+    %30 = arith.addi %29, %c0_i64_10 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb18:  // 2 preds: ^bb2, ^bb12
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c1_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb19, ^bb1(%c80_i8_14 : i8)
+    %32 = arith.cmpi uge, %31, %c1_i64_11 : i64
+    %c80_i8_12 = arith.constant 80 : i8
+    cf.cond_br %32, ^bb19, ^bb1(%c80_i8_12 : i8)
   ^bb19:  // pred: ^bb18
-    %35 = arith.subi %33, %c1_i64_13 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %33 = arith.subi %31, %c1_i64_11 : i64
+    llvm.store %33, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c42_i256 = arith.constant 42 : i256
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %37 = llvm.getelementptr %arg2[%36] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %38 = arith.addi %36, %c1_i64_15 : i64
-    llvm.store %38, %arg3 : i64, !llvm.ptr
-    llvm.store %c42_i256, %37 : i256, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c42_i256, %34 : i256, !llvm.ptr
+    %35 = llvm.getelementptr %34[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %40 = arith.addi %39, %c1_i64_17 : i64
-    %41 = arith.cmpi ult, %c1024_i64_16, %40 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %41, ^bb1(%c92_i8_18 : i8), ^bb20
+    %c1024_i64_13 = arith.constant 1024 : i64
+    %36 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_14 = arith.constant 1 : i64
+    %37 = arith.addi %36, %c1_i64_14 : i64
+    llvm.store %37, %arg3 : i64, !llvm.ptr
+    %38 = arith.cmpi ult, %c1024_i64_13, %37 : i64
+    %c92_i8_15 = arith.constant 92 : i8
+    cf.cond_br %38, ^bb1(%c92_i8_15 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_16 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb23, ^bb1(%c80_i8_20 : i8)
+    %40 = arith.cmpi uge, %39, %c3_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb23, ^bb1(%c80_i8_17 : i8)
   ^bb23:  // pred: ^bb22
-    %44 = arith.subi %42, %c3_i64_19 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c3_i64_16 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_21 = arith.constant 0 : i64
+    %c0_i64_18 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %45, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_18, %c0_i64_18, %42, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,40 +95,39 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_5 = arith.constant 0 : i64
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %22, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %21, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_invalid_jumpdest.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb11
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb11
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,67 +96,65 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c99_i256 = arith.constant 99 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c99_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c99_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    cf.br ^bb2(%24 : i256)
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%22 : i256)
   ^bb12:  // no predecessors
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %26 = arith.addi %25, %c-1_i64 : i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %27 = arith.cmpi ult, %25, %c1_i64_9 : i64
+    %24 = arith.addi %23, %c-1_i64 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %c1_i64_7 = arith.constant 1 : i64
+    %25 = arith.cmpi ult, %23, %c1_i64_7 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %25, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c8_i64 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c8_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c8_i64 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c8_i64 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_11 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %29, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_multiple_destinations.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_multiple_destinations.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       8: ^bb22
     ]
   ^bb3:  // pred: ^bb4
     %c8_i256 = arith.constant 8 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c8_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,143 +96,140 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb14
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb13
     %c10_i256 = arith.constant 10 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_5 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %23 : i256, !llvm.ptr
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_6 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_7 : i64
-    %27 = arith.cmpi ult, %c1024_i64_6, %26 : i64
-    %c92_i8_8 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_8 : i8), ^bb12
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_5 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_5 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_4, %24 : i64
+    %c92_i8_6 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_6 : i8), ^bb12
   ^bb14:  // pred: ^bb8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c3_i64_9 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_7 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c20_i256 = arith.constant 20 : i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_11 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_11 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %32 : i256, !llvm.ptr
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %35 = arith.addi %34, %c1_i64_13 : i64
-    %36 = arith.cmpi ult, %c1024_i64_12, %35 : i64
-    %c92_i8_14 = arith.constant 92 : i8
-    cf.cond_br %36, ^bb1(%c92_i8_14 : i8), ^bb16
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_10 = arith.constant 1 : i64
+    %32 = arith.addi %31, %c1_i64_10 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
+    %33 = arith.cmpi ult, %c1024_i64_9, %32 : i64
+    %c92_i8_11 = arith.constant 92 : i8
+    cf.cond_br %33, ^bb1(%c92_i8_11 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_15 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_15 : i64
-    %c80_i8_16 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb19, ^bb1(%c80_i8_16 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb19, ^bb1(%c80_i8_13 : i8)
   ^bb19:  // pred: ^bb18
-    %39 = arith.subi %37, %c3_i64_15 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_12 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_17 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %41 = arith.addi %40, %c0_i64_18 : i64
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %38 = arith.addi %37, %c0_i64_15 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb22:  // 2 preds: ^bb2, ^bb16
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c1_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb23, ^bb1(%c80_i8_20 : i8)
+    %40 = arith.cmpi uge, %39, %c1_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb23, ^bb1(%c80_i8_17 : i8)
   ^bb23:  // pred: ^bb22
-    %44 = arith.subi %42, %c1_i64_19 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c1_i64_16 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
     %c50_i256 = arith.constant 50 : i256
-    %45 = llvm.load %arg3 : !llvm.ptr -> i64
-    %46 = llvm.getelementptr %arg2[%45] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %47 = arith.addi %45, %c1_i64_21 : i64
-    llvm.store %47, %arg3 : i64, !llvm.ptr
-    llvm.store %c50_i256, %46 : i256, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c50_i256, %42 : i256, !llvm.ptr
+    %43 = llvm.getelementptr %42[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %49 = arith.addi %48, %c1_i64_23 : i64
-    %50 = arith.cmpi ult, %c1024_i64_22, %49 : i64
-    %c92_i8_24 = arith.constant 92 : i8
-    cf.cond_br %50, ^bb1(%c92_i8_24 : i8), ^bb24
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %44 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_19 = arith.constant 1 : i64
+    %45 = arith.addi %44, %c1_i64_19 : i64
+    llvm.store %45, %arg3 : i64, !llvm.ptr
+    %46 = arith.cmpi ult, %c1024_i64_18, %45 : i64
+    %c92_i8_20 = arith.constant 92 : i8
+    cf.cond_br %46, ^bb1(%c92_i8_20 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_25 = arith.constant 3 : i64
+    %47 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_21 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb27, ^bb1(%c80_i8_26 : i8)
+    %48 = arith.cmpi uge, %47, %c3_i64_21 : i64
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %48, ^bb27, ^bb1(%c80_i8_22 : i8)
   ^bb27:  // pred: ^bb26
-    %53 = arith.subi %51, %c3_i64_25 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %49 = arith.subi %47, %c3_i64_21 : i64
+    llvm.store %49, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_27 = arith.constant 0 : i64
+    %c0_i64_23 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %50, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_to_jumpdest_twice.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_to_jumpdest_twice.snap
@@ -53,33 +53,35 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 15 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // 2 preds: ^bb7, ^bb24
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 15 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // 2 preds: ^bb7, ^bb24
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       4: ^bb18,
       5: ^bb35
     ]
   ^bb3:  // pred: ^bb4
     %c4_i256 = arith.constant 4 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c4_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,192 +97,189 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb14
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb13
     %c99_i256 = arith.constant 99 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_5 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c99_i256, %23 : i256, !llvm.ptr
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c99_i256, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_6 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_7 : i64
-    %27 = arith.cmpi ult, %c1024_i64_6, %26 : i64
-    %c92_i8_8 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_8 : i8), ^bb12
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_5 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_5 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_4, %24 : i64
+    %c92_i8_6 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_6 : i8), ^bb12
   ^bb14:  // pred: ^bb8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c3_i64_9 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_7 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %32 = arith.addi %31, %c0_i64_12 : i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
+    %30 = arith.addi %29, %c0_i64_10 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb18:  // 2 preds: ^bb2, ^bb12
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c1_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb19, ^bb1(%c80_i8_14 : i8)
+    %32 = arith.cmpi uge, %31, %c1_i64_11 : i64
+    %c80_i8_12 = arith.constant 80 : i8
+    cf.cond_br %32, ^bb19, ^bb1(%c80_i8_12 : i8)
   ^bb19:  // pred: ^bb18
-    %35 = arith.subi %33, %c1_i64_13 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %33 = arith.subi %31, %c1_i64_11 : i64
+    llvm.store %33, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c42_i256 = arith.constant 42 : i256
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %37 = llvm.getelementptr %arg2[%36] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %38 = arith.addi %36, %c1_i64_15 : i64
-    llvm.store %38, %arg3 : i64, !llvm.ptr
-    llvm.store %c42_i256, %37 : i256, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c42_i256, %34 : i256, !llvm.ptr
+    %35 = llvm.getelementptr %34[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %40 = arith.addi %39, %c1_i64_17 : i64
-    %41 = arith.cmpi ult, %c1024_i64_16, %40 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %41, ^bb1(%c92_i8_18 : i8), ^bb20
+    %c1024_i64_13 = arith.constant 1024 : i64
+    %36 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_14 = arith.constant 1 : i64
+    %37 = arith.addi %36, %c1_i64_14 : i64
+    llvm.store %37, %arg3 : i64, !llvm.ptr
+    %38 = arith.cmpi ult, %c1024_i64_13, %37 : i64
+    %c92_i8_15 = arith.constant 92 : i8
+    cf.cond_br %38, ^bb1(%c92_i8_15 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_16 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb23, ^bb1(%c80_i8_20 : i8)
+    %40 = arith.cmpi uge, %39, %c3_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb23, ^bb1(%c80_i8_17 : i8)
   ^bb23:  // pred: ^bb22
-    %44 = arith.subi %42, %c3_i64_19 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c3_i64_16 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %45 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %46 = arith.subi %45, %c1_i64_21 : i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %46, %arg3 : i64, !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i256
-    cf.br ^bb2(%48 : i256)
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%44 : i256)
   ^bb25:  // no predecessors
     cf.br ^bb31
   ^bb26:  // pred: ^bb28
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_23 = arith.constant -1 : i64
-    %50 = arith.addi %49, %c-1_i64_23 : i64
-    %c1_i64_24 = arith.constant 1 : i64
-    %51 = arith.cmpi ult, %49, %c1_i64_24 : i64
-    %c91_i8_25 = arith.constant 91 : i8
-    cf.cond_br %51, ^bb1(%c91_i8_25 : i8), ^bb24
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_19 = arith.constant -1 : i64
+    %46 = arith.addi %45, %c-1_i64_19 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %c1_i64_20 = arith.constant 1 : i64
+    %47 = arith.cmpi ult, %45, %c1_i64_20 : i64
+    %c91_i8_21 = arith.constant 91 : i8
+    cf.cond_br %47, ^bb1(%c91_i8_21 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c8_i64_26 = arith.constant 8 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c8_i64_22 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c8_i64_26 : i64
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb28, ^bb1(%c80_i8_27 : i8)
+    %49 = arith.cmpi uge, %48, %c8_i64_22 : i64
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb28, ^bb1(%c80_i8_23 : i8)
   ^bb28:  // pred: ^bb27
-    %54 = arith.subi %52, %c8_i64_26 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c8_i64_22 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb30
-    %c4_i256_28 = arith.constant 4 : i256
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %56 = llvm.getelementptr %arg2[%55] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_29 = arith.constant 1 : i64
-    %57 = arith.addi %55, %c1_i64_29 : i64
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    llvm.store %c4_i256_28, %56 : i256, !llvm.ptr
+    %c4_i256_24 = arith.constant 4 : i256
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4_i256_24, %51 : i256, !llvm.ptr
+    %52 = llvm.getelementptr %51[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_30 = arith.constant 1024 : i64
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_31 = arith.constant 1 : i64
-    %59 = arith.addi %58, %c1_i64_31 : i64
-    %60 = arith.cmpi ult, %c1024_i64_30, %59 : i64
-    %c92_i8_32 = arith.constant 92 : i8
-    cf.cond_br %60, ^bb1(%c92_i8_32 : i8), ^bb29
+    %c1024_i64_25 = arith.constant 1024 : i64
+    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_26 = arith.constant 1 : i64
+    %54 = arith.addi %53, %c1_i64_26 : i64
+    llvm.store %54, %arg3 : i64, !llvm.ptr
+    %55 = arith.cmpi ult, %c1024_i64_25, %54 : i64
+    %c92_i8_27 = arith.constant 92 : i8
+    cf.cond_br %55, ^bb1(%c92_i8_27 : i8), ^bb29
   ^bb31:  // pred: ^bb25
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_33 = arith.constant 3 : i64
+    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_28 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %62 = arith.cmpi uge, %61, %c3_i64_33 : i64
-    %c80_i8_34 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb32, ^bb1(%c80_i8_34 : i8)
+    %57 = arith.cmpi uge, %56, %c3_i64_28 : i64
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %57, ^bb32, ^bb1(%c80_i8_29 : i8)
   ^bb32:  // pred: ^bb31
-    %63 = arith.subi %61, %c3_i64_33 : i64
-    llvm.store %63, %arg1 : i64, !llvm.ptr
+    %58 = arith.subi %56, %c3_i64_28 : i64
+    llvm.store %58, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
     cf.br ^bb37
   ^bb34:  // pred: ^bb36
-    %c1024_i64_35 = arith.constant 1024 : i64
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_36 = arith.constant 0 : i64
-    %65 = arith.addi %64, %c0_i64_36 : i64
+    %c1024_i64_30 = arith.constant 1024 : i64
+    %59 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_31 = arith.constant 0 : i64
+    %60 = arith.addi %59, %c0_i64_31 : i64
+    llvm.store %60, %arg3 : i64, !llvm.ptr
     cf.br ^bb33
   ^bb35:  // 2 preds: ^bb2, ^bb29
-    %66 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_37 = arith.constant 1 : i64
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_32 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %67 = arith.cmpi uge, %66, %c1_i64_37 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %67, ^bb36, ^bb1(%c80_i8_38 : i8)
+    %62 = arith.cmpi uge, %61, %c1_i64_32 : i64
+    %c80_i8_33 = arith.constant 80 : i8
+    cf.cond_br %62, ^bb36, ^bb1(%c80_i8_33 : i8)
   ^bb36:  // pred: ^bb35
-    %68 = arith.subi %66, %c1_i64_37 : i64
-    llvm.store %68, %arg1 : i64, !llvm.ptr
+    %63 = arith.subi %61, %c1_i64_32 : i64
+    llvm.store %63, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb33
-    %c0_i64_39 = arith.constant 0 : i64
+    %c0_i64_34 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %69 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_39, %c0_i64_39, %69, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %64 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_34, %c0_i64_34, %64, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_unconditional.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_unconditional.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb11
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb11
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       4: ^bb22
     ]
   ^bb3:  // pred: ^bb4
     %c4_i256 = arith.constant 4 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c4_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,114 +97,112 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    cf.br ^bb2(%24 : i256)
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%22 : i256)
   ^bb12:  // no predecessors
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %26 = arith.addi %25, %c-1_i64 : i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %27 = arith.cmpi ult, %25, %c1_i64_9 : i64
+    %24 = arith.addi %23, %c-1_i64 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %c1_i64_7 = arith.constant 1 : i64
+    %25 = arith.cmpi ult, %23, %c1_i64_7 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %25, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c8_i64 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c8_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c8_i64 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c8_i64 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c20_i256 = arith.constant 20 : i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_11 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_11 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %32 : i256, !llvm.ptr
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %35 = arith.addi %34, %c1_i64_13 : i64
-    %36 = arith.cmpi ult, %c1024_i64_12, %35 : i64
-    %c92_i8_14 = arith.constant 92 : i8
-    cf.cond_br %36, ^bb1(%c92_i8_14 : i8), ^bb16
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_10 = arith.constant 1 : i64
+    %32 = arith.addi %31, %c1_i64_10 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
+    %33 = arith.cmpi ult, %c1024_i64_9, %32 : i64
+    %c92_i8_11 = arith.constant 92 : i8
+    cf.cond_br %33, ^bb1(%c92_i8_11 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_15 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_15 : i64
-    %c80_i8_16 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb19, ^bb1(%c80_i8_16 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb19, ^bb1(%c80_i8_13 : i8)
   ^bb19:  // pred: ^bb18
-    %39 = arith.subi %37, %c3_i64_15 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_12 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_17 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %41 = arith.addi %40, %c0_i64_18 : i64
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %38 = arith.addi %37, %c0_i64_15 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb22:  // 2 preds: ^bb2, ^bb16
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c1_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb23, ^bb1(%c80_i8_20 : i8)
+    %40 = arith.cmpi uge, %39, %c1_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb23, ^bb1(%c80_i8_17 : i8)
   ^bb23:  // pred: ^bb22
-    %44 = arith.subi %42, %c1_i64_19 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c1_i64_16 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_21 = arith.constant 0 : i64
+    %c0_i64_18 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %45, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_18, %c0_i64_18, %42, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_jumpdest.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       5: ^bb22
     ]
   ^bb3:  // pred: ^bb4
     %c5_i256 = arith.constant 5 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c5_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,143 +96,140 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb14
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb13
     %c0_i256 = arith.constant 0 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_5 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %23 : i256, !llvm.ptr
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_6 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_7 : i64
-    %27 = arith.cmpi ult, %c1024_i64_6, %26 : i64
-    %c92_i8_8 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_8 : i8), ^bb12
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_5 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_5 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_4, %24 : i64
+    %c92_i8_6 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_6 : i8), ^bb12
   ^bb14:  // pred: ^bb8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c3_i64_9 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_7 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c1_i256 = arith.constant 1 : i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_11 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_11 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %32 : i256, !llvm.ptr
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %35 = arith.addi %34, %c1_i64_13 : i64
-    %36 = arith.cmpi ult, %c1024_i64_12, %35 : i64
-    %c92_i8_14 = arith.constant 92 : i8
-    cf.cond_br %36, ^bb1(%c92_i8_14 : i8), ^bb16
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_10 = arith.constant 1 : i64
+    %32 = arith.addi %31, %c1_i64_10 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
+    %33 = arith.cmpi ult, %c1024_i64_9, %32 : i64
+    %c92_i8_11 = arith.constant 92 : i8
+    cf.cond_br %33, ^bb1(%c92_i8_11 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_15 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_15 : i64
-    %c80_i8_16 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb19, ^bb1(%c80_i8_16 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb19, ^bb1(%c80_i8_13 : i8)
   ^bb19:  // pred: ^bb18
-    %39 = arith.subi %37, %c3_i64_15 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_12 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_17 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %41 = arith.addi %40, %c0_i64_18 : i64
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %38 = arith.addi %37, %c0_i64_15 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb22:  // 2 preds: ^bb2, ^bb16
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c1_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb23, ^bb1(%c80_i8_20 : i8)
+    %40 = arith.cmpi uge, %39, %c1_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb23, ^bb1(%c80_i8_17 : i8)
   ^bb23:  // pred: ^bb22
-    %44 = arith.subi %42, %c1_i64_19 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c1_i64_16 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
     %c2_i256 = arith.constant 2 : i256
-    %45 = llvm.load %arg3 : !llvm.ptr -> i64
-    %46 = llvm.getelementptr %arg2[%45] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %47 = arith.addi %45, %c1_i64_21 : i64
-    llvm.store %47, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %46 : i256, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %42 : i256, !llvm.ptr
+    %43 = llvm.getelementptr %42[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %49 = arith.addi %48, %c1_i64_23 : i64
-    %50 = arith.cmpi ult, %c1024_i64_22, %49 : i64
-    %c92_i8_24 = arith.constant 92 : i8
-    cf.cond_br %50, ^bb1(%c92_i8_24 : i8), ^bb24
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %44 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_19 = arith.constant 1 : i64
+    %45 = arith.addi %44, %c1_i64_19 : i64
+    llvm.store %45, %arg3 : i64, !llvm.ptr
+    %46 = arith.cmpi ult, %c1024_i64_18, %45 : i64
+    %c92_i8_20 = arith.constant 92 : i8
+    cf.cond_br %46, ^bb1(%c92_i8_20 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_25 = arith.constant 3 : i64
+    %47 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_21 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb27, ^bb1(%c80_i8_26 : i8)
+    %48 = arith.cmpi uge, %47, %c3_i64_21 : i64
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %48, ^bb27, ^bb1(%c80_i8_22 : i8)
   ^bb27:  // pred: ^bb26
-    %53 = arith.subi %51, %c3_i64_25 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %49 = arith.subi %47, %c3_i64_21 : i64
+    llvm.store %49, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_27 = arith.constant 0 : i64
+    %c0_i64_23 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %50, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_push_pop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__jump_with_push_pop.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       6: ^bb26
     ]
   ^bb3:  // pred: ^bb4
     %c6_i256 = arith.constant 6 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c6_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,143 +96,140 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb14
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb13
     %c0_i256 = arith.constant 0 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_5 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %23 : i256, !llvm.ptr
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_6 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_7 : i64
-    %27 = arith.cmpi ult, %c1024_i64_6, %26 : i64
-    %c92_i8_8 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_8 : i8), ^bb12
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_5 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_5 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_4, %24 : i64
+    %c92_i8_6 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_6 : i8), ^bb12
   ^bb14:  // pred: ^bb8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c3_i64_9 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_7 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c42_i256 = arith.constant 42 : i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_11 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_11 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %c42_i256, %32 : i256, !llvm.ptr
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c42_i256, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %35 = arith.addi %34, %c1_i64_13 : i64
-    %36 = arith.cmpi ult, %c1024_i64_12, %35 : i64
-    %c92_i8_14 = arith.constant 92 : i8
-    cf.cond_br %36, ^bb1(%c92_i8_14 : i8), ^bb16
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_10 = arith.constant 1 : i64
+    %32 = arith.addi %31, %c1_i64_10 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
+    %33 = arith.cmpi ult, %c1024_i64_9, %32 : i64
+    %c92_i8_11 = arith.constant 92 : i8
+    cf.cond_br %33, ^bb1(%c92_i8_11 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_15 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_15 : i64
-    %c80_i8_16 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb19, ^bb1(%c80_i8_16 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb19, ^bb1(%c80_i8_13 : i8)
   ^bb19:  // pred: ^bb18
-    %39 = arith.subi %37, %c3_i64_15 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_12 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %41 = arith.subi %40, %c1_i64_17 : i64
-    %42 = llvm.getelementptr %arg2[%41] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    %43 = llvm.load %42 : !llvm.ptr -> i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %38 = llvm.getelementptr %37[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %39 = llvm.load %38 : !llvm.ptr -> i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_18 = arith.constant 1024 : i64
-    %44 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_19 = arith.constant -1 : i64
-    %45 = arith.addi %44, %c-1_i64_19 : i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %46 = arith.cmpi ult, %44, %c1_i64_20 : i64
-    %c91_i8_21 = arith.constant 91 : i8
-    cf.cond_br %46, ^bb1(%c91_i8_21 : i8), ^bb20
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_15 = arith.constant -1 : i64
+    %41 = arith.addi %40, %c-1_i64_15 : i64
+    llvm.store %41, %arg3 : i64, !llvm.ptr
+    %c1_i64_16 = arith.constant 1 : i64
+    %42 = arith.cmpi ult, %40, %c1_i64_16 : i64
+    %c91_i8_17 = arith.constant 91 : i8
+    cf.cond_br %42, ^bb1(%c91_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %47 = llvm.load %arg1 : !llvm.ptr -> i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %48 = arith.cmpi uge, %47, %c2_i64 : i64
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %48, ^bb23, ^bb1(%c80_i8_22 : i8)
+    %44 = arith.cmpi uge, %43, %c2_i64 : i64
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb23, ^bb1(%c80_i8_18 : i8)
   ^bb23:  // pred: ^bb22
-    %49 = arith.subi %47, %c2_i64 : i64
-    llvm.store %49, %arg1 : i64, !llvm.ptr
+    %45 = arith.subi %43, %c2_i64 : i64
+    llvm.store %45, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_23 = arith.constant 1024 : i64
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_24 = arith.constant 0 : i64
-    %51 = arith.addi %50, %c0_i64_24 : i64
+    %c1024_i64_19 = arith.constant 1024 : i64
+    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_20 = arith.constant 0 : i64
+    %47 = arith.addi %46, %c0_i64_20 : i64
+    llvm.store %47, %arg3 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb26:  // 2 preds: ^bb2, ^bb20
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_25 = arith.constant 1 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_21 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c1_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb27, ^bb1(%c80_i8_26 : i8)
+    %49 = arith.cmpi uge, %48, %c1_i64_21 : i64
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb27, ^bb1(%c80_i8_22 : i8)
   ^bb27:  // pred: ^bb26
-    %54 = arith.subi %52, %c1_i64_25 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c1_i64_21 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_27 = arith.constant 0 : i64
+    %c0_i64_23 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %55, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %51 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %51, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 16 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb23, ^bb26, ^bb27
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 16 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb23, ^bb26, ^bb27
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c64_i256 = arith.constant 64 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c64_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,171 +96,167 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c32_i256 = arith.constant 32 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb17
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %30 = arith.cmpi ne, %29, %c0_i8 : i8
+    %27 = arith.cmpi ne, %26, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %30, ^bb1(%c87_i8 : i8), ^bb12
+    cf.cond_br %27, ^bb1(%c87_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %31 = arith.cmpi sgt, %28, %c18446744073709551615_i256 : i256
+    %28 = arith.cmpi sgt, %25, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %31, ^bb1(%c84_i8 : i8), ^bb13
+    cf.cond_br %28, ^bb1(%c84_i8 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %32 = arith.trunci %28 : i256 to i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %33 = arith.cmpi slt, %32, %c0_i64_9 : i64
-    %c84_i8_10 = arith.constant 84 : i8
-    cf.cond_br %33, ^bb1(%c84_i8_10 : i8), ^bb14
+    %29 = arith.trunci %25 : i256 to i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %30 = arith.cmpi slt, %29, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %30, ^bb1(%c84_i8_7 : i8), ^bb14
   ^bb14:  // pred: ^bb13
     %c8_i64 = arith.constant 8 : i64
-    %34 = arith.muli %32, %c8_i64 : i64
-    %35 = llvm.load %arg1 : !llvm.ptr -> i64
-    %36 = arith.cmpi ult, %35, %34 : i64
-    scf.if %36 {
+    %31 = arith.muli %29, %c8_i64 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = arith.cmpi ult, %32, %31 : i64
+    scf.if %33 {
     } else {
-      %74 = arith.subi %35, %34 : i64
-      llvm.store %74, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %32, %31 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %36, ^bb1(%c80_i8_11 : i8), ^bb15
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb1(%c80_i8_8 : i8), ^bb15
   ^bb15:  // pred: ^bb14
-    %c0_i64_12 = arith.constant 0 : i64
-    %37 = arith.cmpi ne, %32, %c0_i64_12 : i64
-    cf.cond_br %37, ^bb21, ^bb16
+    %c0_i64_9 = arith.constant 0 : i64
+    %34 = arith.cmpi ne, %29, %c0_i64_9 : i64
+    cf.cond_br %34, ^bb21, ^bb16
   ^bb16:  // 2 preds: ^bb15, ^bb25
-    %38 = arith.trunci %24 : i256 to i64
-    call @dora_fn_append_log(%arg0, %38, %32) : (!llvm.ptr, i64, i64) -> ()
+    %35 = arith.trunci %22 : i256 to i64
+    call @dora_fn_append_log(%arg0, %35, %29) : (!llvm.ptr, i64, i64) -> ()
     cf.br ^bb20
   ^bb17:  // pred: ^bb19
-    %c1024_i64_13 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %36 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %40 = arith.addi %39, %c-2_i64 : i64
+    %37 = arith.addi %36, %c-2_i64 : i64
+    llvm.store %37, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %41 = arith.cmpi ult, %39, %c2_i64 : i64
+    %38 = arith.cmpi ult, %36, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %41, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %38, ^bb1(%c91_i8 : i8), ^bb11
   ^bb18:  // pred: ^bb7
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
     %c375_i64 = arith.constant 375 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c375_i64 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
+    %40 = arith.cmpi uge, %39, %c375_i64 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb19, ^bb1(%c80_i8_11 : i8)
   ^bb19:  // pred: ^bb18
-    %44 = arith.subi %42, %c375_i64 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c375_i64 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb16
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %45, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %42, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb21:  // pred: ^bb15
-    %c18446744073709551615_i256_16 = arith.constant 18446744073709551615 : i256
-    %46 = arith.cmpi sgt, %24, %c18446744073709551615_i256_16 : i256
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_17 : i8), ^bb22
+    %c18446744073709551615_i256_13 = arith.constant 18446744073709551615 : i256
+    %43 = arith.cmpi sgt, %22, %c18446744073709551615_i256_13 : i256
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %43, ^bb1(%c84_i8_14 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %47 = arith.trunci %24 : i256 to i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %48 = arith.cmpi slt, %47, %c0_i64_18 : i64
-    %c84_i8_19 = arith.constant 84 : i8
-    cf.cond_br %48, ^bb1(%c84_i8_19 : i8), ^bb23
+    %44 = arith.trunci %22 : i256 to i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %45 = arith.cmpi slt, %44, %c0_i64_15 : i64
+    %c84_i8_16 = arith.constant 84 : i8
+    cf.cond_br %45, ^bb1(%c84_i8_16 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %49 = arith.addi %47, %32 : i64
-    %c0_i64_20 = arith.constant 0 : i64
-    %50 = arith.cmpi slt, %49, %c0_i64_20 : i64
-    %c84_i8_21 = arith.constant 84 : i8
-    cf.cond_br %50, ^bb1(%c84_i8_21 : i8), ^bb24
+    %46 = arith.addi %44, %29 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %47 = arith.cmpi slt, %46, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %47, ^bb1(%c84_i8_18 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %51 = arith.addi %49, %c31_i64 : i64
-    %52 = arith.divui %51, %c32_i64 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %53 = arith.muli %52, %c32_i64_22 : i64
-    %54 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_23 = arith.constant 31 : i64
-    %c32_i64_24 = arith.constant 32 : i64
-    %55 = arith.addi %54, %c31_i64_23 : i64
-    %56 = arith.divui %55, %c32_i64_24 : i64
-    %57 = arith.muli %56, %c32_i64_22 : i64
-    %58 = arith.cmpi ult, %57, %53 : i64
-    cf.cond_br %58, ^bb26, ^bb25
+    %48 = arith.addi %46, %c31_i64 : i64
+    %49 = arith.divui %48, %c32_i64 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %50 = arith.muli %49, %c32_i64_19 : i64
+    %51 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %52 = arith.addi %51, %c31_i64_20 : i64
+    %53 = arith.divui %52, %c32_i64_21 : i64
+    %54 = arith.muli %53, %c32_i64_19 : i64
+    %55 = arith.cmpi ult, %54, %50 : i64
+    cf.cond_br %55, ^bb26, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb28
     cf.br ^bb16
   ^bb26:  // pred: ^bb24
-    %c3_i64_25 = arith.constant 3 : i64
+    %c3_i64_22 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %59 = arith.muli %56, %56 : i64
-    %60 = arith.divui %59, %c512_i64 : i64
-    %61 = arith.muli %56, %c3_i64_25 : i64
-    %62 = arith.addi %60, %61 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %c512_i64_27 = arith.constant 512 : i64
-    %63 = arith.muli %52, %52 : i64
-    %64 = arith.divui %63, %c512_i64_27 : i64
-    %65 = arith.muli %52, %c3_i64_26 : i64
-    %66 = arith.addi %64, %65 : i64
-    %67 = arith.subi %66, %62 : i64
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %69 = arith.cmpi ult, %68, %67 : i64
-    scf.if %69 {
+    %56 = arith.muli %53, %53 : i64
+    %57 = arith.divui %56, %c512_i64 : i64
+    %58 = arith.muli %53, %c3_i64_22 : i64
+    %59 = arith.addi %57, %58 : i64
+    %c3_i64_23 = arith.constant 3 : i64
+    %c512_i64_24 = arith.constant 512 : i64
+    %60 = arith.muli %49, %49 : i64
+    %61 = arith.divui %60, %c512_i64_24 : i64
+    %62 = arith.muli %49, %c3_i64_23 : i64
+    %63 = arith.addi %61, %62 : i64
+    %64 = arith.subi %63, %59 : i64
+    %65 = llvm.load %arg1 : !llvm.ptr -> i64
+    %66 = arith.cmpi ult, %65, %64 : i64
+    scf.if %66 {
     } else {
-      %74 = arith.subi %68, %67 : i64
-      llvm.store %74, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %65, %64 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %69, ^bb1(%c80_i8_28 : i8), ^bb27
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %66, ^bb1(%c80_i8_25 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %70 = call @dora_fn_extend_memory(%arg0, %53) : (!llvm.ptr, i64) -> !llvm.ptr
-    %71 = llvm.getelementptr %70[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %72 = llvm.load %71 : !llvm.ptr -> i8
-    %c0_i8_29 = arith.constant 0 : i8
-    %73 = arith.cmpi ne, %72, %c0_i8_29 : i8
-    cf.cond_br %73, ^bb1(%72 : i8), ^bb28
+    %67 = call @dora_fn_extend_memory(%arg0, %50) : (!llvm.ptr, i64) -> !llvm.ptr
+    %68 = llvm.getelementptr %67[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i8
+    %c0_i8_26 = arith.constant 0 : i8
+    %70 = arith.cmpi ne, %69, %c0_i8_26 : i8
+    cf.cond_br %70, ^bb1(%69 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     cf.br ^bb25
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,208 +96,201 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb21
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %43 = arith.cmpi ne, %42, %c0_i8 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %43, ^bb1(%c87_i8 : i8), ^bb16
+    cf.cond_br %38, ^bb1(%c87_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %44 = arith.cmpi sgt, %37, %c18446744073709551615_i256 : i256
+    %39 = arith.cmpi sgt, %33, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb17
+    cf.cond_br %39, ^bb1(%c84_i8 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %45 = arith.trunci %37 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_17 : i8), ^bb18
+    %40 = arith.trunci %33 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_12 : i8), ^bb18
   ^bb18:  // pred: ^bb17
     %c8_i64 = arith.constant 8 : i64
-    %47 = arith.muli %45, %c8_i64 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %47 : i64
-    scf.if %49 {
+    %42 = arith.muli %40, %c8_i64 : i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %42 : i64
+    scf.if %44 {
     } else {
-      %88 = arith.subi %48, %47 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %43, %42 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_18 : i8), ^bb19
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_13 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %c0_i64_19 = arith.constant 0 : i64
-    %50 = arith.cmpi ne, %45, %c0_i64_19 : i64
-    cf.cond_br %50, ^bb25, ^bb20
+    %c0_i64_14 = arith.constant 0 : i64
+    %45 = arith.cmpi ne, %40, %c0_i64_14 : i64
+    cf.cond_br %45, ^bb25, ^bb20
   ^bb20:  // 2 preds: ^bb19, ^bb29
-    %51 = arith.trunci %33 : i256 to i64
-    %c1_i256_20 = arith.constant 1 : i256
-    %52 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
-    llvm.store %41, %52 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_append_log_with_one_topic(%arg0, %51, %45, %52) : (!llvm.ptr, i64, i64, !llvm.ptr) -> ()
+    %46 = arith.trunci %30 : i256 to i64
+    %c1_i256_15 = arith.constant 1 : i256
+    %47 = llvm.alloca %c1_i256_15 x i256 : (i256) -> !llvm.ptr
+    llvm.store %36, %47 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_append_log_with_one_topic(%arg0, %46, %40, %47) : (!llvm.ptr, i64, i64, !llvm.ptr) -> ()
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %48 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %54 = arith.addi %53, %c-3_i64 : i64
-    %c3_i64_22 = arith.constant 3 : i64
-    %55 = arith.cmpi ult, %53, %c3_i64_22 : i64
+    %49 = arith.addi %48, %c-3_i64 : i64
+    llvm.store %49, %arg3 : i64, !llvm.ptr
+    %c3_i64_17 = arith.constant 3 : i64
+    %50 = arith.cmpi ult, %48, %c3_i64_17 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %55, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
   ^bb22:  // pred: ^bb11
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %51 = llvm.load %arg1 : !llvm.ptr -> i64
     %c750_i64 = arith.constant 750 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c750_i64 : i64
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb23, ^bb1(%c80_i8_23 : i8)
+    %52 = arith.cmpi uge, %51, %c750_i64 : i64
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %52, ^bb23, ^bb1(%c80_i8_18 : i8)
   ^bb23:  // pred: ^bb22
-    %58 = arith.subi %56, %c750_i64 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %53 = arith.subi %51, %c750_i64 : i64
+    llvm.store %53, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_24 = arith.constant 0 : i64
+    %c0_i64_19 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %59, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_19, %c0_i64_19, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb25:  // pred: ^bb19
-    %c18446744073709551615_i256_25 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_25 : i256
-    %c84_i8_26 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_26 : i8), ^bb26
+    %c18446744073709551615_i256_20 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_20 : i256
+    %c84_i8_21 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_21 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_27 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_27 : i64
-    %c84_i8_28 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_28 : i8), ^bb27
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_22 : i64
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_23 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %63 = arith.addi %61, %45 : i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_29 : i64
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_30 : i8), ^bb28
+    %58 = arith.addi %56, %40 : i64
+    %c0_i64_24 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_24 : i64
+    %c84_i8_25 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_25 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64 : i64
-    %66 = arith.divui %65, %c32_i64 : i64
-    %c32_i64_31 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_31 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_32 : i64
-    %70 = arith.divui %69, %c32_i64_33 : i64
-    %71 = arith.muli %70, %c32_i64_31 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb30, ^bb29
+    %60 = arith.addi %58, %c31_i64 : i64
+    %61 = arith.divui %60, %c32_i64 : i64
+    %c32_i64_26 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_26 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_27 : i64
+    %65 = arith.divui %64, %c32_i64_28 : i64
+    %66 = arith.muli %65, %c32_i64_26 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb30, ^bb29
   ^bb29:  // 2 preds: ^bb28, ^bb32
     cf.br ^bb20
   ^bb30:  // pred: ^bb28
-    %c3_i64_34 = arith.constant 3 : i64
+    %c3_i64_29 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_34 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_35 = arith.constant 3 : i64
-    %c512_i64_36 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_36 : i64
-    %79 = arith.muli %66, %c3_i64_35 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_29 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_30 = arith.constant 3 : i64
+    %c512_i64_31 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_31 : i64
+    %74 = arith.muli %61, %c3_i64_30 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_37 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_37 : i8), ^bb31
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_32 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
-    %c0_i8_38 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8_38 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb32
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
+    %c0_i8_33 = arith.constant 0 : i8
+    %82 = arith.cmpi ne, %81, %c0_i8_33 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb32
   ^bb32:  // pred: ^bb31
     cf.br ^bb29
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log2.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,245 +96,235 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c2_i256 = arith.constant 2 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb25
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_19 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %44 = arith.subi %43, %c1_i64_20 : i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %44, %arg3 : i64, !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %48 = arith.subi %47, %c1_i64_21 : i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i256
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %52 = arith.subi %51, %c1_i64_22 : i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i256
-    %55 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
+    %48 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8 : i8
+    %49 = arith.cmpi ne, %48, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %56, ^bb1(%c87_i8 : i8), ^bb20
+    cf.cond_br %49, ^bb1(%c87_i8 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %57 = arith.cmpi sgt, %46, %c18446744073709551615_i256 : i256
+    %50 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8 : i8), ^bb21
+    cf.cond_br %50, ^bb1(%c84_i8 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %58 = arith.trunci %46 : i256 to i64
-    %c0_i64_23 = arith.constant 0 : i64
-    %59 = arith.cmpi slt, %58, %c0_i64_23 : i64
-    %c84_i8_24 = arith.constant 84 : i8
-    cf.cond_br %59, ^bb1(%c84_i8_24 : i8), ^bb22
+    %51 = arith.trunci %41 : i256 to i64
+    %c0_i64_16 = arith.constant 0 : i64
+    %52 = arith.cmpi slt, %51, %c0_i64_16 : i64
+    %c84_i8_17 = arith.constant 84 : i8
+    cf.cond_br %52, ^bb1(%c84_i8_17 : i8), ^bb22
   ^bb22:  // pred: ^bb21
     %c8_i64 = arith.constant 8 : i64
-    %60 = arith.muli %58, %c8_i64 : i64
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %62 = arith.cmpi ult, %61, %60 : i64
-    scf.if %62 {
+    %53 = arith.muli %51, %c8_i64 : i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %102 = arith.subi %61, %60 : i64
-      llvm.store %102, %arg1 : i64, !llvm.ptr
+      %95 = arith.subi %54, %53 : i64
+      llvm.store %95, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb1(%c80_i8_25 : i8), ^bb23
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_18 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %c0_i64_26 = arith.constant 0 : i64
-    %63 = arith.cmpi ne, %58, %c0_i64_26 : i64
-    cf.cond_br %63, ^bb29, ^bb24
+    %c0_i64_19 = arith.constant 0 : i64
+    %56 = arith.cmpi ne, %51, %c0_i64_19 : i64
+    cf.cond_br %56, ^bb29, ^bb24
   ^bb24:  // 2 preds: ^bb23, ^bb33
-    %64 = arith.trunci %42 : i256 to i64
-    %c1_i256_27 = arith.constant 1 : i256
-    %65 = llvm.alloca %c1_i256_27 x i256 : (i256) -> !llvm.ptr
-    llvm.store %50, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_28 = arith.constant 1 : i256
-    %66 = llvm.alloca %c1_i256_28 x i256 : (i256) -> !llvm.ptr
-    llvm.store %54, %66 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_append_log_with_two_topics(%arg0, %64, %58, %65, %66) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+    %57 = arith.trunci %38 : i256 to i64
+    %c1_i256_20 = arith.constant 1 : i256
+    %58 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
+    llvm.store %44, %58 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_21 = arith.constant 1 : i256
+    %59 = llvm.alloca %c1_i256_21 x i256 : (i256) -> !llvm.ptr
+    llvm.store %47, %59 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_append_log_with_two_topics(%arg0, %57, %51, %58, %59) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_29 = arith.constant 1024 : i64
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %60 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-4_i64 = arith.constant -4 : i64
-    %68 = arith.addi %67, %c-4_i64 : i64
+    %61 = arith.addi %60, %c-4_i64 : i64
+    llvm.store %61, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %69 = arith.cmpi ult, %67, %c4_i64 : i64
+    %62 = arith.cmpi ult, %60, %c4_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %69, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %62, ^bb1(%c91_i8 : i8), ^bb19
   ^bb26:  // pred: ^bb15
-    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %63 = llvm.load %arg1 : !llvm.ptr -> i64
     %c1125_i64 = arith.constant 1125 : i64
     call @dora_fn_nop() : () -> ()
-    %71 = arith.cmpi uge, %70, %c1125_i64 : i64
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %71, ^bb27, ^bb1(%c80_i8_30 : i8)
+    %64 = arith.cmpi uge, %63, %c1125_i64 : i64
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %64, ^bb27, ^bb1(%c80_i8_23 : i8)
   ^bb27:  // pred: ^bb26
-    %72 = arith.subi %70, %c1125_i64 : i64
-    llvm.store %72, %arg1 : i64, !llvm.ptr
+    %65 = arith.subi %63, %c1125_i64 : i64
+    llvm.store %65, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_31 = arith.constant 0 : i64
+    %c0_i64_24 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %73 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_31, %c0_i64_31, %73, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %66 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %66, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb29:  // pred: ^bb23
-    %c18446744073709551615_i256_32 = arith.constant 18446744073709551615 : i256
-    %74 = arith.cmpi sgt, %42, %c18446744073709551615_i256_32 : i256
-    %c84_i8_33 = arith.constant 84 : i8
-    cf.cond_br %74, ^bb1(%c84_i8_33 : i8), ^bb30
+    %c18446744073709551615_i256_25 = arith.constant 18446744073709551615 : i256
+    %67 = arith.cmpi sgt, %38, %c18446744073709551615_i256_25 : i256
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %67, ^bb1(%c84_i8_26 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %75 = arith.trunci %42 : i256 to i64
-    %c0_i64_34 = arith.constant 0 : i64
-    %76 = arith.cmpi slt, %75, %c0_i64_34 : i64
-    %c84_i8_35 = arith.constant 84 : i8
-    cf.cond_br %76, ^bb1(%c84_i8_35 : i8), ^bb31
+    %68 = arith.trunci %38 : i256 to i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %69 = arith.cmpi slt, %68, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %69, ^bb1(%c84_i8_28 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %77 = arith.addi %75, %58 : i64
-    %c0_i64_36 = arith.constant 0 : i64
-    %78 = arith.cmpi slt, %77, %c0_i64_36 : i64
-    %c84_i8_37 = arith.constant 84 : i8
-    cf.cond_br %78, ^bb1(%c84_i8_37 : i8), ^bb32
+    %70 = arith.addi %68, %51 : i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %71 = arith.cmpi slt, %70, %c0_i64_29 : i64
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %71, ^bb1(%c84_i8_30 : i8), ^bb32
   ^bb32:  // pred: ^bb31
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %79 = arith.addi %77, %c31_i64 : i64
-    %80 = arith.divui %79, %c32_i64 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %81 = arith.muli %80, %c32_i64_38 : i64
-    %82 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_39 = arith.constant 31 : i64
-    %c32_i64_40 = arith.constant 32 : i64
-    %83 = arith.addi %82, %c31_i64_39 : i64
-    %84 = arith.divui %83, %c32_i64_40 : i64
-    %85 = arith.muli %84, %c32_i64_38 : i64
-    %86 = arith.cmpi ult, %85, %81 : i64
-    cf.cond_br %86, ^bb34, ^bb33
+    %72 = arith.addi %70, %c31_i64 : i64
+    %73 = arith.divui %72, %c32_i64 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %74 = arith.muli %73, %c32_i64_31 : i64
+    %75 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_32 = arith.constant 31 : i64
+    %c32_i64_33 = arith.constant 32 : i64
+    %76 = arith.addi %75, %c31_i64_32 : i64
+    %77 = arith.divui %76, %c32_i64_33 : i64
+    %78 = arith.muli %77, %c32_i64_31 : i64
+    %79 = arith.cmpi ult, %78, %74 : i64
+    cf.cond_br %79, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb24
   ^bb34:  // pred: ^bb32
-    %c3_i64_41 = arith.constant 3 : i64
+    %c3_i64_34 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %87 = arith.muli %84, %84 : i64
-    %88 = arith.divui %87, %c512_i64 : i64
-    %89 = arith.muli %84, %c3_i64_41 : i64
-    %90 = arith.addi %88, %89 : i64
-    %c3_i64_42 = arith.constant 3 : i64
-    %c512_i64_43 = arith.constant 512 : i64
-    %91 = arith.muli %80, %80 : i64
-    %92 = arith.divui %91, %c512_i64_43 : i64
-    %93 = arith.muli %80, %c3_i64_42 : i64
-    %94 = arith.addi %92, %93 : i64
-    %95 = arith.subi %94, %90 : i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %80 = arith.muli %77, %77 : i64
+    %81 = arith.divui %80, %c512_i64 : i64
+    %82 = arith.muli %77, %c3_i64_34 : i64
+    %83 = arith.addi %81, %82 : i64
+    %c3_i64_35 = arith.constant 3 : i64
+    %c512_i64_36 = arith.constant 512 : i64
+    %84 = arith.muli %73, %73 : i64
+    %85 = arith.divui %84, %c512_i64_36 : i64
+    %86 = arith.muli %73, %c3_i64_35 : i64
+    %87 = arith.addi %85, %86 : i64
+    %88 = arith.subi %87, %83 : i64
+    %89 = llvm.load %arg1 : !llvm.ptr -> i64
+    %90 = arith.cmpi ult, %89, %88 : i64
+    scf.if %90 {
     } else {
-      %102 = arith.subi %96, %95 : i64
-      llvm.store %102, %arg1 : i64, !llvm.ptr
+      %95 = arith.subi %89, %88 : i64
+      llvm.store %95, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_44 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_44 : i8), ^bb35
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %90, ^bb1(%c80_i8_37 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = call @dora_fn_extend_memory(%arg0, %81) : (!llvm.ptr, i64) -> !llvm.ptr
-    %99 = llvm.getelementptr %98[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %100 = llvm.load %99 : !llvm.ptr -> i8
-    %c0_i8_45 = arith.constant 0 : i8
-    %101 = arith.cmpi ne, %100, %c0_i8_45 : i8
-    cf.cond_br %101, ^bb1(%100 : i8), ^bb36
+    %91 = call @dora_fn_extend_memory(%arg0, %74) : (!llvm.ptr, i64) -> !llvm.ptr
+    %92 = llvm.getelementptr %91[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %93 = llvm.load %92 : !llvm.ptr -> i8
+    %c0_i8_38 = arith.constant 0 : i8
+    %94 = arith.cmpi ne, %93, %c0_i8_38 : i8
+    cf.cond_br %94, ^bb1(%93 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log3.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log3.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,282 +96,269 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c2_i256 = arith.constant 2 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
     %c3_i256 = arith.constant 3 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_19 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c3_i256, %40 : i256, !llvm.ptr
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3_i256, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb20:  // pred: ^bb22
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_21 : i64
-    %44 = arith.cmpi ult, %c1024_i64_20, %43 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_22 : i8), ^bb19
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_17 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_16, %39 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_18 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb22, ^bb1(%c80_i8_24 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_20 : i8)
   ^bb22:  // pred: ^bb21
-    %47 = arith.subi %45, %c3_i64_23 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_19 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb29
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_25 = arith.constant 1 : i64
-    %49 = arith.subi %48, %c1_i64_25 : i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %49, %arg3 : i64, !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i256
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %53 = arith.subi %52, %c1_i64_26 : i64
-    %54 = llvm.getelementptr %arg2[%53] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %44[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %46 = llvm.load %45 : !llvm.ptr -> i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
+    %47 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %49 = llvm.load %48 : !llvm.ptr -> i256
+    llvm.store %48, %0 : !llvm.ptr, !llvm.ptr
+    %50 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %52 = llvm.load %51 : !llvm.ptr -> i256
+    llvm.store %51, %0 : !llvm.ptr, !llvm.ptr
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %55 = llvm.load %54 : !llvm.ptr -> i256
-    %56 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %57 = arith.subi %56, %c1_i64_27 : i64
-    %58 = llvm.getelementptr %arg2[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    %59 = llvm.load %58 : !llvm.ptr -> i256
-    %60 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %61 = arith.subi %60, %c1_i64_28 : i64
-    %62 = llvm.getelementptr %arg2[%61] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %61, %arg3 : i64, !llvm.ptr
-    %63 = llvm.load %62 : !llvm.ptr -> i256
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %65 = arith.subi %64, %c1_i64_29 : i64
-    %66 = llvm.getelementptr %arg2[%65] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %65, %arg3 : i64, !llvm.ptr
-    %67 = llvm.load %66 : !llvm.ptr -> i256
-    %68 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %59 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %69 = arith.cmpi ne, %68, %c0_i8 : i8
+    %60 = arith.cmpi ne, %59, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %69, ^bb1(%c87_i8 : i8), ^bb24
+    cf.cond_br %60, ^bb1(%c87_i8 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %70 = arith.cmpi sgt, %55, %c18446744073709551615_i256 : i256
+    %61 = arith.cmpi sgt, %49, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %70, ^bb1(%c84_i8 : i8), ^bb25
+    cf.cond_br %61, ^bb1(%c84_i8 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %71 = arith.trunci %55 : i256 to i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %72 = arith.cmpi slt, %71, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %72, ^bb1(%c84_i8_31 : i8), ^bb26
+    %62 = arith.trunci %49 : i256 to i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %63 = arith.cmpi slt, %62, %c0_i64_21 : i64
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %63, ^bb1(%c84_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
     %c8_i64 = arith.constant 8 : i64
-    %73 = arith.muli %71, %c8_i64 : i64
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %75 = arith.cmpi ult, %74, %73 : i64
-    scf.if %75 {
+    %64 = arith.muli %62, %c8_i64 : i64
+    %65 = llvm.load %arg1 : !llvm.ptr -> i64
+    %66 = arith.cmpi ult, %65, %64 : i64
+    scf.if %66 {
     } else {
-      %116 = arith.subi %74, %73 : i64
-      llvm.store %116, %arg1 : i64, !llvm.ptr
+      %107 = arith.subi %65, %64 : i64
+      llvm.store %107, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb1(%c80_i8_32 : i8), ^bb27
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %66, ^bb1(%c80_i8_23 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c0_i64_33 = arith.constant 0 : i64
-    %76 = arith.cmpi ne, %71, %c0_i64_33 : i64
-    cf.cond_br %76, ^bb33, ^bb28
+    %c0_i64_24 = arith.constant 0 : i64
+    %67 = arith.cmpi ne, %62, %c0_i64_24 : i64
+    cf.cond_br %67, ^bb33, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb37
-    %77 = arith.trunci %51 : i256 to i64
-    %c1_i256_34 = arith.constant 1 : i256
-    %78 = llvm.alloca %c1_i256_34 x i256 : (i256) -> !llvm.ptr
-    llvm.store %59, %78 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_35 = arith.constant 1 : i256
-    %79 = llvm.alloca %c1_i256_35 x i256 : (i256) -> !llvm.ptr
-    llvm.store %63, %79 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_36 = arith.constant 1 : i256
-    %80 = llvm.alloca %c1_i256_36 x i256 : (i256) -> !llvm.ptr
-    llvm.store %67, %80 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_append_log_with_three_topics(%arg0, %77, %71, %78, %79, %80) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %68 = arith.trunci %46 : i256 to i64
+    %c1_i256_25 = arith.constant 1 : i256
+    %69 = llvm.alloca %c1_i256_25 x i256 : (i256) -> !llvm.ptr
+    llvm.store %52, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_26 = arith.constant 1 : i256
+    %70 = llvm.alloca %c1_i256_26 x i256 : (i256) -> !llvm.ptr
+    llvm.store %55, %70 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_27 = arith.constant 1 : i256
+    %71 = llvm.alloca %c1_i256_27 x i256 : (i256) -> !llvm.ptr
+    llvm.store %58, %71 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_append_log_with_three_topics(%arg0, %68, %62, %69, %70, %71) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb32
   ^bb29:  // pred: ^bb31
-    %c1024_i64_37 = arith.constant 1024 : i64
-    %81 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_28 = arith.constant 1024 : i64
+    %72 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %82 = arith.addi %81, %c-5_i64 : i64
+    %73 = arith.addi %72, %c-5_i64 : i64
+    llvm.store %73, %arg3 : i64, !llvm.ptr
     %c5_i64 = arith.constant 5 : i64
-    %83 = arith.cmpi ult, %81, %c5_i64 : i64
+    %74 = arith.cmpi ult, %72, %c5_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %83, ^bb1(%c91_i8 : i8), ^bb23
+    cf.cond_br %74, ^bb1(%c91_i8 : i8), ^bb23
   ^bb30:  // pred: ^bb19
-    %84 = llvm.load %arg1 : !llvm.ptr -> i64
+    %75 = llvm.load %arg1 : !llvm.ptr -> i64
     %c1500_i64 = arith.constant 1500 : i64
     call @dora_fn_nop() : () -> ()
-    %85 = arith.cmpi uge, %84, %c1500_i64 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %85, ^bb31, ^bb1(%c80_i8_38 : i8)
+    %76 = arith.cmpi uge, %75, %c1500_i64 : i64
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %76, ^bb31, ^bb1(%c80_i8_29 : i8)
   ^bb31:  // pred: ^bb30
-    %86 = arith.subi %84, %c1500_i64 : i64
-    llvm.store %86, %arg1 : i64, !llvm.ptr
+    %77 = arith.subi %75, %c1500_i64 : i64
+    llvm.store %77, %arg1 : i64, !llvm.ptr
     cf.br ^bb29
   ^bb32:  // pred: ^bb28
-    %c0_i64_39 = arith.constant 0 : i64
+    %c0_i64_30 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %87 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_39, %c0_i64_39, %87, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %78 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %78, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb33:  // pred: ^bb27
-    %c18446744073709551615_i256_40 = arith.constant 18446744073709551615 : i256
-    %88 = arith.cmpi sgt, %51, %c18446744073709551615_i256_40 : i256
-    %c84_i8_41 = arith.constant 84 : i8
-    cf.cond_br %88, ^bb1(%c84_i8_41 : i8), ^bb34
+    %c18446744073709551615_i256_31 = arith.constant 18446744073709551615 : i256
+    %79 = arith.cmpi sgt, %46, %c18446744073709551615_i256_31 : i256
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %79, ^bb1(%c84_i8_32 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %89 = arith.trunci %51 : i256 to i64
-    %c0_i64_42 = arith.constant 0 : i64
-    %90 = arith.cmpi slt, %89, %c0_i64_42 : i64
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %90, ^bb1(%c84_i8_43 : i8), ^bb35
+    %80 = arith.trunci %46 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %81 = arith.cmpi slt, %80, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %81, ^bb1(%c84_i8_34 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %91 = arith.addi %89, %71 : i64
-    %c0_i64_44 = arith.constant 0 : i64
-    %92 = arith.cmpi slt, %91, %c0_i64_44 : i64
-    %c84_i8_45 = arith.constant 84 : i8
-    cf.cond_br %92, ^bb1(%c84_i8_45 : i8), ^bb36
+    %82 = arith.addi %80, %62 : i64
+    %c0_i64_35 = arith.constant 0 : i64
+    %83 = arith.cmpi slt, %82, %c0_i64_35 : i64
+    %c84_i8_36 = arith.constant 84 : i8
+    cf.cond_br %83, ^bb1(%c84_i8_36 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %93 = arith.addi %91, %c31_i64 : i64
-    %94 = arith.divui %93, %c32_i64 : i64
-    %c32_i64_46 = arith.constant 32 : i64
-    %95 = arith.muli %94, %c32_i64_46 : i64
-    %96 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_47 = arith.constant 31 : i64
-    %c32_i64_48 = arith.constant 32 : i64
-    %97 = arith.addi %96, %c31_i64_47 : i64
-    %98 = arith.divui %97, %c32_i64_48 : i64
-    %99 = arith.muli %98, %c32_i64_46 : i64
-    %100 = arith.cmpi ult, %99, %95 : i64
-    cf.cond_br %100, ^bb38, ^bb37
+    %84 = arith.addi %82, %c31_i64 : i64
+    %85 = arith.divui %84, %c32_i64 : i64
+    %c32_i64_37 = arith.constant 32 : i64
+    %86 = arith.muli %85, %c32_i64_37 : i64
+    %87 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_38 = arith.constant 31 : i64
+    %c32_i64_39 = arith.constant 32 : i64
+    %88 = arith.addi %87, %c31_i64_38 : i64
+    %89 = arith.divui %88, %c32_i64_39 : i64
+    %90 = arith.muli %89, %c32_i64_37 : i64
+    %91 = arith.cmpi ult, %90, %86 : i64
+    cf.cond_br %91, ^bb38, ^bb37
   ^bb37:  // 2 preds: ^bb36, ^bb40
     cf.br ^bb28
   ^bb38:  // pred: ^bb36
-    %c3_i64_49 = arith.constant 3 : i64
+    %c3_i64_40 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %101 = arith.muli %98, %98 : i64
-    %102 = arith.divui %101, %c512_i64 : i64
-    %103 = arith.muli %98, %c3_i64_49 : i64
-    %104 = arith.addi %102, %103 : i64
-    %c3_i64_50 = arith.constant 3 : i64
-    %c512_i64_51 = arith.constant 512 : i64
-    %105 = arith.muli %94, %94 : i64
-    %106 = arith.divui %105, %c512_i64_51 : i64
-    %107 = arith.muli %94, %c3_i64_50 : i64
-    %108 = arith.addi %106, %107 : i64
-    %109 = arith.subi %108, %104 : i64
-    %110 = llvm.load %arg1 : !llvm.ptr -> i64
-    %111 = arith.cmpi ult, %110, %109 : i64
-    scf.if %111 {
+    %92 = arith.muli %89, %89 : i64
+    %93 = arith.divui %92, %c512_i64 : i64
+    %94 = arith.muli %89, %c3_i64_40 : i64
+    %95 = arith.addi %93, %94 : i64
+    %c3_i64_41 = arith.constant 3 : i64
+    %c512_i64_42 = arith.constant 512 : i64
+    %96 = arith.muli %85, %85 : i64
+    %97 = arith.divui %96, %c512_i64_42 : i64
+    %98 = arith.muli %85, %c3_i64_41 : i64
+    %99 = arith.addi %97, %98 : i64
+    %100 = arith.subi %99, %95 : i64
+    %101 = llvm.load %arg1 : !llvm.ptr -> i64
+    %102 = arith.cmpi ult, %101, %100 : i64
+    scf.if %102 {
     } else {
-      %116 = arith.subi %110, %109 : i64
-      llvm.store %116, %arg1 : i64, !llvm.ptr
+      %107 = arith.subi %101, %100 : i64
+      llvm.store %107, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_52 = arith.constant 80 : i8
-    cf.cond_br %111, ^bb1(%c80_i8_52 : i8), ^bb39
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %102, ^bb1(%c80_i8_43 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %112 = call @dora_fn_extend_memory(%arg0, %95) : (!llvm.ptr, i64) -> !llvm.ptr
-    %113 = llvm.getelementptr %112[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %114 = llvm.load %113 : !llvm.ptr -> i8
-    %c0_i8_53 = arith.constant 0 : i8
-    %115 = arith.cmpi ne, %114, %c0_i8_53 : i8
-    cf.cond_br %115, ^bb1(%114 : i8), ^bb40
+    %103 = call @dora_fn_extend_memory(%arg0, %86) : (!llvm.ptr, i64) -> !llvm.ptr
+    %104 = llvm.getelementptr %103[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %105 = llvm.load %104 : !llvm.ptr -> i8
+    %c0_i8_44 = arith.constant 0 : i8
+    %106 = arith.cmpi ne, %105, %c0_i8_44 : i8
+    cf.cond_br %106, ^bb1(%105 : i8), ^bb40
   ^bb40:  // pred: ^bb39
     cf.br ^bb37
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log4.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__log4.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 24 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb27, ^bb28, ^bb29, ^bb30, ^bb33, ^bb34, ^bb37, ^bb38, ^bb39, ^bb42, ^bb43
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 24 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb27, ^bb28, ^bb29, ^bb30, ^bb33, ^bb34, ^bb37, ^bb38, ^bb39, ^bb42, ^bb43
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,319 +96,303 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c2_i256 = arith.constant 2 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
     %c3_i256 = arith.constant 3 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_19 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c3_i256, %40 : i256, !llvm.ptr
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3_i256, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_21 : i64
-    %44 = arith.cmpi ult, %c1024_i64_20, %43 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_22 : i8), ^bb19
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_17 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_16, %39 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_18 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb22, ^bb1(%c80_i8_24 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_20 : i8)
   ^bb22:  // pred: ^bb21
-    %47 = arith.subi %45, %c3_i64_23 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_19 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
     %c4_i256 = arith.constant 4 : i256
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_25 = arith.constant 1 : i64
-    %50 = arith.addi %48, %c1_i64_25 : i64
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    llvm.store %c4_i256, %49 : i256, !llvm.ptr
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4_i256, %44 : i256, !llvm.ptr
+    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb34
   ^bb24:  // pred: ^bb26
-    %c1024_i64_26 = arith.constant 1024 : i64
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %52 = arith.addi %51, %c1_i64_27 : i64
-    %53 = arith.cmpi ult, %c1024_i64_26, %52 : i64
-    %c92_i8_28 = arith.constant 92 : i8
-    cf.cond_br %53, ^bb1(%c92_i8_28 : i8), ^bb23
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %47 = arith.addi %46, %c1_i64_22 : i64
+    llvm.store %47, %arg3 : i64, !llvm.ptr
+    %48 = arith.cmpi ult, %c1024_i64_21, %47 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %48, ^bb1(%c92_i8_23 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_29 = arith.constant 3 : i64
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %55 = arith.cmpi uge, %54, %c3_i64_29 : i64
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %55, ^bb26, ^bb1(%c80_i8_30 : i8)
+    %50 = arith.cmpi uge, %49, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %50, ^bb26, ^bb1(%c80_i8_25 : i8)
   ^bb26:  // pred: ^bb25
-    %56 = arith.subi %54, %c3_i64_29 : i64
-    llvm.store %56, %arg1 : i64, !llvm.ptr
+    %51 = arith.subi %49, %c3_i64_24 : i64
+    llvm.store %51, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb33
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_31 = arith.constant 1 : i64
-    %58 = arith.subi %57, %c1_i64_31 : i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %58, %arg3 : i64, !llvm.ptr
+    %52 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %0 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %0 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %60 = llvm.load %59 : !llvm.ptr -> i256
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %62 = arith.subi %61, %c1_i64_32 : i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %62, %arg3 : i64, !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> i256
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %66 = arith.subi %65, %c1_i64_33 : i64
-    %67 = llvm.getelementptr %arg2[%66] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %66, %arg3 : i64, !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> i256
-    %69 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %70 = arith.subi %69, %c1_i64_34 : i64
-    %71 = llvm.getelementptr %arg2[%70] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %70, %arg3 : i64, !llvm.ptr
-    %72 = llvm.load %71 : !llvm.ptr -> i256
-    %73 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %74 = arith.subi %73, %c1_i64_35 : i64
-    %75 = llvm.getelementptr %arg2[%74] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %74, %arg3 : i64, !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_36 = arith.constant 1 : i64
-    %78 = arith.subi %77, %c1_i64_36 : i64
-    %79 = llvm.getelementptr %arg2[%78] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %78, %arg3 : i64, !llvm.ptr
-    %80 = llvm.load %79 : !llvm.ptr -> i256
-    %81 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %59, %0 : !llvm.ptr, !llvm.ptr
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %82, ^bb1(%c87_i8 : i8), ^bb28
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %83 = arith.cmpi sgt, %64, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %57, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8 : i8), ^bb29
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %84 = arith.trunci %64 : i256 to i64
-    %c0_i64_37 = arith.constant 0 : i64
-    %85 = arith.cmpi slt, %84, %c0_i64_37 : i64
-    %c84_i8_38 = arith.constant 84 : i8
-    cf.cond_br %85, ^bb1(%c84_i8_38 : i8), ^bb30
+    %73 = arith.trunci %57 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb30
   ^bb30:  // pred: ^bb29
     %c8_i64 = arith.constant 8 : i64
-    %86 = arith.muli %84, %c8_i64 : i64
-    %87 = llvm.load %arg1 : !llvm.ptr -> i64
-    %88 = arith.cmpi ult, %87, %86 : i64
-    scf.if %88 {
+    %75 = arith.muli %73, %c8_i64 : i64
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %75 : i64
+    scf.if %77 {
     } else {
-      %130 = arith.subi %87, %86 : i64
-      llvm.store %130, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %76, %75 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_39 = arith.constant 80 : i8
-    cf.cond_br %88, ^bb1(%c80_i8_39 : i8), ^bb31
+    %c80_i8_28 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_28 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_40 = arith.constant 0 : i64
-    %89 = arith.cmpi ne, %84, %c0_i64_40 : i64
-    cf.cond_br %89, ^bb37, ^bb32
+    %c0_i64_29 = arith.constant 0 : i64
+    %78 = arith.cmpi ne, %73, %c0_i64_29 : i64
+    cf.cond_br %78, ^bb37, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb41
-    %90 = arith.trunci %60 : i256 to i64
-    %c1_i256_41 = arith.constant 1 : i256
-    %91 = llvm.alloca %c1_i256_41 x i256 : (i256) -> !llvm.ptr
-    llvm.store %68, %91 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_42 = arith.constant 1 : i256
-    %92 = llvm.alloca %c1_i256_42 x i256 : (i256) -> !llvm.ptr
-    llvm.store %72, %92 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_43 = arith.constant 1 : i256
-    %93 = llvm.alloca %c1_i256_43 x i256 : (i256) -> !llvm.ptr
-    llvm.store %76, %93 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_44 = arith.constant 1 : i256
-    %94 = llvm.alloca %c1_i256_44 x i256 : (i256) -> !llvm.ptr
-    llvm.store %80, %94 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_append_log_with_four_topics(%arg0, %90, %84, %91, %92, %93, %94) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %79 = arith.trunci %54 : i256 to i64
+    %c1_i256_30 = arith.constant 1 : i256
+    %80 = llvm.alloca %c1_i256_30 x i256 : (i256) -> !llvm.ptr
+    llvm.store %60, %80 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_31 = arith.constant 1 : i256
+    %81 = llvm.alloca %c1_i256_31 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_32 = arith.constant 1 : i256
+    %82 = llvm.alloca %c1_i256_32 x i256 : (i256) -> !llvm.ptr
+    llvm.store %66, %82 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_33 = arith.constant 1 : i256
+    %83 = llvm.alloca %c1_i256_33 x i256 : (i256) -> !llvm.ptr
+    llvm.store %69, %83 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_append_log_with_four_topics(%arg0, %79, %73, %80, %81, %82, %83) : (!llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb36
   ^bb33:  // pred: ^bb35
-    %c1024_i64_45 = arith.constant 1024 : i64
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_34 = arith.constant 1024 : i64
+    %84 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %96 = arith.addi %95, %c-6_i64 : i64
+    %85 = arith.addi %84, %c-6_i64 : i64
+    llvm.store %85, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %97 = arith.cmpi ult, %95, %c6_i64 : i64
+    %86 = arith.cmpi ult, %84, %c6_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %97, ^bb1(%c91_i8 : i8), ^bb27
+    cf.cond_br %86, ^bb1(%c91_i8 : i8), ^bb27
   ^bb34:  // pred: ^bb23
-    %98 = llvm.load %arg1 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
     %c1875_i64 = arith.constant 1875 : i64
     call @dora_fn_nop() : () -> ()
-    %99 = arith.cmpi uge, %98, %c1875_i64 : i64
-    %c80_i8_46 = arith.constant 80 : i8
-    cf.cond_br %99, ^bb35, ^bb1(%c80_i8_46 : i8)
+    %88 = arith.cmpi uge, %87, %c1875_i64 : i64
+    %c80_i8_35 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb35, ^bb1(%c80_i8_35 : i8)
   ^bb35:  // pred: ^bb34
-    %100 = arith.subi %98, %c1875_i64 : i64
-    llvm.store %100, %arg1 : i64, !llvm.ptr
+    %89 = arith.subi %87, %c1875_i64 : i64
+    llvm.store %89, %arg1 : i64, !llvm.ptr
     cf.br ^bb33
   ^bb36:  // pred: ^bb32
-    %c0_i64_47 = arith.constant 0 : i64
+    %c0_i64_36 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_47, %c0_i64_47, %101, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %90 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_36, %c0_i64_36, %90, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb37:  // pred: ^bb31
-    %c18446744073709551615_i256_48 = arith.constant 18446744073709551615 : i256
-    %102 = arith.cmpi sgt, %60, %c18446744073709551615_i256_48 : i256
-    %c84_i8_49 = arith.constant 84 : i8
-    cf.cond_br %102, ^bb1(%c84_i8_49 : i8), ^bb38
+    %c18446744073709551615_i256_37 = arith.constant 18446744073709551615 : i256
+    %91 = arith.cmpi sgt, %54, %c18446744073709551615_i256_37 : i256
+    %c84_i8_38 = arith.constant 84 : i8
+    cf.cond_br %91, ^bb1(%c84_i8_38 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %103 = arith.trunci %60 : i256 to i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %104 = arith.cmpi slt, %103, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %104, ^bb1(%c84_i8_51 : i8), ^bb39
+    %92 = arith.trunci %54 : i256 to i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_39 : i64
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_40 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %105 = arith.addi %103, %84 : i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %106 = arith.cmpi slt, %105, %c0_i64_52 : i64
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %106, ^bb1(%c84_i8_53 : i8), ^bb40
+    %94 = arith.addi %92, %73 : i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %95 = arith.cmpi slt, %94, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %95, ^bb1(%c84_i8_42 : i8), ^bb40
   ^bb40:  // pred: ^bb39
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %107 = arith.addi %105, %c31_i64 : i64
-    %108 = arith.divui %107, %c32_i64 : i64
-    %c32_i64_54 = arith.constant 32 : i64
-    %109 = arith.muli %108, %c32_i64_54 : i64
-    %110 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_55 = arith.constant 31 : i64
-    %c32_i64_56 = arith.constant 32 : i64
-    %111 = arith.addi %110, %c31_i64_55 : i64
-    %112 = arith.divui %111, %c32_i64_56 : i64
-    %113 = arith.muli %112, %c32_i64_54 : i64
-    %114 = arith.cmpi ult, %113, %109 : i64
-    cf.cond_br %114, ^bb42, ^bb41
+    %96 = arith.addi %94, %c31_i64 : i64
+    %97 = arith.divui %96, %c32_i64 : i64
+    %c32_i64_43 = arith.constant 32 : i64
+    %98 = arith.muli %97, %c32_i64_43 : i64
+    %99 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_44 = arith.constant 31 : i64
+    %c32_i64_45 = arith.constant 32 : i64
+    %100 = arith.addi %99, %c31_i64_44 : i64
+    %101 = arith.divui %100, %c32_i64_45 : i64
+    %102 = arith.muli %101, %c32_i64_43 : i64
+    %103 = arith.cmpi ult, %102, %98 : i64
+    cf.cond_br %103, ^bb42, ^bb41
   ^bb41:  // 2 preds: ^bb40, ^bb44
     cf.br ^bb32
   ^bb42:  // pred: ^bb40
-    %c3_i64_57 = arith.constant 3 : i64
+    %c3_i64_46 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %115 = arith.muli %112, %112 : i64
-    %116 = arith.divui %115, %c512_i64 : i64
-    %117 = arith.muli %112, %c3_i64_57 : i64
-    %118 = arith.addi %116, %117 : i64
-    %c3_i64_58 = arith.constant 3 : i64
-    %c512_i64_59 = arith.constant 512 : i64
-    %119 = arith.muli %108, %108 : i64
-    %120 = arith.divui %119, %c512_i64_59 : i64
-    %121 = arith.muli %108, %c3_i64_58 : i64
-    %122 = arith.addi %120, %121 : i64
-    %123 = arith.subi %122, %118 : i64
-    %124 = llvm.load %arg1 : !llvm.ptr -> i64
-    %125 = arith.cmpi ult, %124, %123 : i64
-    scf.if %125 {
+    %104 = arith.muli %101, %101 : i64
+    %105 = arith.divui %104, %c512_i64 : i64
+    %106 = arith.muli %101, %c3_i64_46 : i64
+    %107 = arith.addi %105, %106 : i64
+    %c3_i64_47 = arith.constant 3 : i64
+    %c512_i64_48 = arith.constant 512 : i64
+    %108 = arith.muli %97, %97 : i64
+    %109 = arith.divui %108, %c512_i64_48 : i64
+    %110 = arith.muli %97, %c3_i64_47 : i64
+    %111 = arith.addi %109, %110 : i64
+    %112 = arith.subi %111, %107 : i64
+    %113 = llvm.load %arg1 : !llvm.ptr -> i64
+    %114 = arith.cmpi ult, %113, %112 : i64
+    scf.if %114 {
     } else {
-      %130 = arith.subi %124, %123 : i64
-      llvm.store %130, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %113, %112 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_60 = arith.constant 80 : i8
-    cf.cond_br %125, ^bb1(%c80_i8_60 : i8), ^bb43
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %114, ^bb1(%c80_i8_49 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %126 = call @dora_fn_extend_memory(%arg0, %109) : (!llvm.ptr, i64) -> !llvm.ptr
-    %127 = llvm.getelementptr %126[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %128 = llvm.load %127 : !llvm.ptr -> i8
-    %c0_i8_61 = arith.constant 0 : i8
-    %129 = arith.cmpi ne, %128, %c0_i8_61 : i8
-    cf.cond_br %129, ^bb1(%128 : i8), ^bb44
+    %115 = call @dora_fn_extend_memory(%arg0, %98) : (!llvm.ptr, i64) -> !llvm.ptr
+    %116 = llvm.getelementptr %115[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %117 = llvm.load %116 : !llvm.ptr -> i8
+    %c0_i8_50 = arith.constant 0 : i8
+    %118 = arith.cmpi ne, %117, %c0_i8_50 : i8
+    cf.cond_br %118, ^bb1(%117 : i8), ^bb44
   ^bb44:  // pred: ^bb43
     cf.br ^bb41
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb23, ^bb26, ^bb27, ^bb28, ^bb31, ^bb32, ^bb34, ^bb35, ^bb36, ^bb39, ^bb40
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb23, ^bb26, ^bb27, ^bb28, ^bb31, ^bb32, ^bb34, ^bb35, ^bb36, ^bb39, ^bb40
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,284 +96,276 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c42_i256 = arith.constant 42 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c42_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c42_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb26, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb26, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb30
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c0_i256_13 = arith.constant 0 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_13, %41 : i256, !llvm.ptr
+    %c0_i256_10 = arith.constant 0 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb22
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %50 = arith.subi %49, %c1_i64_20 : i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    %c32_i64_21 = arith.constant 32 : i64
-    %c0_i64_22 = arith.constant 0 : i64
-    %53 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
-    cf.cond_br %53, ^bb34, ^bb21
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_16 = arith.constant 32 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %48 = arith.cmpi ne, %c32_i64_16, %c0_i64_17 : i64
+    cf.cond_br %48, ^bb34, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb38
-    %54 = arith.trunci %52 : i256 to i64
-    %55 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %56 = llvm.getelementptr %55[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %57 = llvm.load %56 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %58 = llvm.intr.bswap(%57)  : (i256) -> i256
-    %59 = llvm.load %arg3 : !llvm.ptr -> i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_23 = arith.constant 1 : i64
-    %61 = arith.addi %59, %c1_i64_23 : i64
-    llvm.store %61, %arg3 : i64, !llvm.ptr
-    llvm.store %58, %60 : i256, !llvm.ptr
+    %49 = arith.trunci %47 : i256 to i64
+    %50 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %52 = llvm.load %51 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %53 = llvm.intr.bswap(%52)  : (i256) -> i256
+    %54 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %53, %54 : i256, !llvm.ptr
+    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %55, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb22:  // pred: ^bb24
-    %c1024_i64_24 = arith.constant 1024 : i64
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
-    %63 = arith.addi %62, %c0_i64_25 : i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %64 = arith.cmpi ult, %62, %c1_i64_26 : i64
-    %c91_i8_27 = arith.constant 91 : i8
-    cf.cond_br %64, ^bb1(%c91_i8_27 : i8), ^bb20
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %56 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_19 = arith.constant 0 : i64
+    %57 = arith.addi %56, %c0_i64_19 : i64
+    llvm.store %57, %arg3 : i64, !llvm.ptr
+    %c1_i64_20 = arith.constant 1 : i64
+    %58 = arith.cmpi ult, %56, %c1_i64_20 : i64
+    %c91_i8_21 = arith.constant 91 : i8
+    cf.cond_br %58, ^bb1(%c91_i8_21 : i8), ^bb20
   ^bb23:  // pred: ^bb16
-    %65 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_28 = arith.constant 3 : i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_22 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %66 = arith.cmpi uge, %65, %c3_i64_28 : i64
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %66, ^bb24, ^bb1(%c80_i8_29 : i8)
+    %60 = arith.cmpi uge, %59, %c3_i64_22 : i64
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb24, ^bb1(%c80_i8_23 : i8)
   ^bb24:  // pred: ^bb23
-    %67 = arith.subi %65, %c3_i64_28 : i64
-    llvm.store %67, %arg1 : i64, !llvm.ptr
+    %61 = arith.subi %59, %c3_i64_22 : i64
+    llvm.store %61, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb21
-    %c0_i64_30 = arith.constant 0 : i64
+    %c0_i64_24 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %68, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %62, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb26:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %69 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %63 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %69, ^bb1(%c84_i8 : i8), ^bb27
+    cf.cond_br %63, ^bb1(%c84_i8 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %70 = arith.trunci %24 : i256 to i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %71 = arith.cmpi slt, %70, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %71, ^bb1(%c84_i8_32 : i8), ^bb28
+    %64 = arith.trunci %22 : i256 to i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %65 = arith.cmpi slt, %64, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %65, ^bb1(%c84_i8_26 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %72 = arith.addi %70, %c32_i64 : i64
-    %c0_i64_33 = arith.constant 0 : i64
-    %73 = arith.cmpi slt, %72, %c0_i64_33 : i64
-    %c84_i8_34 = arith.constant 84 : i8
-    cf.cond_br %73, ^bb1(%c84_i8_34 : i8), ^bb29
+    %66 = arith.addi %64, %c32_i64 : i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %67 = arith.cmpi slt, %66, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %67, ^bb1(%c84_i8_28 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %74 = arith.addi %72, %c31_i64 : i64
-    %75 = arith.divui %74, %c32_i64_35 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %76 = arith.muli %75, %c32_i64_36 : i64
-    %77 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_37 = arith.constant 31 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %78 = arith.addi %77, %c31_i64_37 : i64
-    %79 = arith.divui %78, %c32_i64_38 : i64
-    %80 = arith.muli %79, %c32_i64_36 : i64
-    %81 = arith.cmpi ult, %80, %76 : i64
-    cf.cond_br %81, ^bb31, ^bb30
+    %c32_i64_29 = arith.constant 32 : i64
+    %68 = arith.addi %66, %c31_i64 : i64
+    %69 = arith.divui %68, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %70 = arith.muli %69, %c32_i64_30 : i64
+    %71 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %72 = arith.addi %71, %c31_i64_31 : i64
+    %73 = arith.divui %72, %c32_i64_32 : i64
+    %74 = arith.muli %73, %c32_i64_30 : i64
+    %75 = arith.cmpi ult, %74, %70 : i64
+    cf.cond_br %75, ^bb31, ^bb30
   ^bb30:  // 2 preds: ^bb29, ^bb33
     cf.br ^bb12
   ^bb31:  // pred: ^bb29
-    %c3_i64_39 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %82 = arith.muli %79, %79 : i64
-    %83 = arith.divui %82, %c512_i64 : i64
-    %84 = arith.muli %79, %c3_i64_39 : i64
-    %85 = arith.addi %83, %84 : i64
-    %c3_i64_40 = arith.constant 3 : i64
-    %c512_i64_41 = arith.constant 512 : i64
-    %86 = arith.muli %75, %75 : i64
-    %87 = arith.divui %86, %c512_i64_41 : i64
-    %88 = arith.muli %75, %c3_i64_40 : i64
-    %89 = arith.addi %87, %88 : i64
-    %90 = arith.subi %89, %85 : i64
-    %91 = llvm.load %arg1 : !llvm.ptr -> i64
-    %92 = arith.cmpi ult, %91, %90 : i64
-    scf.if %92 {
+    %76 = arith.muli %73, %73 : i64
+    %77 = arith.divui %76, %c512_i64 : i64
+    %78 = arith.muli %73, %c3_i64_33 : i64
+    %79 = arith.addi %77, %78 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %80 = arith.muli %69, %69 : i64
+    %81 = arith.divui %80, %c512_i64_35 : i64
+    %82 = arith.muli %69, %c3_i64_34 : i64
+    %83 = arith.addi %81, %82 : i64
+    %84 = arith.subi %83, %79 : i64
+    %85 = llvm.load %arg1 : !llvm.ptr -> i64
+    %86 = arith.cmpi ult, %85, %84 : i64
+    scf.if %86 {
     } else {
-      %125 = arith.subi %91, %90 : i64
-      llvm.store %125, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %85, %84 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_42 = arith.constant 80 : i8
-    cf.cond_br %92, ^bb1(%c80_i8_42 : i8), ^bb32
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %86, ^bb1(%c80_i8_36 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %93 = call @dora_fn_extend_memory(%arg0, %76) : (!llvm.ptr, i64) -> !llvm.ptr
-    %94 = llvm.getelementptr %93[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i8
+    %87 = call @dora_fn_extend_memory(%arg0, %70) : (!llvm.ptr, i64) -> !llvm.ptr
+    %88 = llvm.getelementptr %87[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %89 = llvm.load %88 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %96 = arith.cmpi ne, %95, %c0_i8 : i8
-    cf.cond_br %96, ^bb1(%95 : i8), ^bb33
+    %90 = arith.cmpi ne, %89, %c0_i8 : i8
+    cf.cond_br %90, ^bb1(%89 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     cf.br ^bb30
   ^bb34:  // pred: ^bb20
-    %c18446744073709551615_i256_43 = arith.constant 18446744073709551615 : i256
-    %97 = arith.cmpi sgt, %52, %c18446744073709551615_i256_43 : i256
-    %c84_i8_44 = arith.constant 84 : i8
-    cf.cond_br %97, ^bb1(%c84_i8_44 : i8), ^bb35
+    %c18446744073709551615_i256_37 = arith.constant 18446744073709551615 : i256
+    %91 = arith.cmpi sgt, %47, %c18446744073709551615_i256_37 : i256
+    %c84_i8_38 = arith.constant 84 : i8
+    cf.cond_br %91, ^bb1(%c84_i8_38 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = arith.trunci %52 : i256 to i64
-    %c0_i64_45 = arith.constant 0 : i64
-    %99 = arith.cmpi slt, %98, %c0_i64_45 : i64
-    %c84_i8_46 = arith.constant 84 : i8
-    cf.cond_br %99, ^bb1(%c84_i8_46 : i8), ^bb36
+    %92 = arith.trunci %47 : i256 to i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_39 : i64
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_40 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %100 = arith.addi %98, %c32_i64_21 : i64
-    %c0_i64_47 = arith.constant 0 : i64
-    %101 = arith.cmpi slt, %100, %c0_i64_47 : i64
-    %c84_i8_48 = arith.constant 84 : i8
-    cf.cond_br %101, ^bb1(%c84_i8_48 : i8), ^bb37
+    %94 = arith.addi %92, %c32_i64_16 : i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %95 = arith.cmpi slt, %94, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %95, ^bb1(%c84_i8_42 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %c31_i64_49 = arith.constant 31 : i64
-    %c32_i64_50 = arith.constant 32 : i64
-    %102 = arith.addi %100, %c31_i64_49 : i64
-    %103 = arith.divui %102, %c32_i64_50 : i64
-    %c32_i64_51 = arith.constant 32 : i64
-    %104 = arith.muli %103, %c32_i64_51 : i64
-    %105 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_52 = arith.constant 31 : i64
-    %c32_i64_53 = arith.constant 32 : i64
-    %106 = arith.addi %105, %c31_i64_52 : i64
-    %107 = arith.divui %106, %c32_i64_53 : i64
-    %108 = arith.muli %107, %c32_i64_51 : i64
-    %109 = arith.cmpi ult, %108, %104 : i64
-    cf.cond_br %109, ^bb39, ^bb38
+    %c31_i64_43 = arith.constant 31 : i64
+    %c32_i64_44 = arith.constant 32 : i64
+    %96 = arith.addi %94, %c31_i64_43 : i64
+    %97 = arith.divui %96, %c32_i64_44 : i64
+    %c32_i64_45 = arith.constant 32 : i64
+    %98 = arith.muli %97, %c32_i64_45 : i64
+    %99 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_46 = arith.constant 31 : i64
+    %c32_i64_47 = arith.constant 32 : i64
+    %100 = arith.addi %99, %c31_i64_46 : i64
+    %101 = arith.divui %100, %c32_i64_47 : i64
+    %102 = arith.muli %101, %c32_i64_45 : i64
+    %103 = arith.cmpi ult, %102, %98 : i64
+    cf.cond_br %103, ^bb39, ^bb38
   ^bb38:  // 2 preds: ^bb37, ^bb41
     cf.br ^bb21
   ^bb39:  // pred: ^bb37
-    %c3_i64_54 = arith.constant 3 : i64
-    %c512_i64_55 = arith.constant 512 : i64
-    %110 = arith.muli %107, %107 : i64
-    %111 = arith.divui %110, %c512_i64_55 : i64
-    %112 = arith.muli %107, %c3_i64_54 : i64
-    %113 = arith.addi %111, %112 : i64
-    %c3_i64_56 = arith.constant 3 : i64
-    %c512_i64_57 = arith.constant 512 : i64
-    %114 = arith.muli %103, %103 : i64
-    %115 = arith.divui %114, %c512_i64_57 : i64
-    %116 = arith.muli %103, %c3_i64_56 : i64
-    %117 = arith.addi %115, %116 : i64
-    %118 = arith.subi %117, %113 : i64
-    %119 = llvm.load %arg1 : !llvm.ptr -> i64
-    %120 = arith.cmpi ult, %119, %118 : i64
-    scf.if %120 {
+    %c3_i64_48 = arith.constant 3 : i64
+    %c512_i64_49 = arith.constant 512 : i64
+    %104 = arith.muli %101, %101 : i64
+    %105 = arith.divui %104, %c512_i64_49 : i64
+    %106 = arith.muli %101, %c3_i64_48 : i64
+    %107 = arith.addi %105, %106 : i64
+    %c3_i64_50 = arith.constant 3 : i64
+    %c512_i64_51 = arith.constant 512 : i64
+    %108 = arith.muli %97, %97 : i64
+    %109 = arith.divui %108, %c512_i64_51 : i64
+    %110 = arith.muli %97, %c3_i64_50 : i64
+    %111 = arith.addi %109, %110 : i64
+    %112 = arith.subi %111, %107 : i64
+    %113 = llvm.load %arg1 : !llvm.ptr -> i64
+    %114 = arith.cmpi ult, %113, %112 : i64
+    scf.if %114 {
     } else {
-      %125 = arith.subi %119, %118 : i64
-      llvm.store %125, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %113, %112 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_58 = arith.constant 80 : i8
-    cf.cond_br %120, ^bb1(%c80_i8_58 : i8), ^bb40
+    %c80_i8_52 = arith.constant 80 : i8
+    cf.cond_br %114, ^bb1(%c80_i8_52 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %121 = call @dora_fn_extend_memory(%arg0, %104) : (!llvm.ptr, i64) -> !llvm.ptr
-    %122 = llvm.getelementptr %121[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %123 = llvm.load %122 : !llvm.ptr -> i8
-    %c0_i8_59 = arith.constant 0 : i8
-    %124 = arith.cmpi ne, %123, %c0_i8_59 : i8
-    cf.cond_br %124, ^bb1(%123 : i8), ^bb41
+    %115 = call @dora_fn_extend_memory(%arg0, %98) : (!llvm.ptr, i64) -> !llvm.ptr
+    %116 = llvm.getelementptr %115[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %117 = llvm.load %116 : !llvm.ptr -> i8
+    %c0_i8_53 = arith.constant 0 : i8
+    %118 = arith.cmpi ne, %117, %c0_i8_53 : i8
+    cf.cond_br %118, ^bb1(%117 : i8), ^bb41
   ^bb41:  // pred: ^bb40
     cf.br ^bb38
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_high_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_high_address.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb23, ^bb26, ^bb27, ^bb28, ^bb31, ^bb32, ^bb34, ^bb35, ^bb36, ^bb39, ^bb40
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb23, ^bb26, ^bb27, ^bb28, ^bb31, ^bb32, ^bb34, ^bb35, ^bb36, ^bb39, ^bb40
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1024_i256 = arith.constant 1024 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1024_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,284 +96,276 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c987654321_i256 = arith.constant 987654321 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c987654321_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c987654321_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb26, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb26, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb30
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c1024_i256_13 = arith.constant 1024 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c1024_i256_13, %41 : i256, !llvm.ptr
+    %c1024_i256_10 = arith.constant 1024 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1024_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb22
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %50 = arith.subi %49, %c1_i64_20 : i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    %c32_i64_21 = arith.constant 32 : i64
-    %c0_i64_22 = arith.constant 0 : i64
-    %53 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
-    cf.cond_br %53, ^bb34, ^bb21
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_16 = arith.constant 32 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %48 = arith.cmpi ne, %c32_i64_16, %c0_i64_17 : i64
+    cf.cond_br %48, ^bb34, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb38
-    %54 = arith.trunci %52 : i256 to i64
-    %55 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %56 = llvm.getelementptr %55[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %57 = llvm.load %56 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %58 = llvm.intr.bswap(%57)  : (i256) -> i256
-    %59 = llvm.load %arg3 : !llvm.ptr -> i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_23 = arith.constant 1 : i64
-    %61 = arith.addi %59, %c1_i64_23 : i64
-    llvm.store %61, %arg3 : i64, !llvm.ptr
-    llvm.store %58, %60 : i256, !llvm.ptr
+    %49 = arith.trunci %47 : i256 to i64
+    %50 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %52 = llvm.load %51 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %53 = llvm.intr.bswap(%52)  : (i256) -> i256
+    %54 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %53, %54 : i256, !llvm.ptr
+    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %55, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb22:  // pred: ^bb24
-    %c1024_i64_24 = arith.constant 1024 : i64
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
-    %63 = arith.addi %62, %c0_i64_25 : i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %64 = arith.cmpi ult, %62, %c1_i64_26 : i64
-    %c91_i8_27 = arith.constant 91 : i8
-    cf.cond_br %64, ^bb1(%c91_i8_27 : i8), ^bb20
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %56 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_19 = arith.constant 0 : i64
+    %57 = arith.addi %56, %c0_i64_19 : i64
+    llvm.store %57, %arg3 : i64, !llvm.ptr
+    %c1_i64_20 = arith.constant 1 : i64
+    %58 = arith.cmpi ult, %56, %c1_i64_20 : i64
+    %c91_i8_21 = arith.constant 91 : i8
+    cf.cond_br %58, ^bb1(%c91_i8_21 : i8), ^bb20
   ^bb23:  // pred: ^bb16
-    %65 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_28 = arith.constant 3 : i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_22 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %66 = arith.cmpi uge, %65, %c3_i64_28 : i64
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %66, ^bb24, ^bb1(%c80_i8_29 : i8)
+    %60 = arith.cmpi uge, %59, %c3_i64_22 : i64
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb24, ^bb1(%c80_i8_23 : i8)
   ^bb24:  // pred: ^bb23
-    %67 = arith.subi %65, %c3_i64_28 : i64
-    llvm.store %67, %arg1 : i64, !llvm.ptr
+    %61 = arith.subi %59, %c3_i64_22 : i64
+    llvm.store %61, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb21
-    %c0_i64_30 = arith.constant 0 : i64
+    %c0_i64_24 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %68, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %62, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb26:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %69 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %63 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %69, ^bb1(%c84_i8 : i8), ^bb27
+    cf.cond_br %63, ^bb1(%c84_i8 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %70 = arith.trunci %24 : i256 to i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %71 = arith.cmpi slt, %70, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %71, ^bb1(%c84_i8_32 : i8), ^bb28
+    %64 = arith.trunci %22 : i256 to i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %65 = arith.cmpi slt, %64, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %65, ^bb1(%c84_i8_26 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %72 = arith.addi %70, %c32_i64 : i64
-    %c0_i64_33 = arith.constant 0 : i64
-    %73 = arith.cmpi slt, %72, %c0_i64_33 : i64
-    %c84_i8_34 = arith.constant 84 : i8
-    cf.cond_br %73, ^bb1(%c84_i8_34 : i8), ^bb29
+    %66 = arith.addi %64, %c32_i64 : i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %67 = arith.cmpi slt, %66, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %67, ^bb1(%c84_i8_28 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %74 = arith.addi %72, %c31_i64 : i64
-    %75 = arith.divui %74, %c32_i64_35 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %76 = arith.muli %75, %c32_i64_36 : i64
-    %77 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_37 = arith.constant 31 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %78 = arith.addi %77, %c31_i64_37 : i64
-    %79 = arith.divui %78, %c32_i64_38 : i64
-    %80 = arith.muli %79, %c32_i64_36 : i64
-    %81 = arith.cmpi ult, %80, %76 : i64
-    cf.cond_br %81, ^bb31, ^bb30
+    %c32_i64_29 = arith.constant 32 : i64
+    %68 = arith.addi %66, %c31_i64 : i64
+    %69 = arith.divui %68, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %70 = arith.muli %69, %c32_i64_30 : i64
+    %71 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %72 = arith.addi %71, %c31_i64_31 : i64
+    %73 = arith.divui %72, %c32_i64_32 : i64
+    %74 = arith.muli %73, %c32_i64_30 : i64
+    %75 = arith.cmpi ult, %74, %70 : i64
+    cf.cond_br %75, ^bb31, ^bb30
   ^bb30:  // 2 preds: ^bb29, ^bb33
     cf.br ^bb12
   ^bb31:  // pred: ^bb29
-    %c3_i64_39 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %82 = arith.muli %79, %79 : i64
-    %83 = arith.divui %82, %c512_i64 : i64
-    %84 = arith.muli %79, %c3_i64_39 : i64
-    %85 = arith.addi %83, %84 : i64
-    %c3_i64_40 = arith.constant 3 : i64
-    %c512_i64_41 = arith.constant 512 : i64
-    %86 = arith.muli %75, %75 : i64
-    %87 = arith.divui %86, %c512_i64_41 : i64
-    %88 = arith.muli %75, %c3_i64_40 : i64
-    %89 = arith.addi %87, %88 : i64
-    %90 = arith.subi %89, %85 : i64
-    %91 = llvm.load %arg1 : !llvm.ptr -> i64
-    %92 = arith.cmpi ult, %91, %90 : i64
-    scf.if %92 {
+    %76 = arith.muli %73, %73 : i64
+    %77 = arith.divui %76, %c512_i64 : i64
+    %78 = arith.muli %73, %c3_i64_33 : i64
+    %79 = arith.addi %77, %78 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %80 = arith.muli %69, %69 : i64
+    %81 = arith.divui %80, %c512_i64_35 : i64
+    %82 = arith.muli %69, %c3_i64_34 : i64
+    %83 = arith.addi %81, %82 : i64
+    %84 = arith.subi %83, %79 : i64
+    %85 = llvm.load %arg1 : !llvm.ptr -> i64
+    %86 = arith.cmpi ult, %85, %84 : i64
+    scf.if %86 {
     } else {
-      %125 = arith.subi %91, %90 : i64
-      llvm.store %125, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %85, %84 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_42 = arith.constant 80 : i8
-    cf.cond_br %92, ^bb1(%c80_i8_42 : i8), ^bb32
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %86, ^bb1(%c80_i8_36 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %93 = call @dora_fn_extend_memory(%arg0, %76) : (!llvm.ptr, i64) -> !llvm.ptr
-    %94 = llvm.getelementptr %93[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i8
+    %87 = call @dora_fn_extend_memory(%arg0, %70) : (!llvm.ptr, i64) -> !llvm.ptr
+    %88 = llvm.getelementptr %87[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %89 = llvm.load %88 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %96 = arith.cmpi ne, %95, %c0_i8 : i8
-    cf.cond_br %96, ^bb1(%95 : i8), ^bb33
+    %90 = arith.cmpi ne, %89, %c0_i8 : i8
+    cf.cond_br %90, ^bb1(%89 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     cf.br ^bb30
   ^bb34:  // pred: ^bb20
-    %c18446744073709551615_i256_43 = arith.constant 18446744073709551615 : i256
-    %97 = arith.cmpi sgt, %52, %c18446744073709551615_i256_43 : i256
-    %c84_i8_44 = arith.constant 84 : i8
-    cf.cond_br %97, ^bb1(%c84_i8_44 : i8), ^bb35
+    %c18446744073709551615_i256_37 = arith.constant 18446744073709551615 : i256
+    %91 = arith.cmpi sgt, %47, %c18446744073709551615_i256_37 : i256
+    %c84_i8_38 = arith.constant 84 : i8
+    cf.cond_br %91, ^bb1(%c84_i8_38 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = arith.trunci %52 : i256 to i64
-    %c0_i64_45 = arith.constant 0 : i64
-    %99 = arith.cmpi slt, %98, %c0_i64_45 : i64
-    %c84_i8_46 = arith.constant 84 : i8
-    cf.cond_br %99, ^bb1(%c84_i8_46 : i8), ^bb36
+    %92 = arith.trunci %47 : i256 to i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_39 : i64
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_40 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %100 = arith.addi %98, %c32_i64_21 : i64
-    %c0_i64_47 = arith.constant 0 : i64
-    %101 = arith.cmpi slt, %100, %c0_i64_47 : i64
-    %c84_i8_48 = arith.constant 84 : i8
-    cf.cond_br %101, ^bb1(%c84_i8_48 : i8), ^bb37
+    %94 = arith.addi %92, %c32_i64_16 : i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %95 = arith.cmpi slt, %94, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %95, ^bb1(%c84_i8_42 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %c31_i64_49 = arith.constant 31 : i64
-    %c32_i64_50 = arith.constant 32 : i64
-    %102 = arith.addi %100, %c31_i64_49 : i64
-    %103 = arith.divui %102, %c32_i64_50 : i64
-    %c32_i64_51 = arith.constant 32 : i64
-    %104 = arith.muli %103, %c32_i64_51 : i64
-    %105 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_52 = arith.constant 31 : i64
-    %c32_i64_53 = arith.constant 32 : i64
-    %106 = arith.addi %105, %c31_i64_52 : i64
-    %107 = arith.divui %106, %c32_i64_53 : i64
-    %108 = arith.muli %107, %c32_i64_51 : i64
-    %109 = arith.cmpi ult, %108, %104 : i64
-    cf.cond_br %109, ^bb39, ^bb38
+    %c31_i64_43 = arith.constant 31 : i64
+    %c32_i64_44 = arith.constant 32 : i64
+    %96 = arith.addi %94, %c31_i64_43 : i64
+    %97 = arith.divui %96, %c32_i64_44 : i64
+    %c32_i64_45 = arith.constant 32 : i64
+    %98 = arith.muli %97, %c32_i64_45 : i64
+    %99 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_46 = arith.constant 31 : i64
+    %c32_i64_47 = arith.constant 32 : i64
+    %100 = arith.addi %99, %c31_i64_46 : i64
+    %101 = arith.divui %100, %c32_i64_47 : i64
+    %102 = arith.muli %101, %c32_i64_45 : i64
+    %103 = arith.cmpi ult, %102, %98 : i64
+    cf.cond_br %103, ^bb39, ^bb38
   ^bb38:  // 2 preds: ^bb37, ^bb41
     cf.br ^bb21
   ^bb39:  // pred: ^bb37
-    %c3_i64_54 = arith.constant 3 : i64
-    %c512_i64_55 = arith.constant 512 : i64
-    %110 = arith.muli %107, %107 : i64
-    %111 = arith.divui %110, %c512_i64_55 : i64
-    %112 = arith.muli %107, %c3_i64_54 : i64
-    %113 = arith.addi %111, %112 : i64
-    %c3_i64_56 = arith.constant 3 : i64
-    %c512_i64_57 = arith.constant 512 : i64
-    %114 = arith.muli %103, %103 : i64
-    %115 = arith.divui %114, %c512_i64_57 : i64
-    %116 = arith.muli %103, %c3_i64_56 : i64
-    %117 = arith.addi %115, %116 : i64
-    %118 = arith.subi %117, %113 : i64
-    %119 = llvm.load %arg1 : !llvm.ptr -> i64
-    %120 = arith.cmpi ult, %119, %118 : i64
-    scf.if %120 {
+    %c3_i64_48 = arith.constant 3 : i64
+    %c512_i64_49 = arith.constant 512 : i64
+    %104 = arith.muli %101, %101 : i64
+    %105 = arith.divui %104, %c512_i64_49 : i64
+    %106 = arith.muli %101, %c3_i64_48 : i64
+    %107 = arith.addi %105, %106 : i64
+    %c3_i64_50 = arith.constant 3 : i64
+    %c512_i64_51 = arith.constant 512 : i64
+    %108 = arith.muli %97, %97 : i64
+    %109 = arith.divui %108, %c512_i64_51 : i64
+    %110 = arith.muli %97, %c3_i64_50 : i64
+    %111 = arith.addi %109, %110 : i64
+    %112 = arith.subi %111, %107 : i64
+    %113 = llvm.load %arg1 : !llvm.ptr -> i64
+    %114 = arith.cmpi ult, %113, %112 : i64
+    scf.if %114 {
     } else {
-      %125 = arith.subi %119, %118 : i64
-      llvm.store %125, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %113, %112 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_58 = arith.constant 80 : i8
-    cf.cond_br %120, ^bb1(%c80_i8_58 : i8), ^bb40
+    %c80_i8_52 = arith.constant 80 : i8
+    cf.cond_br %114, ^bb1(%c80_i8_52 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %121 = call @dora_fn_extend_memory(%arg0, %104) : (!llvm.ptr, i64) -> !llvm.ptr
-    %122 = llvm.getelementptr %121[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %123 = llvm.load %122 : !llvm.ptr -> i8
-    %c0_i8_59 = arith.constant 0 : i8
-    %124 = arith.cmpi ne, %123, %c0_i8_59 : i8
-    cf.cond_br %124, ^bb1(%123 : i8), ^bb41
+    %115 = call @dora_fn_extend_memory(%arg0, %98) : (!llvm.ptr, i64) -> !llvm.ptr
+    %116 = llvm.getelementptr %115[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %117 = llvm.load %116 : !llvm.ptr -> i8
+    %c0_i8_53 = arith.constant 0 : i8
+    %118 = arith.cmpi ne, %117, %c0_i8_53 : i8
+    cf.cond_br %118, ^bb1(%117 : i8), ^bb41
   ^bb41:  // pred: ^bb40
     cf.br ^bb38
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_uninitialized.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mload_uninitialized.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb15, ^bb18, ^bb19
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb15, ^bb18, ^bb19
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,119 +95,116 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_2 = arith.constant 0 : i64
-    %16 = arith.cmpi ne, %c32_i64, %c0_i64_2 : i64
-    cf.cond_br %16, ^bb13, ^bb8
+    %c0_i64_1 = arith.constant 0 : i64
+    %15 = arith.cmpi ne, %c32_i64, %c0_i64_1 : i64
+    cf.cond_br %15, ^bb13, ^bb8
   ^bb8:  // 2 preds: ^bb7, ^bb17
-    %17 = arith.trunci %15 : i256 to i64
-    %18 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %19 = llvm.getelementptr %18[%17] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %20 = llvm.load %19 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %21 = llvm.intr.bswap(%20)  : (i256) -> i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_3 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %21, %23 : i256, !llvm.ptr
+    %16 = arith.trunci %14 : i256 to i64
+    %17 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %18 = llvm.getelementptr %17[%16] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %19 = llvm.load %18 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %20 = llvm.intr.bswap(%19)  : (i256) -> i256
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %20, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %26 = arith.addi %25, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %27 = arith.cmpi ult, %25, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %24 = arith.addi %23, %c0_i64_3 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %25 = arith.cmpi ult, %23, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %25, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_7 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb11, ^bb1(%c80_i8_8 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb11, ^bb1(%c80_i8_6 : i8)
   ^bb11:  // pred: ^bb10
-    %30 = arith.subi %28, %c3_i64_7 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_5 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %29, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb13:  // pred: ^bb7
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %32 = arith.cmpi sgt, %15, %c18446744073709551615_i256 : i256
+    %30 = arith.cmpi sgt, %14, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %32, ^bb1(%c84_i8 : i8), ^bb14
+    cf.cond_br %30, ^bb1(%c84_i8 : i8), ^bb14
   ^bb14:  // pred: ^bb13
-    %33 = arith.trunci %15 : i256 to i64
+    %31 = arith.trunci %14 : i256 to i64
+    %c0_i64_8 = arith.constant 0 : i64
+    %32 = arith.cmpi slt, %31, %c0_i64_8 : i64
+    %c84_i8_9 = arith.constant 84 : i8
+    cf.cond_br %32, ^bb1(%c84_i8_9 : i8), ^bb15
+  ^bb15:  // pred: ^bb14
+    %33 = arith.addi %31, %c32_i64 : i64
     %c0_i64_10 = arith.constant 0 : i64
     %34 = arith.cmpi slt, %33, %c0_i64_10 : i64
     %c84_i8_11 = arith.constant 84 : i8
-    cf.cond_br %34, ^bb1(%c84_i8_11 : i8), ^bb15
-  ^bb15:  // pred: ^bb14
-    %35 = arith.addi %33, %c32_i64 : i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %36 = arith.cmpi slt, %35, %c0_i64_12 : i64
-    %c84_i8_13 = arith.constant 84 : i8
-    cf.cond_br %36, ^bb1(%c84_i8_13 : i8), ^bb16
+    cf.cond_br %34, ^bb1(%c84_i8_11 : i8), ^bb16
   ^bb16:  // pred: ^bb15
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_14 = arith.constant 32 : i64
-    %37 = arith.addi %35, %c31_i64 : i64
-    %38 = arith.divui %37, %c32_i64_14 : i64
+    %c32_i64_12 = arith.constant 32 : i64
+    %35 = arith.addi %33, %c31_i64 : i64
+    %36 = arith.divui %35, %c32_i64_12 : i64
+    %c32_i64_13 = arith.constant 32 : i64
+    %37 = arith.muli %36, %c32_i64_13 : i64
+    %38 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_14 = arith.constant 31 : i64
     %c32_i64_15 = arith.constant 32 : i64
-    %39 = arith.muli %38, %c32_i64_15 : i64
-    %40 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_16 = arith.constant 31 : i64
-    %c32_i64_17 = arith.constant 32 : i64
-    %41 = arith.addi %40, %c31_i64_16 : i64
-    %42 = arith.divui %41, %c32_i64_17 : i64
-    %43 = arith.muli %42, %c32_i64_15 : i64
-    %44 = arith.cmpi ult, %43, %39 : i64
-    cf.cond_br %44, ^bb18, ^bb17
+    %39 = arith.addi %38, %c31_i64_14 : i64
+    %40 = arith.divui %39, %c32_i64_15 : i64
+    %41 = arith.muli %40, %c32_i64_13 : i64
+    %42 = arith.cmpi ult, %41, %37 : i64
+    cf.cond_br %42, ^bb18, ^bb17
   ^bb17:  // 2 preds: ^bb16, ^bb20
     cf.br ^bb8
   ^bb18:  // pred: ^bb16
-    %c3_i64_18 = arith.constant 3 : i64
+    %c3_i64_16 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %45 = arith.muli %42, %42 : i64
-    %46 = arith.divui %45, %c512_i64 : i64
-    %47 = arith.muli %42, %c3_i64_18 : i64
-    %48 = arith.addi %46, %47 : i64
-    %c3_i64_19 = arith.constant 3 : i64
-    %c512_i64_20 = arith.constant 512 : i64
-    %49 = arith.muli %38, %38 : i64
-    %50 = arith.divui %49, %c512_i64_20 : i64
-    %51 = arith.muli %38, %c3_i64_19 : i64
-    %52 = arith.addi %50, %51 : i64
-    %53 = arith.subi %52, %48 : i64
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    %55 = arith.cmpi ult, %54, %53 : i64
-    scf.if %55 {
+    %43 = arith.muli %40, %40 : i64
+    %44 = arith.divui %43, %c512_i64 : i64
+    %45 = arith.muli %40, %c3_i64_16 : i64
+    %46 = arith.addi %44, %45 : i64
+    %c3_i64_17 = arith.constant 3 : i64
+    %c512_i64_18 = arith.constant 512 : i64
+    %47 = arith.muli %36, %36 : i64
+    %48 = arith.divui %47, %c512_i64_18 : i64
+    %49 = arith.muli %36, %c3_i64_17 : i64
+    %50 = arith.addi %48, %49 : i64
+    %51 = arith.subi %50, %46 : i64
+    %52 = llvm.load %arg1 : !llvm.ptr -> i64
+    %53 = arith.cmpi ult, %52, %51 : i64
+    scf.if %53 {
     } else {
-      %60 = arith.subi %54, %53 : i64
-      llvm.store %60, %arg1 : i64, !llvm.ptr
+      %58 = arith.subi %52, %51 : i64
+      llvm.store %58, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_21 = arith.constant 80 : i8
-    cf.cond_br %55, ^bb1(%c80_i8_21 : i8), ^bb19
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %53, ^bb1(%c80_i8_19 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %56 = call @dora_fn_extend_memory(%arg0, %39) : (!llvm.ptr, i64) -> !llvm.ptr
-    %57 = llvm.getelementptr %56[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i8
+    %54 = call @dora_fn_extend_memory(%arg0, %37) : (!llvm.ptr, i64) -> !llvm.ptr
+    %55 = llvm.getelementptr %54[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %56 = llvm.load %55 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %59 = arith.cmpi ne, %58, %c0_i8 : i8
-    cf.cond_br %59, ^bb1(%58 : i8), ^bb20
+    %57 = arith.cmpi ne, %56, %c0_i8 : i8
+    cf.cond_br %57, ^bb1(%56 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     cf.br ^bb17
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,146 +96,142 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c42_i256 = arith.constant 42 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c42_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c42_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb17, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb17, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb21
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb17:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %41 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %38 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %41, ^bb1(%c84_i8 : i8), ^bb18
+    cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %42 = arith.trunci %24 : i256 to i64
-    %c0_i64_14 = arith.constant 0 : i64
-    %43 = arith.cmpi slt, %42, %c0_i64_14 : i64
-    %c84_i8_15 = arith.constant 84 : i8
-    cf.cond_br %43, ^bb1(%c84_i8_15 : i8), ^bb19
+    %39 = arith.trunci %22 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %40 = arith.cmpi slt, %39, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %40, ^bb1(%c84_i8_12 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %44 = arith.addi %42, %c32_i64 : i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %45 = arith.cmpi slt, %44, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %45, ^bb1(%c84_i8_17 : i8), ^bb20
+    %41 = arith.addi %39, %c32_i64 : i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %42 = arith.cmpi slt, %41, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %42, ^bb1(%c84_i8_14 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c31_i64 = arith.constant 31 : i64
+    %c32_i64_15 = arith.constant 32 : i64
+    %43 = arith.addi %41, %c31_i64 : i64
+    %44 = arith.divui %43, %c32_i64_15 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %45 = arith.muli %44, %c32_i64_16 : i64
+    %46 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_17 = arith.constant 31 : i64
     %c32_i64_18 = arith.constant 32 : i64
-    %46 = arith.addi %44, %c31_i64 : i64
-    %47 = arith.divui %46, %c32_i64_18 : i64
-    %c32_i64_19 = arith.constant 32 : i64
-    %48 = arith.muli %47, %c32_i64_19 : i64
-    %49 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_20 = arith.constant 31 : i64
-    %c32_i64_21 = arith.constant 32 : i64
-    %50 = arith.addi %49, %c31_i64_20 : i64
-    %51 = arith.divui %50, %c32_i64_21 : i64
-    %52 = arith.muli %51, %c32_i64_19 : i64
-    %53 = arith.cmpi ult, %52, %48 : i64
-    cf.cond_br %53, ^bb22, ^bb21
+    %47 = arith.addi %46, %c31_i64_17 : i64
+    %48 = arith.divui %47, %c32_i64_18 : i64
+    %49 = arith.muli %48, %c32_i64_16 : i64
+    %50 = arith.cmpi ult, %49, %45 : i64
+    cf.cond_br %50, ^bb22, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb24
     cf.br ^bb12
   ^bb22:  // pred: ^bb20
-    %c3_i64_22 = arith.constant 3 : i64
+    %c3_i64_19 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %54 = arith.muli %51, %51 : i64
-    %55 = arith.divui %54, %c512_i64 : i64
-    %56 = arith.muli %51, %c3_i64_22 : i64
-    %57 = arith.addi %55, %56 : i64
-    %c3_i64_23 = arith.constant 3 : i64
-    %c512_i64_24 = arith.constant 512 : i64
-    %58 = arith.muli %47, %47 : i64
-    %59 = arith.divui %58, %c512_i64_24 : i64
-    %60 = arith.muli %47, %c3_i64_23 : i64
-    %61 = arith.addi %59, %60 : i64
-    %62 = arith.subi %61, %57 : i64
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %64 = arith.cmpi ult, %63, %62 : i64
-    scf.if %64 {
+    %51 = arith.muli %48, %48 : i64
+    %52 = arith.divui %51, %c512_i64 : i64
+    %53 = arith.muli %48, %c3_i64_19 : i64
+    %54 = arith.addi %52, %53 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %c512_i64_21 = arith.constant 512 : i64
+    %55 = arith.muli %44, %44 : i64
+    %56 = arith.divui %55, %c512_i64_21 : i64
+    %57 = arith.muli %44, %c3_i64_20 : i64
+    %58 = arith.addi %56, %57 : i64
+    %59 = arith.subi %58, %54 : i64
+    %60 = llvm.load %arg1 : !llvm.ptr -> i64
+    %61 = arith.cmpi ult, %60, %59 : i64
+    scf.if %61 {
     } else {
-      %69 = arith.subi %63, %62 : i64
-      llvm.store %69, %arg1 : i64, !llvm.ptr
+      %66 = arith.subi %60, %59 : i64
+      llvm.store %66, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb1(%c80_i8_25 : i8), ^bb23
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %61, ^bb1(%c80_i8_22 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %65 = call @dora_fn_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
-    %66 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %67 = llvm.load %66 : !llvm.ptr -> i8
+    %62 = call @dora_fn_extend_memory(%arg0, %45) : (!llvm.ptr, i64) -> !llvm.ptr
+    %63 = llvm.getelementptr %62[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %64 = llvm.load %63 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %68 = arith.cmpi ne, %67, %c0_i8 : i8
-    cf.cond_br %68, ^bb1(%67 : i8), ^bb24
+    %65 = arith.cmpi ne, %64, %c0_i8 : i8
+    cf.cond_br %65, ^bb1(%64 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb21
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_high_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_high_address.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1024_i256 = arith.constant 1024 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1024_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,146 +96,142 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c123_i256 = arith.constant 123 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c123_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c123_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb17, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb17, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb21
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb17:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %41 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %38 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %41, ^bb1(%c84_i8 : i8), ^bb18
+    cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %42 = arith.trunci %24 : i256 to i64
-    %c0_i64_14 = arith.constant 0 : i64
-    %43 = arith.cmpi slt, %42, %c0_i64_14 : i64
-    %c84_i8_15 = arith.constant 84 : i8
-    cf.cond_br %43, ^bb1(%c84_i8_15 : i8), ^bb19
+    %39 = arith.trunci %22 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %40 = arith.cmpi slt, %39, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %40, ^bb1(%c84_i8_12 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %44 = arith.addi %42, %c32_i64 : i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %45 = arith.cmpi slt, %44, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %45, ^bb1(%c84_i8_17 : i8), ^bb20
+    %41 = arith.addi %39, %c32_i64 : i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %42 = arith.cmpi slt, %41, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %42, ^bb1(%c84_i8_14 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c31_i64 = arith.constant 31 : i64
+    %c32_i64_15 = arith.constant 32 : i64
+    %43 = arith.addi %41, %c31_i64 : i64
+    %44 = arith.divui %43, %c32_i64_15 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %45 = arith.muli %44, %c32_i64_16 : i64
+    %46 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_17 = arith.constant 31 : i64
     %c32_i64_18 = arith.constant 32 : i64
-    %46 = arith.addi %44, %c31_i64 : i64
-    %47 = arith.divui %46, %c32_i64_18 : i64
-    %c32_i64_19 = arith.constant 32 : i64
-    %48 = arith.muli %47, %c32_i64_19 : i64
-    %49 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_20 = arith.constant 31 : i64
-    %c32_i64_21 = arith.constant 32 : i64
-    %50 = arith.addi %49, %c31_i64_20 : i64
-    %51 = arith.divui %50, %c32_i64_21 : i64
-    %52 = arith.muli %51, %c32_i64_19 : i64
-    %53 = arith.cmpi ult, %52, %48 : i64
-    cf.cond_br %53, ^bb22, ^bb21
+    %47 = arith.addi %46, %c31_i64_17 : i64
+    %48 = arith.divui %47, %c32_i64_18 : i64
+    %49 = arith.muli %48, %c32_i64_16 : i64
+    %50 = arith.cmpi ult, %49, %45 : i64
+    cf.cond_br %50, ^bb22, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb24
     cf.br ^bb12
   ^bb22:  // pred: ^bb20
-    %c3_i64_22 = arith.constant 3 : i64
+    %c3_i64_19 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %54 = arith.muli %51, %51 : i64
-    %55 = arith.divui %54, %c512_i64 : i64
-    %56 = arith.muli %51, %c3_i64_22 : i64
-    %57 = arith.addi %55, %56 : i64
-    %c3_i64_23 = arith.constant 3 : i64
-    %c512_i64_24 = arith.constant 512 : i64
-    %58 = arith.muli %47, %47 : i64
-    %59 = arith.divui %58, %c512_i64_24 : i64
-    %60 = arith.muli %47, %c3_i64_23 : i64
-    %61 = arith.addi %59, %60 : i64
-    %62 = arith.subi %61, %57 : i64
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %64 = arith.cmpi ult, %63, %62 : i64
-    scf.if %64 {
+    %51 = arith.muli %48, %48 : i64
+    %52 = arith.divui %51, %c512_i64 : i64
+    %53 = arith.muli %48, %c3_i64_19 : i64
+    %54 = arith.addi %52, %53 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %c512_i64_21 = arith.constant 512 : i64
+    %55 = arith.muli %44, %44 : i64
+    %56 = arith.divui %55, %c512_i64_21 : i64
+    %57 = arith.muli %44, %c3_i64_20 : i64
+    %58 = arith.addi %56, %57 : i64
+    %59 = arith.subi %58, %54 : i64
+    %60 = llvm.load %arg1 : !llvm.ptr -> i64
+    %61 = arith.cmpi ult, %60, %59 : i64
+    scf.if %61 {
     } else {
-      %69 = arith.subi %63, %62 : i64
-      llvm.store %69, %arg1 : i64, !llvm.ptr
+      %66 = arith.subi %60, %59 : i64
+      llvm.store %66, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb1(%c80_i8_25 : i8), ^bb23
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %61, ^bb1(%c80_i8_22 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %65 = call @dora_fn_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
-    %66 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %67 = llvm.load %66 : !llvm.ptr -> i8
+    %62 = call @dora_fn_extend_memory(%arg0, %45) : (!llvm.ptr, i64) -> !llvm.ptr
+    %63 = llvm.getelementptr %62[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %64 = llvm.load %63 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %68 = arith.cmpi ne, %67, %c0_i8 : i8
-    cf.cond_br %68, ^bb1(%67 : i8), ^bb24
+    %65 = arith.cmpi ne, %64, %c0_i8 : i8
+    cf.cond_br %65, ^bb1(%64 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb21
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_overwrite.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__mstore_overwrite.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 23 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb32, ^bb35, ^bb36, ^bb38, ^bb39, ^bb40, ^bb43, ^bb44
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 23 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb32, ^bb35, ^bb36, ^bb38, ^bb39, ^bb40, ^bb43, ^bb44
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,312 +96,303 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c42_i256 = arith.constant 42 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c42_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c42_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb30, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb30, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb34
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c0_i256_13 = arith.constant 0 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_13, %41 : i256, !llvm.ptr
+    %c0_i256_10 = arith.constant 0 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c99_i256 = arith.constant 99 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c99_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c99_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
-    %c32_i64_28 = arith.constant 32 : i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %66 = arith.cmpi ne, %c32_i64_28, %c0_i64_29 : i64
-    cf.cond_br %66, ^bb38, ^bb25
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_21 = arith.constant 32 : i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %59 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
+    cf.cond_br %59, ^bb38, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb42
-    %67 = arith.trunci %61 : i256 to i64
-    %68 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %69 = llvm.getelementptr %68[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %70 = llvm.intr.bswap(%65)  : (i256) -> i256
-    llvm.store %70, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = arith.trunci %55 : i256 to i64
+    %61 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %63 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %63, %62 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb29
   ^bb26:  // pred: ^bb28
-    %c1024_i64_30 = arith.constant 1024 : i64
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_31 = arith.constant -2 : i64
-    %72 = arith.addi %71, %c-2_i64_31 : i64
-    %c2_i64_32 = arith.constant 2 : i64
-    %73 = arith.cmpi ult, %71, %c2_i64_32 : i64
-    %c91_i8_33 = arith.constant 91 : i8
-    cf.cond_br %73, ^bb1(%c91_i8_33 : i8), ^bb24
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_24 = arith.constant -2 : i64
+    %65 = arith.addi %64, %c-2_i64_24 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c2_i64_25 = arith.constant 2 : i64
+    %66 = arith.cmpi ult, %64, %c2_i64_25 : i64
+    %c91_i8_26 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_26 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_34 = arith.constant 3 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_27 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %75 = arith.cmpi uge, %74, %c3_i64_34 : i64
-    %c80_i8_35 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb28, ^bb1(%c80_i8_35 : i8)
+    %68 = arith.cmpi uge, %67, %c3_i64_27 : i64
+    %c80_i8_28 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb28, ^bb1(%c80_i8_28 : i8)
   ^bb28:  // pred: ^bb27
-    %76 = arith.subi %74, %c3_i64_34 : i64
-    llvm.store %76, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c3_i64_27 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb25
-    %c0_i64_36 = arith.constant 0 : i64
+    %c0_i64_29 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %77 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_36, %c0_i64_36, %77, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_29, %c0_i64_29, %70, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb30:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %78 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %71 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %78, ^bb1(%c84_i8 : i8), ^bb31
+    cf.cond_br %71, ^bb1(%c84_i8 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %79 = arith.trunci %24 : i256 to i64
-    %c0_i64_37 = arith.constant 0 : i64
-    %80 = arith.cmpi slt, %79, %c0_i64_37 : i64
-    %c84_i8_38 = arith.constant 84 : i8
-    cf.cond_br %80, ^bb1(%c84_i8_38 : i8), ^bb32
+    %72 = arith.trunci %22 : i256 to i64
+    %c0_i64_30 = arith.constant 0 : i64
+    %73 = arith.cmpi slt, %72, %c0_i64_30 : i64
+    %c84_i8_31 = arith.constant 84 : i8
+    cf.cond_br %73, ^bb1(%c84_i8_31 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %81 = arith.addi %79, %c32_i64 : i64
-    %c0_i64_39 = arith.constant 0 : i64
-    %82 = arith.cmpi slt, %81, %c0_i64_39 : i64
-    %c84_i8_40 = arith.constant 84 : i8
-    cf.cond_br %82, ^bb1(%c84_i8_40 : i8), ^bb33
+    %74 = arith.addi %72, %c32_i64 : i64
+    %c0_i64_32 = arith.constant 0 : i64
+    %75 = arith.cmpi slt, %74, %c0_i64_32 : i64
+    %c84_i8_33 = arith.constant 84 : i8
+    cf.cond_br %75, ^bb1(%c84_i8_33 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_41 = arith.constant 32 : i64
-    %83 = arith.addi %81, %c31_i64 : i64
-    %84 = arith.divui %83, %c32_i64_41 : i64
-    %c32_i64_42 = arith.constant 32 : i64
-    %85 = arith.muli %84, %c32_i64_42 : i64
-    %86 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_43 = arith.constant 31 : i64
-    %c32_i64_44 = arith.constant 32 : i64
-    %87 = arith.addi %86, %c31_i64_43 : i64
-    %88 = arith.divui %87, %c32_i64_44 : i64
-    %89 = arith.muli %88, %c32_i64_42 : i64
-    %90 = arith.cmpi ult, %89, %85 : i64
-    cf.cond_br %90, ^bb35, ^bb34
+    %c32_i64_34 = arith.constant 32 : i64
+    %76 = arith.addi %74, %c31_i64 : i64
+    %77 = arith.divui %76, %c32_i64_34 : i64
+    %c32_i64_35 = arith.constant 32 : i64
+    %78 = arith.muli %77, %c32_i64_35 : i64
+    %79 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_36 = arith.constant 31 : i64
+    %c32_i64_37 = arith.constant 32 : i64
+    %80 = arith.addi %79, %c31_i64_36 : i64
+    %81 = arith.divui %80, %c32_i64_37 : i64
+    %82 = arith.muli %81, %c32_i64_35 : i64
+    %83 = arith.cmpi ult, %82, %78 : i64
+    cf.cond_br %83, ^bb35, ^bb34
   ^bb34:  // 2 preds: ^bb33, ^bb37
     cf.br ^bb12
   ^bb35:  // pred: ^bb33
-    %c3_i64_45 = arith.constant 3 : i64
+    %c3_i64_38 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %91 = arith.muli %88, %88 : i64
-    %92 = arith.divui %91, %c512_i64 : i64
-    %93 = arith.muli %88, %c3_i64_45 : i64
-    %94 = arith.addi %92, %93 : i64
-    %c3_i64_46 = arith.constant 3 : i64
-    %c512_i64_47 = arith.constant 512 : i64
-    %95 = arith.muli %84, %84 : i64
-    %96 = arith.divui %95, %c512_i64_47 : i64
-    %97 = arith.muli %84, %c3_i64_46 : i64
-    %98 = arith.addi %96, %97 : i64
-    %99 = arith.subi %98, %94 : i64
-    %100 = llvm.load %arg1 : !llvm.ptr -> i64
-    %101 = arith.cmpi ult, %100, %99 : i64
-    scf.if %101 {
+    %84 = arith.muli %81, %81 : i64
+    %85 = arith.divui %84, %c512_i64 : i64
+    %86 = arith.muli %81, %c3_i64_38 : i64
+    %87 = arith.addi %85, %86 : i64
+    %c3_i64_39 = arith.constant 3 : i64
+    %c512_i64_40 = arith.constant 512 : i64
+    %88 = arith.muli %77, %77 : i64
+    %89 = arith.divui %88, %c512_i64_40 : i64
+    %90 = arith.muli %77, %c3_i64_39 : i64
+    %91 = arith.addi %89, %90 : i64
+    %92 = arith.subi %91, %87 : i64
+    %93 = llvm.load %arg1 : !llvm.ptr -> i64
+    %94 = arith.cmpi ult, %93, %92 : i64
+    scf.if %94 {
     } else {
-      %134 = arith.subi %100, %99 : i64
-      llvm.store %134, %arg1 : i64, !llvm.ptr
+      %127 = arith.subi %93, %92 : i64
+      llvm.store %127, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %101, ^bb1(%c80_i8_48 : i8), ^bb36
+    %c80_i8_41 = arith.constant 80 : i8
+    cf.cond_br %94, ^bb1(%c80_i8_41 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %102 = call @dora_fn_extend_memory(%arg0, %85) : (!llvm.ptr, i64) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
+    %95 = call @dora_fn_extend_memory(%arg0, %78) : (!llvm.ptr, i64) -> !llvm.ptr
+    %96 = llvm.getelementptr %95[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %97 = llvm.load %96 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %104, %c0_i8 : i8
-    cf.cond_br %105, ^bb1(%104 : i8), ^bb37
+    %98 = arith.cmpi ne, %97, %c0_i8 : i8
+    cf.cond_br %98, ^bb1(%97 : i8), ^bb37
   ^bb37:  // pred: ^bb36
     cf.br ^bb34
   ^bb38:  // pred: ^bb24
-    %c18446744073709551615_i256_49 = arith.constant 18446744073709551615 : i256
-    %106 = arith.cmpi sgt, %61, %c18446744073709551615_i256_49 : i256
-    %c84_i8_50 = arith.constant 84 : i8
-    cf.cond_br %106, ^bb1(%c84_i8_50 : i8), ^bb39
+    %c18446744073709551615_i256_42 = arith.constant 18446744073709551615 : i256
+    %99 = arith.cmpi sgt, %55, %c18446744073709551615_i256_42 : i256
+    %c84_i8_43 = arith.constant 84 : i8
+    cf.cond_br %99, ^bb1(%c84_i8_43 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %107 = arith.trunci %61 : i256 to i64
-    %c0_i64_51 = arith.constant 0 : i64
-    %108 = arith.cmpi slt, %107, %c0_i64_51 : i64
-    %c84_i8_52 = arith.constant 84 : i8
-    cf.cond_br %108, ^bb1(%c84_i8_52 : i8), ^bb40
+    %100 = arith.trunci %55 : i256 to i64
+    %c0_i64_44 = arith.constant 0 : i64
+    %101 = arith.cmpi slt, %100, %c0_i64_44 : i64
+    %c84_i8_45 = arith.constant 84 : i8
+    cf.cond_br %101, ^bb1(%c84_i8_45 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %109 = arith.addi %107, %c32_i64_28 : i64
-    %c0_i64_53 = arith.constant 0 : i64
-    %110 = arith.cmpi slt, %109, %c0_i64_53 : i64
-    %c84_i8_54 = arith.constant 84 : i8
-    cf.cond_br %110, ^bb1(%c84_i8_54 : i8), ^bb41
+    %102 = arith.addi %100, %c32_i64_21 : i64
+    %c0_i64_46 = arith.constant 0 : i64
+    %103 = arith.cmpi slt, %102, %c0_i64_46 : i64
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %103, ^bb1(%c84_i8_47 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %c31_i64_55 = arith.constant 31 : i64
-    %c32_i64_56 = arith.constant 32 : i64
-    %111 = arith.addi %109, %c31_i64_55 : i64
-    %112 = arith.divui %111, %c32_i64_56 : i64
-    %c32_i64_57 = arith.constant 32 : i64
-    %113 = arith.muli %112, %c32_i64_57 : i64
-    %114 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_58 = arith.constant 31 : i64
-    %c32_i64_59 = arith.constant 32 : i64
-    %115 = arith.addi %114, %c31_i64_58 : i64
-    %116 = arith.divui %115, %c32_i64_59 : i64
-    %117 = arith.muli %116, %c32_i64_57 : i64
-    %118 = arith.cmpi ult, %117, %113 : i64
-    cf.cond_br %118, ^bb43, ^bb42
+    %c31_i64_48 = arith.constant 31 : i64
+    %c32_i64_49 = arith.constant 32 : i64
+    %104 = arith.addi %102, %c31_i64_48 : i64
+    %105 = arith.divui %104, %c32_i64_49 : i64
+    %c32_i64_50 = arith.constant 32 : i64
+    %106 = arith.muli %105, %c32_i64_50 : i64
+    %107 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_51 = arith.constant 31 : i64
+    %c32_i64_52 = arith.constant 32 : i64
+    %108 = arith.addi %107, %c31_i64_51 : i64
+    %109 = arith.divui %108, %c32_i64_52 : i64
+    %110 = arith.muli %109, %c32_i64_50 : i64
+    %111 = arith.cmpi ult, %110, %106 : i64
+    cf.cond_br %111, ^bb43, ^bb42
   ^bb42:  // 2 preds: ^bb41, ^bb45
     cf.br ^bb25
   ^bb43:  // pred: ^bb41
-    %c3_i64_60 = arith.constant 3 : i64
-    %c512_i64_61 = arith.constant 512 : i64
-    %119 = arith.muli %116, %116 : i64
-    %120 = arith.divui %119, %c512_i64_61 : i64
-    %121 = arith.muli %116, %c3_i64_60 : i64
-    %122 = arith.addi %120, %121 : i64
-    %c3_i64_62 = arith.constant 3 : i64
-    %c512_i64_63 = arith.constant 512 : i64
-    %123 = arith.muli %112, %112 : i64
-    %124 = arith.divui %123, %c512_i64_63 : i64
-    %125 = arith.muli %112, %c3_i64_62 : i64
-    %126 = arith.addi %124, %125 : i64
-    %127 = arith.subi %126, %122 : i64
-    %128 = llvm.load %arg1 : !llvm.ptr -> i64
-    %129 = arith.cmpi ult, %128, %127 : i64
-    scf.if %129 {
+    %c3_i64_53 = arith.constant 3 : i64
+    %c512_i64_54 = arith.constant 512 : i64
+    %112 = arith.muli %109, %109 : i64
+    %113 = arith.divui %112, %c512_i64_54 : i64
+    %114 = arith.muli %109, %c3_i64_53 : i64
+    %115 = arith.addi %113, %114 : i64
+    %c3_i64_55 = arith.constant 3 : i64
+    %c512_i64_56 = arith.constant 512 : i64
+    %116 = arith.muli %105, %105 : i64
+    %117 = arith.divui %116, %c512_i64_56 : i64
+    %118 = arith.muli %105, %c3_i64_55 : i64
+    %119 = arith.addi %117, %118 : i64
+    %120 = arith.subi %119, %115 : i64
+    %121 = llvm.load %arg1 : !llvm.ptr -> i64
+    %122 = arith.cmpi ult, %121, %120 : i64
+    scf.if %122 {
     } else {
-      %134 = arith.subi %128, %127 : i64
-      llvm.store %134, %arg1 : i64, !llvm.ptr
+      %127 = arith.subi %121, %120 : i64
+      llvm.store %127, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_64 = arith.constant 80 : i8
-    cf.cond_br %129, ^bb1(%c80_i8_64 : i8), ^bb44
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %122, ^bb1(%c80_i8_57 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %130 = call @dora_fn_extend_memory(%arg0, %113) : (!llvm.ptr, i64) -> !llvm.ptr
-    %131 = llvm.getelementptr %130[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %132 = llvm.load %131 : !llvm.ptr -> i8
-    %c0_i8_65 = arith.constant 0 : i8
-    %133 = arith.cmpi ne, %132, %c0_i8_65 : i8
-    cf.cond_br %133, ^bb1(%132 : i8), ^bb45
+    %123 = call @dora_fn_extend_memory(%arg0, %106) : (!llvm.ptr, i64) -> !llvm.ptr
+    %124 = llvm.getelementptr %123[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %125 = llvm.load %124 : !llvm.ptr -> i8
+    %c0_i8_58 = arith.constant 0 : i8
+    %126 = arith.cmpi ne, %125, %c0_i8_58 : i8
+    cf.cond_br %126, ^bb1(%125 : i8), ^bb45
   ^bb45:  // pred: ^bb44
     cf.br ^bb42
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__number.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__number.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_block_number(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_block_number(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__origin.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__origin.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_origin(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_origin(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__pc.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__pc.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       2: ^bb13
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,140 +97,137 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_5 = arith.constant 2 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_4 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c2_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c2_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c2_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c2_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_7 = arith.constant 1024 : i64
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_8 = arith.constant 0 : i64
-    %22 = arith.addi %21, %c0_i64_8 : i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %20 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_7 = arith.constant 0 : i64
+    %21 = arith.addi %20, %c0_i64_7 : i64
+    llvm.store %21, %arg3 : i64, !llvm.ptr
     cf.br ^bb11
   ^bb13:  // 2 preds: ^bb2, ^bb7
-    %23 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
+    %22 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %24 = arith.cmpi uge, %23, %c1_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %24, ^bb14, ^bb1(%c80_i8_10 : i8)
+    %23 = arith.cmpi uge, %22, %c1_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %23, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %25 = arith.subi %23, %c1_i64_9 : i64
-    llvm.store %25, %arg1 : i64, !llvm.ptr
+    %24 = arith.subi %22, %c1_i64_8 : i64
+    llvm.store %24, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c3_i256 = arith.constant 3 : i256
-    %26 = llvm.load %arg3 : !llvm.ptr -> i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_11 = arith.constant 1 : i64
-    %28 = arith.addi %26, %c1_i64_11 : i64
-    llvm.store %28, %arg3 : i64, !llvm.ptr
-    llvm.store %c3_i256, %27 : i256, !llvm.ptr
+    %25 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3_i256, %25 : i256, !llvm.ptr
+    %26 = llvm.getelementptr %25[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %26, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %29 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %30 = arith.addi %29, %c1_i64_13 : i64
-    %31 = arith.cmpi ult, %c1024_i64_12, %30 : i64
-    %c92_i8_14 = arith.constant 92 : i8
-    cf.cond_br %31, ^bb1(%c92_i8_14 : i8), ^bb15
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %27 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %28 = arith.addi %27, %c1_i64_11 : i64
+    llvm.store %28, %arg3 : i64, !llvm.ptr
+    %29 = arith.cmpi ult, %c1024_i64_10, %28 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %29, ^bb1(%c92_i8_12 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %32 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_15 = arith.constant 2 : i64
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_13 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %33 = arith.cmpi uge, %32, %c2_i64_15 : i64
-    %c80_i8_16 = arith.constant 80 : i8
-    cf.cond_br %33, ^bb18, ^bb1(%c80_i8_16 : i8)
+    %31 = arith.cmpi uge, %30, %c2_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %31, ^bb18, ^bb1(%c80_i8_14 : i8)
   ^bb18:  // pred: ^bb17
-    %34 = arith.subi %32, %c2_i64_15 : i64
-    llvm.store %34, %arg1 : i64, !llvm.ptr
+    %32 = arith.subi %30, %c2_i64_13 : i64
+    llvm.store %32, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %c1_i256_17 = arith.constant 1 : i256
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_18 = arith.constant 1 : i64
-    %37 = arith.addi %35, %c1_i64_18 : i64
-    llvm.store %37, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_17, %36 : i256, !llvm.ptr
+    %c1_i256_15 = arith.constant 1 : i256
+    %33 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_15, %33 : i256, !llvm.ptr
+    %34 = llvm.getelementptr %33[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %34, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_19 = arith.constant 1024 : i64
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %39 = arith.addi %38, %c1_i64_20 : i64
-    %40 = arith.cmpi ult, %c1024_i64_19, %39 : i64
-    %c92_i8_21 = arith.constant 92 : i8
-    cf.cond_br %40, ^bb1(%c92_i8_21 : i8), ^bb19
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %36 = arith.addi %35, %c1_i64_17 : i64
+    llvm.store %36, %arg3 : i64, !llvm.ptr
+    %37 = arith.cmpi ult, %c1024_i64_16, %36 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %37, ^bb1(%c92_i8_18 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
     %c3_i64 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %42 = arith.cmpi uge, %41, %c3_i64 : i64
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_22 : i8)
+    %39 = arith.cmpi uge, %38, %c3_i64 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %39, ^bb22, ^bb1(%c80_i8_19 : i8)
   ^bb22:  // pred: ^bb21
-    %43 = arith.subi %41, %c3_i64 : i64
-    llvm.store %43, %arg1 : i64, !llvm.ptr
+    %40 = arith.subi %38, %c3_i64 : i64
+    llvm.store %40, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
     %c6_i256 = arith.constant 6 : i256
-    %44 = llvm.load %arg3 : !llvm.ptr -> i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_23 = arith.constant 1 : i64
-    %46 = arith.addi %44, %c1_i64_23 : i64
-    llvm.store %46, %arg3 : i64, !llvm.ptr
-    llvm.store %c6_i256, %45 : i256, !llvm.ptr
+    %41 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c6_i256, %41 : i256, !llvm.ptr
+    %42 = llvm.getelementptr %41[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %42, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb24:  // pred: ^bb26
-    %c1024_i64_24 = arith.constant 1024 : i64
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_25 = arith.constant 1 : i64
-    %48 = arith.addi %47, %c1_i64_25 : i64
-    %49 = arith.cmpi ult, %c1024_i64_24, %48 : i64
-    %c92_i8_26 = arith.constant 92 : i8
-    cf.cond_br %49, ^bb1(%c92_i8_26 : i8), ^bb23
+    %c1024_i64_20 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_21 = arith.constant 1 : i64
+    %44 = arith.addi %43, %c1_i64_21 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %45 = arith.cmpi ult, %c1024_i64_20, %44 : i64
+    %c92_i8_22 = arith.constant 92 : i8
+    cf.cond_br %45, ^bb1(%c92_i8_22 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %50 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_27 = arith.constant 2 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_23 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %51 = arith.cmpi uge, %50, %c2_i64_27 : i64
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %51, ^bb26, ^bb1(%c80_i8_28 : i8)
+    %47 = arith.cmpi uge, %46, %c2_i64_23 : i64
+    %c80_i8_24 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb26, ^bb1(%c80_i8_24 : i8)
   ^bb26:  // pred: ^bb25
-    %52 = arith.subi %50, %c2_i64_27 : i64
-    llvm.store %52, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c2_i64_23 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb23
-    %c0_i64_29 = arith.constant 0 : i64
+    %c0_i64_25 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %53 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_29, %c0_i64_29, %53, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_25, %c0_i64_25, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__prevrandao.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__prevrandao.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_prevrando(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_prevrando(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 34 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb31, ^bb32, ^bb33, ^bb35, ^bb36, ^bb38, ^bb39, ^bb41, ^bb42, ^bb45, ^bb46, ^bb47, ^bb50, ^bb51, ^bb53, ^bb54, ^bb55, ^bb58, ^bb59
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 34 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb31, ^bb32, ^bb33, ^bb35, ^bb36, ^bb38, ^bb39, ^bb41, ^bb42, ^bb45, ^bb46, ^bb47, ^bb50, ^bb51, ^bb53, ^bb54, ^bb55, ^bb58, ^bb59
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10000_i256 = arith.constant 10000 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10000_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,452 +96,431 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c4096_i256 = arith.constant 4096 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c4096_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4096_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c32_i256 = arith.constant 32 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %c32_i256_19 = arith.constant 32 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_20 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_19, %40 : i256, !llvm.ptr
+    %c32_i256_16 = arith.constant 32 : i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_16, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_22 : i64
-    %44 = arith.cmpi ult, %c1024_i64_21, %43 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_23 : i8), ^bb19
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_18 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_17, %39 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_19 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb22, ^bb1(%c80_i8_25 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_21 : i8)
   ^bb22:  // pred: ^bb21
-    %47 = arith.subi %45, %c3_i64_24 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_20 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
     %c64_i256 = arith.constant 64 : i256
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %50 = arith.addi %48, %c1_i64_26 : i64
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %49 : i256, !llvm.ptr
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %44 : i256, !llvm.ptr
+    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb24:  // pred: ^bb26
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %52 = arith.addi %51, %c1_i64_28 : i64
-    %53 = arith.cmpi ult, %c1024_i64_27, %52 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %53, ^bb1(%c92_i8_29 : i8), ^bb23
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_23 = arith.constant 1 : i64
+    %47 = arith.addi %46, %c1_i64_23 : i64
+    llvm.store %47, %arg3 : i64, !llvm.ptr
+    %48 = arith.cmpi ult, %c1024_i64_22, %47 : i64
+    %c92_i8_24 = arith.constant 92 : i8
+    cf.cond_br %48, ^bb1(%c92_i8_24 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_25 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %55 = arith.cmpi uge, %54, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %55, ^bb26, ^bb1(%c80_i8_31 : i8)
+    %50 = arith.cmpi uge, %49, %c3_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %50, ^bb26, ^bb1(%c80_i8_26 : i8)
   ^bb26:  // pred: ^bb25
-    %56 = arith.subi %54, %c3_i64_30 : i64
-    llvm.store %56, %arg1 : i64, !llvm.ptr
+    %51 = arith.subi %49, %c3_i64_25 : i64
+    llvm.store %51, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb28
-    %c64_i256_32 = arith.constant 64 : i256
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %58 = llvm.getelementptr %arg2[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_33 = arith.constant 1 : i64
-    %59 = arith.addi %57, %c1_i64_33 : i64
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256_32, %58 : i256, !llvm.ptr
+    %c64_i256_27 = arith.constant 64 : i256
+    %52 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_27, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb42
   ^bb28:  // pred: ^bb30
-    %c1024_i64_34 = arith.constant 1024 : i64
-    %60 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %61 = arith.addi %60, %c1_i64_35 : i64
-    %62 = arith.cmpi ult, %c1024_i64_34, %61 : i64
-    %c92_i8_36 = arith.constant 92 : i8
-    cf.cond_br %62, ^bb1(%c92_i8_36 : i8), ^bb27
+    %c1024_i64_28 = arith.constant 1024 : i64
+    %54 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_29 = arith.constant 1 : i64
+    %55 = arith.addi %54, %c1_i64_29 : i64
+    llvm.store %55, %arg3 : i64, !llvm.ptr
+    %56 = arith.cmpi ult, %c1024_i64_28, %55 : i64
+    %c92_i8_30 = arith.constant 92 : i8
+    cf.cond_br %56, ^bb1(%c92_i8_30 : i8), ^bb27
   ^bb29:  // pred: ^bb23
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_37 = arith.constant 3 : i64
+    %57 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_31 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %64 = arith.cmpi uge, %63, %c3_i64_37 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb30, ^bb1(%c80_i8_38 : i8)
+    %58 = arith.cmpi uge, %57, %c3_i64_31 : i64
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %58, ^bb30, ^bb1(%c80_i8_32 : i8)
   ^bb30:  // pred: ^bb29
-    %65 = arith.subi %63, %c3_i64_37 : i64
-    llvm.store %65, %arg1 : i64, !llvm.ptr
+    %59 = arith.subi %57, %c3_i64_31 : i64
+    llvm.store %59, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb41
-    %66 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_39 = arith.constant 1 : i64
-    %67 = arith.subi %66, %c1_i64_39 : i64
-    %68 = llvm.getelementptr %arg2[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %67, %arg3 : i64, !llvm.ptr
-    %69 = llvm.load %68 : !llvm.ptr -> i256
-    %70 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_40 = arith.constant 1 : i64
-    %71 = arith.subi %70, %c1_i64_40 : i64
-    %72 = llvm.getelementptr %arg2[%71] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %71, %arg3 : i64, !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i256
-    %74 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_41 = arith.constant 1 : i64
-    %75 = arith.subi %74, %c1_i64_41 : i64
-    %76 = llvm.getelementptr %arg2[%75] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %75, %arg3 : i64, !llvm.ptr
+    %60 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %61 = llvm.getelementptr %60[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %62 = llvm.load %61 : !llvm.ptr -> i256
+    llvm.store %61, %0 : !llvm.ptr, !llvm.ptr
+    %63 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %0 : !llvm.ptr, !llvm.ptr
+    %66 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %67 = llvm.getelementptr %66[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %68 = llvm.load %67 : !llvm.ptr -> i256
+    llvm.store %67, %0 : !llvm.ptr, !llvm.ptr
+    %69 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %70 = llvm.getelementptr %69[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %71 = llvm.load %70 : !llvm.ptr -> i256
+    llvm.store %70, %0 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %73 = llvm.getelementptr %72[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %74 = llvm.load %73 : !llvm.ptr -> i256
+    llvm.store %73, %0 : !llvm.ptr, !llvm.ptr
+    %75 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %75[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %77 = llvm.load %76 : !llvm.ptr -> i256
-    %78 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_42 = arith.constant 1 : i64
-    %79 = arith.subi %78, %c1_i64_42 : i64
-    %80 = llvm.getelementptr %arg2[%79] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> i256
-    %82 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_43 = arith.constant 1 : i64
-    %83 = arith.subi %82, %c1_i64_43 : i64
-    %84 = llvm.getelementptr %arg2[%83] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %83, %arg3 : i64, !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %87 = arith.subi %86, %c1_i64_44 : i64
-    %88 = llvm.getelementptr %arg2[%87] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %87, %arg3 : i64, !llvm.ptr
-    %89 = llvm.load %88 : !llvm.ptr -> i256
-    %90 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_45 = arith.constant 1 : i64
-    %91 = arith.subi %90, %c1_i64_45 : i64
-    %92 = llvm.getelementptr %arg2[%91] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %91, %arg3 : i64, !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> i256
-    %94 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %76, %0 : !llvm.ptr, !llvm.ptr
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %79 = llvm.getelementptr %78[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %80 = llvm.load %79 : !llvm.ptr -> i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
+    %81 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %95 = arith.cmpi ne, %94, %c0_i8 : i8
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
     %c0_i256 = arith.constant 0 : i256
-    %96 = arith.cmpi ne, %77, %c0_i256 : i256
-    %97 = arith.andi %95, %96 : i1
+    %83 = arith.cmpi ne, %68, %c0_i256 : i256
+    %84 = arith.andi %82, %83 : i1
     %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %97, ^bb1(%c86_i8 : i8), ^bb32
+    cf.cond_br %84, ^bb1(%c86_i8 : i8), ^bb32
   ^bb32:  // pred: ^bb31
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %98 = arith.cmpi sgt, %85, %c18446744073709551615_i256 : i256
+    %85 = arith.cmpi sgt, %74, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %98, ^bb1(%c84_i8 : i8), ^bb33
+    cf.cond_br %85, ^bb1(%c84_i8 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %99 = arith.trunci %85 : i256 to i64
-    %c0_i64_46 = arith.constant 0 : i64
-    %100 = arith.cmpi slt, %99, %c0_i64_46 : i64
-    %c84_i8_47 = arith.constant 84 : i8
-    cf.cond_br %100, ^bb1(%c84_i8_47 : i8), ^bb34
+    %86 = arith.trunci %74 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %87 = arith.cmpi slt, %86, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %87, ^bb1(%c84_i8_34 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %c0_i64_48 = arith.constant 0 : i64
-    %101 = arith.cmpi ne, %99, %c0_i64_48 : i64
-    cf.cond_br %101, ^bb45, ^bb35
+    %c0_i64_35 = arith.constant 0 : i64
+    %88 = arith.cmpi ne, %86, %c0_i64_35 : i64
+    cf.cond_br %88, ^bb45, ^bb35
   ^bb35:  // 2 preds: ^bb34, ^bb49
-    %c18446744073709551615_i256_49 = arith.constant 18446744073709551615 : i256
-    %102 = arith.cmpi sgt, %93, %c18446744073709551615_i256_49 : i256
-    %c84_i8_50 = arith.constant 84 : i8
-    cf.cond_br %102, ^bb1(%c84_i8_50 : i8), ^bb36
+    %c18446744073709551615_i256_36 = arith.constant 18446744073709551615 : i256
+    %89 = arith.cmpi sgt, %80, %c18446744073709551615_i256_36 : i256
+    %c84_i8_37 = arith.constant 84 : i8
+    cf.cond_br %89, ^bb1(%c84_i8_37 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %103 = arith.trunci %93 : i256 to i64
-    %c0_i64_51 = arith.constant 0 : i64
-    %104 = arith.cmpi slt, %103, %c0_i64_51 : i64
-    %c84_i8_52 = arith.constant 84 : i8
-    cf.cond_br %104, ^bb1(%c84_i8_52 : i8), ^bb37
+    %90 = arith.trunci %80 : i256 to i64
+    %c0_i64_38 = arith.constant 0 : i64
+    %91 = arith.cmpi slt, %90, %c0_i64_38 : i64
+    %c84_i8_39 = arith.constant 84 : i8
+    cf.cond_br %91, ^bb1(%c84_i8_39 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %c0_i64_53 = arith.constant 0 : i64
-    %105 = arith.cmpi ne, %103, %c0_i64_53 : i64
-    cf.cond_br %105, ^bb53, ^bb38
+    %c0_i64_40 = arith.constant 0 : i64
+    %92 = arith.cmpi ne, %90, %c0_i64_40 : i64
+    cf.cond_br %92, ^bb53, ^bb38
   ^bb38:  // 2 preds: ^bb37, ^bb57
-    %106 = arith.trunci %81 : i256 to i64
-    %107 = arith.trunci %89 : i256 to i64
-    %108 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_54 = arith.constant 1 : i256
-    %109 = llvm.alloca %c1_i256_54 x i256 : (i256) -> !llvm.ptr
-    llvm.store %77, %109 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_55 = arith.constant 1 : i256
-    %110 = llvm.alloca %c1_i256_55 x i256 : (i256) -> !llvm.ptr
-    llvm.store %69, %110 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_56 = arith.constant 1 : i256
-    %111 = llvm.alloca %c1_i256_56 x i256 : (i256) -> !llvm.ptr
-    llvm.store %73, %111 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i8_57 = arith.constant 0 : i8
-    %112 = call @dora_fn_call(%arg0, %110, %111, %109, %106, %99, %107, %103, %108, %c0_i8_57) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %113 = llvm.getelementptr %112[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %114 = llvm.load %113 : !llvm.ptr -> i8
-    %115 = llvm.getelementptr %112[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %116 = llvm.load %115 : !llvm.ptr -> i8
-    %c0_i8_58 = arith.constant 0 : i8
-    %117 = arith.cmpi ne, %116, %c0_i8_58 : i8
-    cf.cond_br %117, ^bb1(%116 : i8), ^bb39
+    %93 = arith.trunci %71 : i256 to i64
+    %94 = arith.trunci %77 : i256 to i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_41 = arith.constant 1 : i256
+    %96 = llvm.alloca %c1_i256_41 x i256 : (i256) -> !llvm.ptr
+    llvm.store %68, %96 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_42 = arith.constant 1 : i256
+    %97 = llvm.alloca %c1_i256_42 x i256 : (i256) -> !llvm.ptr
+    llvm.store %62, %97 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_43 = arith.constant 1 : i256
+    %98 = llvm.alloca %c1_i256_43 x i256 : (i256) -> !llvm.ptr
+    llvm.store %65, %98 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i8_44 = arith.constant 0 : i8
+    %99 = call @dora_fn_call(%arg0, %97, %98, %96, %93, %86, %94, %90, %95, %c0_i8_44) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %100 = llvm.getelementptr %99[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %101 = llvm.load %100 : !llvm.ptr -> i8
+    %102 = llvm.getelementptr %99[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %103 = llvm.load %102 : !llvm.ptr -> i8
+    %c0_i8_45 = arith.constant 0 : i8
+    %104 = arith.cmpi ne, %103, %c0_i8_45 : i8
+    cf.cond_br %104, ^bb1(%103 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %118 = llvm.getelementptr %112[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %119 = llvm.load %118 : !llvm.ptr -> i64
-    %120 = llvm.load %arg1 : !llvm.ptr -> i64
-    %121 = arith.cmpi ult, %120, %119 : i64
-    scf.if %121 {
+    %105 = llvm.getelementptr %99[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %106 = llvm.load %105 : !llvm.ptr -> i64
+    %107 = llvm.load %arg1 : !llvm.ptr -> i64
+    %108 = arith.cmpi ult, %107, %106 : i64
+    scf.if %108 {
     } else {
-      %189 = arith.subi %120, %119 : i64
-      llvm.store %189, %arg1 : i64, !llvm.ptr
+      %175 = arith.subi %107, %106 : i64
+      llvm.store %175, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_59 = arith.constant 80 : i8
-    cf.cond_br %121, ^bb1(%c80_i8_59 : i8), ^bb40
+    %c80_i8_46 = arith.constant 80 : i8
+    cf.cond_br %108, ^bb1(%c80_i8_46 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %122 = arith.extui %114 : i8 to i256
-    %123 = llvm.load %arg3 : !llvm.ptr -> i64
-    %124 = llvm.getelementptr %arg2[%123] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_60 = arith.constant 1 : i64
-    %125 = arith.addi %123, %c1_i64_60 : i64
-    llvm.store %125, %arg3 : i64, !llvm.ptr
-    llvm.store %122, %124 : i256, !llvm.ptr
+    %109 = arith.extui %101 : i8 to i256
+    %110 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %109, %110 : i256, !llvm.ptr
+    %111 = llvm.getelementptr %110[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %111, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb44
   ^bb41:  // pred: ^bb43
-    %c1024_i64_61 = arith.constant 1024 : i64
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_47 = arith.constant 1024 : i64
+    %112 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %127 = arith.addi %126, %c-6_i64 : i64
+    %113 = arith.addi %112, %c-6_i64 : i64
+    llvm.store %113, %arg3 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %128 = arith.cmpi ult, %126, %c7_i64 : i64
+    %114 = arith.cmpi ult, %112, %c7_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %128, ^bb1(%c91_i8 : i8), ^bb31
+    cf.cond_br %114, ^bb1(%c91_i8 : i8), ^bb31
   ^bb42:  // pred: ^bb27
-    %129 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_62 = arith.constant 0 : i64
+    %115 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_48 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %130 = arith.cmpi uge, %129, %c0_i64_62 : i64
-    %c80_i8_63 = arith.constant 80 : i8
-    cf.cond_br %130, ^bb43, ^bb1(%c80_i8_63 : i8)
+    %116 = arith.cmpi uge, %115, %c0_i64_48 : i64
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %116, ^bb43, ^bb1(%c80_i8_49 : i8)
   ^bb43:  // pred: ^bb42
-    %131 = arith.subi %129, %c0_i64_62 : i64
-    llvm.store %131, %arg1 : i64, !llvm.ptr
+    %117 = arith.subi %115, %c0_i64_48 : i64
+    llvm.store %117, %arg1 : i64, !llvm.ptr
     cf.br ^bb41
   ^bb44:  // pred: ^bb40
-    %c0_i64_64 = arith.constant 0 : i64
+    %c0_i64_50 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %132 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_64, %c0_i64_64, %132, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %118 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_50, %c0_i64_50, %118, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb45:  // pred: ^bb34
-    %c18446744073709551615_i256_65 = arith.constant 18446744073709551615 : i256
-    %133 = arith.cmpi sgt, %81, %c18446744073709551615_i256_65 : i256
-    %c84_i8_66 = arith.constant 84 : i8
-    cf.cond_br %133, ^bb1(%c84_i8_66 : i8), ^bb46
+    %c18446744073709551615_i256_51 = arith.constant 18446744073709551615 : i256
+    %119 = arith.cmpi sgt, %71, %c18446744073709551615_i256_51 : i256
+    %c84_i8_52 = arith.constant 84 : i8
+    cf.cond_br %119, ^bb1(%c84_i8_52 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %134 = arith.trunci %81 : i256 to i64
-    %c0_i64_67 = arith.constant 0 : i64
-    %135 = arith.cmpi slt, %134, %c0_i64_67 : i64
-    %c84_i8_68 = arith.constant 84 : i8
-    cf.cond_br %135, ^bb1(%c84_i8_68 : i8), ^bb47
+    %120 = arith.trunci %71 : i256 to i64
+    %c0_i64_53 = arith.constant 0 : i64
+    %121 = arith.cmpi slt, %120, %c0_i64_53 : i64
+    %c84_i8_54 = arith.constant 84 : i8
+    cf.cond_br %121, ^bb1(%c84_i8_54 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %136 = arith.addi %134, %99 : i64
-    %c0_i64_69 = arith.constant 0 : i64
-    %137 = arith.cmpi slt, %136, %c0_i64_69 : i64
-    %c84_i8_70 = arith.constant 84 : i8
-    cf.cond_br %137, ^bb1(%c84_i8_70 : i8), ^bb48
+    %122 = arith.addi %120, %86 : i64
+    %c0_i64_55 = arith.constant 0 : i64
+    %123 = arith.cmpi slt, %122, %c0_i64_55 : i64
+    %c84_i8_56 = arith.constant 84 : i8
+    cf.cond_br %123, ^bb1(%c84_i8_56 : i8), ^bb48
   ^bb48:  // pred: ^bb47
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %138 = arith.addi %136, %c31_i64 : i64
-    %139 = arith.divui %138, %c32_i64 : i64
-    %c32_i64_71 = arith.constant 32 : i64
-    %140 = arith.muli %139, %c32_i64_71 : i64
-    %141 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_72 = arith.constant 31 : i64
-    %c32_i64_73 = arith.constant 32 : i64
-    %142 = arith.addi %141, %c31_i64_72 : i64
-    %143 = arith.divui %142, %c32_i64_73 : i64
-    %144 = arith.muli %143, %c32_i64_71 : i64
-    %145 = arith.cmpi ult, %144, %140 : i64
-    cf.cond_br %145, ^bb50, ^bb49
+    %124 = arith.addi %122, %c31_i64 : i64
+    %125 = arith.divui %124, %c32_i64 : i64
+    %c32_i64_57 = arith.constant 32 : i64
+    %126 = arith.muli %125, %c32_i64_57 : i64
+    %127 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_58 = arith.constant 31 : i64
+    %c32_i64_59 = arith.constant 32 : i64
+    %128 = arith.addi %127, %c31_i64_58 : i64
+    %129 = arith.divui %128, %c32_i64_59 : i64
+    %130 = arith.muli %129, %c32_i64_57 : i64
+    %131 = arith.cmpi ult, %130, %126 : i64
+    cf.cond_br %131, ^bb50, ^bb49
   ^bb49:  // 2 preds: ^bb48, ^bb52
     cf.br ^bb35
   ^bb50:  // pred: ^bb48
-    %c3_i64_74 = arith.constant 3 : i64
+    %c3_i64_60 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %146 = arith.muli %143, %143 : i64
-    %147 = arith.divui %146, %c512_i64 : i64
-    %148 = arith.muli %143, %c3_i64_74 : i64
-    %149 = arith.addi %147, %148 : i64
-    %c3_i64_75 = arith.constant 3 : i64
-    %c512_i64_76 = arith.constant 512 : i64
-    %150 = arith.muli %139, %139 : i64
-    %151 = arith.divui %150, %c512_i64_76 : i64
-    %152 = arith.muli %139, %c3_i64_75 : i64
-    %153 = arith.addi %151, %152 : i64
-    %154 = arith.subi %153, %149 : i64
-    %155 = llvm.load %arg1 : !llvm.ptr -> i64
-    %156 = arith.cmpi ult, %155, %154 : i64
-    scf.if %156 {
+    %132 = arith.muli %129, %129 : i64
+    %133 = arith.divui %132, %c512_i64 : i64
+    %134 = arith.muli %129, %c3_i64_60 : i64
+    %135 = arith.addi %133, %134 : i64
+    %c3_i64_61 = arith.constant 3 : i64
+    %c512_i64_62 = arith.constant 512 : i64
+    %136 = arith.muli %125, %125 : i64
+    %137 = arith.divui %136, %c512_i64_62 : i64
+    %138 = arith.muli %125, %c3_i64_61 : i64
+    %139 = arith.addi %137, %138 : i64
+    %140 = arith.subi %139, %135 : i64
+    %141 = llvm.load %arg1 : !llvm.ptr -> i64
+    %142 = arith.cmpi ult, %141, %140 : i64
+    scf.if %142 {
     } else {
-      %189 = arith.subi %155, %154 : i64
-      llvm.store %189, %arg1 : i64, !llvm.ptr
+      %175 = arith.subi %141, %140 : i64
+      llvm.store %175, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_77 = arith.constant 80 : i8
-    cf.cond_br %156, ^bb1(%c80_i8_77 : i8), ^bb51
+    %c80_i8_63 = arith.constant 80 : i8
+    cf.cond_br %142, ^bb1(%c80_i8_63 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %157 = call @dora_fn_extend_memory(%arg0, %140) : (!llvm.ptr, i64) -> !llvm.ptr
-    %158 = llvm.getelementptr %157[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %159 = llvm.load %158 : !llvm.ptr -> i8
-    %c0_i8_78 = arith.constant 0 : i8
-    %160 = arith.cmpi ne, %159, %c0_i8_78 : i8
-    cf.cond_br %160, ^bb1(%159 : i8), ^bb52
+    %143 = call @dora_fn_extend_memory(%arg0, %126) : (!llvm.ptr, i64) -> !llvm.ptr
+    %144 = llvm.getelementptr %143[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %145 = llvm.load %144 : !llvm.ptr -> i8
+    %c0_i8_64 = arith.constant 0 : i8
+    %146 = arith.cmpi ne, %145, %c0_i8_64 : i8
+    cf.cond_br %146, ^bb1(%145 : i8), ^bb52
   ^bb52:  // pred: ^bb51
     cf.br ^bb49
   ^bb53:  // pred: ^bb37
-    %c18446744073709551615_i256_79 = arith.constant 18446744073709551615 : i256
-    %161 = arith.cmpi sgt, %89, %c18446744073709551615_i256_79 : i256
-    %c84_i8_80 = arith.constant 84 : i8
-    cf.cond_br %161, ^bb1(%c84_i8_80 : i8), ^bb54
+    %c18446744073709551615_i256_65 = arith.constant 18446744073709551615 : i256
+    %147 = arith.cmpi sgt, %77, %c18446744073709551615_i256_65 : i256
+    %c84_i8_66 = arith.constant 84 : i8
+    cf.cond_br %147, ^bb1(%c84_i8_66 : i8), ^bb54
   ^bb54:  // pred: ^bb53
-    %162 = arith.trunci %89 : i256 to i64
-    %c0_i64_81 = arith.constant 0 : i64
-    %163 = arith.cmpi slt, %162, %c0_i64_81 : i64
-    %c84_i8_82 = arith.constant 84 : i8
-    cf.cond_br %163, ^bb1(%c84_i8_82 : i8), ^bb55
+    %148 = arith.trunci %77 : i256 to i64
+    %c0_i64_67 = arith.constant 0 : i64
+    %149 = arith.cmpi slt, %148, %c0_i64_67 : i64
+    %c84_i8_68 = arith.constant 84 : i8
+    cf.cond_br %149, ^bb1(%c84_i8_68 : i8), ^bb55
   ^bb55:  // pred: ^bb54
-    %164 = arith.addi %162, %103 : i64
-    %c0_i64_83 = arith.constant 0 : i64
-    %165 = arith.cmpi slt, %164, %c0_i64_83 : i64
-    %c84_i8_84 = arith.constant 84 : i8
-    cf.cond_br %165, ^bb1(%c84_i8_84 : i8), ^bb56
+    %150 = arith.addi %148, %90 : i64
+    %c0_i64_69 = arith.constant 0 : i64
+    %151 = arith.cmpi slt, %150, %c0_i64_69 : i64
+    %c84_i8_70 = arith.constant 84 : i8
+    cf.cond_br %151, ^bb1(%c84_i8_70 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %c31_i64_85 = arith.constant 31 : i64
-    %c32_i64_86 = arith.constant 32 : i64
-    %166 = arith.addi %164, %c31_i64_85 : i64
-    %167 = arith.divui %166, %c32_i64_86 : i64
-    %c32_i64_87 = arith.constant 32 : i64
-    %168 = arith.muli %167, %c32_i64_87 : i64
-    %169 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_88 = arith.constant 31 : i64
-    %c32_i64_89 = arith.constant 32 : i64
-    %170 = arith.addi %169, %c31_i64_88 : i64
-    %171 = arith.divui %170, %c32_i64_89 : i64
-    %172 = arith.muli %171, %c32_i64_87 : i64
-    %173 = arith.cmpi ult, %172, %168 : i64
-    cf.cond_br %173, ^bb58, ^bb57
+    %c31_i64_71 = arith.constant 31 : i64
+    %c32_i64_72 = arith.constant 32 : i64
+    %152 = arith.addi %150, %c31_i64_71 : i64
+    %153 = arith.divui %152, %c32_i64_72 : i64
+    %c32_i64_73 = arith.constant 32 : i64
+    %154 = arith.muli %153, %c32_i64_73 : i64
+    %155 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_74 = arith.constant 31 : i64
+    %c32_i64_75 = arith.constant 32 : i64
+    %156 = arith.addi %155, %c31_i64_74 : i64
+    %157 = arith.divui %156, %c32_i64_75 : i64
+    %158 = arith.muli %157, %c32_i64_73 : i64
+    %159 = arith.cmpi ult, %158, %154 : i64
+    cf.cond_br %159, ^bb58, ^bb57
   ^bb57:  // 2 preds: ^bb56, ^bb60
     cf.br ^bb38
   ^bb58:  // pred: ^bb56
-    %c3_i64_90 = arith.constant 3 : i64
-    %c512_i64_91 = arith.constant 512 : i64
-    %174 = arith.muli %171, %171 : i64
-    %175 = arith.divui %174, %c512_i64_91 : i64
-    %176 = arith.muli %171, %c3_i64_90 : i64
-    %177 = arith.addi %175, %176 : i64
-    %c3_i64_92 = arith.constant 3 : i64
-    %c512_i64_93 = arith.constant 512 : i64
-    %178 = arith.muli %167, %167 : i64
-    %179 = arith.divui %178, %c512_i64_93 : i64
-    %180 = arith.muli %167, %c3_i64_92 : i64
-    %181 = arith.addi %179, %180 : i64
-    %182 = arith.subi %181, %177 : i64
-    %183 = llvm.load %arg1 : !llvm.ptr -> i64
-    %184 = arith.cmpi ult, %183, %182 : i64
-    scf.if %184 {
+    %c3_i64_76 = arith.constant 3 : i64
+    %c512_i64_77 = arith.constant 512 : i64
+    %160 = arith.muli %157, %157 : i64
+    %161 = arith.divui %160, %c512_i64_77 : i64
+    %162 = arith.muli %157, %c3_i64_76 : i64
+    %163 = arith.addi %161, %162 : i64
+    %c3_i64_78 = arith.constant 3 : i64
+    %c512_i64_79 = arith.constant 512 : i64
+    %164 = arith.muli %153, %153 : i64
+    %165 = arith.divui %164, %c512_i64_79 : i64
+    %166 = arith.muli %153, %c3_i64_78 : i64
+    %167 = arith.addi %165, %166 : i64
+    %168 = arith.subi %167, %163 : i64
+    %169 = llvm.load %arg1 : !llvm.ptr -> i64
+    %170 = arith.cmpi ult, %169, %168 : i64
+    scf.if %170 {
     } else {
-      %189 = arith.subi %183, %182 : i64
-      llvm.store %189, %arg1 : i64, !llvm.ptr
+      %175 = arith.subi %169, %168 : i64
+      llvm.store %175, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_94 = arith.constant 80 : i8
-    cf.cond_br %184, ^bb1(%c80_i8_94 : i8), ^bb59
+    %c80_i8_80 = arith.constant 80 : i8
+    cf.cond_br %170, ^bb1(%c80_i8_80 : i8), ^bb59
   ^bb59:  // pred: ^bb58
-    %185 = call @dora_fn_extend_memory(%arg0, %168) : (!llvm.ptr, i64) -> !llvm.ptr
-    %186 = llvm.getelementptr %185[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %187 = llvm.load %186 : !llvm.ptr -> i8
-    %c0_i8_95 = arith.constant 0 : i8
-    %188 = arith.cmpi ne, %187, %c0_i8_95 : i8
-    cf.cond_br %188, ^bb1(%187 : i8), ^bb60
+    %171 = call @dora_fn_extend_memory(%arg0, %154) : (!llvm.ptr, i64) -> !llvm.ptr
+    %172 = llvm.getelementptr %171[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %173 = llvm.load %172 : !llvm.ptr -> i8
+    %c0_i8_81 = arith.constant 0 : i8
+    %174 = arith.cmpi ne, %173, %c0_i8_81 : i8
+    cf.cond_br %174, ^bb1(%173 : i8), ^bb60
   ^bb60:  // pred: ^bb59
     cf.br ^bb57
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 33 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb31, ^bb32, ^bb34, ^bb35, ^bb37, ^bb38, ^bb40, ^bb41, ^bb44, ^bb45, ^bb46, ^bb49, ^bb50, ^bb52, ^bb53, ^bb54, ^bb57, ^bb58
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 33 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb31, ^bb32, ^bb34, ^bb35, ^bb37, ^bb38, ^bb40, ^bb41, ^bb44, ^bb45, ^bb46, ^bb49, ^bb50, ^bb52, ^bb53, ^bb54, ^bb57, ^bb58
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c5000_i256 = arith.constant 5000 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c5000_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,443 +96,422 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c8192_i256 = arith.constant 8192 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c8192_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c8192_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c0_i256 = arith.constant 0 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c32_i256 = arith.constant 32 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %c32_i256_19 = arith.constant 32 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_20 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_19, %40 : i256, !llvm.ptr
+    %c32_i256_16 = arith.constant 32 : i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_16, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_22 : i64
-    %44 = arith.cmpi ult, %c1024_i64_21, %43 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_23 : i8), ^bb19
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_18 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_17, %39 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_19 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb22, ^bb1(%c80_i8_25 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_21 : i8)
   ^bb22:  // pred: ^bb21
-    %47 = arith.subi %45, %c3_i64_24 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_20 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
     %c64_i256 = arith.constant 64 : i256
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %50 = arith.addi %48, %c1_i64_26 : i64
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %49 : i256, !llvm.ptr
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %44 : i256, !llvm.ptr
+    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb24:  // pred: ^bb26
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %52 = arith.addi %51, %c1_i64_28 : i64
-    %53 = arith.cmpi ult, %c1024_i64_27, %52 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %53, ^bb1(%c92_i8_29 : i8), ^bb23
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_23 = arith.constant 1 : i64
+    %47 = arith.addi %46, %c1_i64_23 : i64
+    llvm.store %47, %arg3 : i64, !llvm.ptr
+    %48 = arith.cmpi ult, %c1024_i64_22, %47 : i64
+    %c92_i8_24 = arith.constant 92 : i8
+    cf.cond_br %48, ^bb1(%c92_i8_24 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_25 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %55 = arith.cmpi uge, %54, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %55, ^bb26, ^bb1(%c80_i8_31 : i8)
+    %50 = arith.cmpi uge, %49, %c3_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %50, ^bb26, ^bb1(%c80_i8_26 : i8)
   ^bb26:  // pred: ^bb25
-    %56 = arith.subi %54, %c3_i64_30 : i64
-    llvm.store %56, %arg1 : i64, !llvm.ptr
+    %51 = arith.subi %49, %c3_i64_25 : i64
+    llvm.store %51, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb28
-    %c64_i256_32 = arith.constant 64 : i256
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %58 = llvm.getelementptr %arg2[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_33 = arith.constant 1 : i64
-    %59 = arith.addi %57, %c1_i64_33 : i64
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256_32, %58 : i256, !llvm.ptr
+    %c64_i256_27 = arith.constant 64 : i256
+    %52 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_27, %52 : i256, !llvm.ptr
+    %53 = llvm.getelementptr %52[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %53, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb41
   ^bb28:  // pred: ^bb30
-    %c1024_i64_34 = arith.constant 1024 : i64
-    %60 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %61 = arith.addi %60, %c1_i64_35 : i64
-    %62 = arith.cmpi ult, %c1024_i64_34, %61 : i64
-    %c92_i8_36 = arith.constant 92 : i8
-    cf.cond_br %62, ^bb1(%c92_i8_36 : i8), ^bb27
+    %c1024_i64_28 = arith.constant 1024 : i64
+    %54 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_29 = arith.constant 1 : i64
+    %55 = arith.addi %54, %c1_i64_29 : i64
+    llvm.store %55, %arg3 : i64, !llvm.ptr
+    %56 = arith.cmpi ult, %c1024_i64_28, %55 : i64
+    %c92_i8_30 = arith.constant 92 : i8
+    cf.cond_br %56, ^bb1(%c92_i8_30 : i8), ^bb27
   ^bb29:  // pred: ^bb23
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_37 = arith.constant 3 : i64
+    %57 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_31 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %64 = arith.cmpi uge, %63, %c3_i64_37 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb30, ^bb1(%c80_i8_38 : i8)
+    %58 = arith.cmpi uge, %57, %c3_i64_31 : i64
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %58, ^bb30, ^bb1(%c80_i8_32 : i8)
   ^bb30:  // pred: ^bb29
-    %65 = arith.subi %63, %c3_i64_37 : i64
-    llvm.store %65, %arg1 : i64, !llvm.ptr
+    %59 = arith.subi %57, %c3_i64_31 : i64
+    llvm.store %59, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb40
-    %66 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_39 = arith.constant 1 : i64
-    %67 = arith.subi %66, %c1_i64_39 : i64
-    %68 = llvm.getelementptr %arg2[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %67, %arg3 : i64, !llvm.ptr
-    %69 = llvm.load %68 : !llvm.ptr -> i256
-    %70 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_40 = arith.constant 1 : i64
-    %71 = arith.subi %70, %c1_i64_40 : i64
-    %72 = llvm.getelementptr %arg2[%71] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %71, %arg3 : i64, !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i256
-    %74 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_41 = arith.constant 1 : i64
-    %75 = arith.subi %74, %c1_i64_41 : i64
-    %76 = llvm.getelementptr %arg2[%75] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %75, %arg3 : i64, !llvm.ptr
+    %60 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %61 = llvm.getelementptr %60[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %62 = llvm.load %61 : !llvm.ptr -> i256
+    llvm.store %61, %0 : !llvm.ptr, !llvm.ptr
+    %63 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %0 : !llvm.ptr, !llvm.ptr
+    %66 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %67 = llvm.getelementptr %66[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %68 = llvm.load %67 : !llvm.ptr -> i256
+    llvm.store %67, %0 : !llvm.ptr, !llvm.ptr
+    %69 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %70 = llvm.getelementptr %69[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %71 = llvm.load %70 : !llvm.ptr -> i256
+    llvm.store %70, %0 : !llvm.ptr, !llvm.ptr
+    %72 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %73 = llvm.getelementptr %72[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %74 = llvm.load %73 : !llvm.ptr -> i256
+    llvm.store %73, %0 : !llvm.ptr, !llvm.ptr
+    %75 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %76 = llvm.getelementptr %75[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %77 = llvm.load %76 : !llvm.ptr -> i256
-    %78 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_42 = arith.constant 1 : i64
-    %79 = arith.subi %78, %c1_i64_42 : i64
-    %80 = llvm.getelementptr %arg2[%79] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    %81 = llvm.load %80 : !llvm.ptr -> i256
-    %82 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_43 = arith.constant 1 : i64
-    %83 = arith.subi %82, %c1_i64_43 : i64
-    %84 = llvm.getelementptr %arg2[%83] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %83, %arg3 : i64, !llvm.ptr
-    %85 = llvm.load %84 : !llvm.ptr -> i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %87 = arith.subi %86, %c1_i64_44 : i64
-    %88 = llvm.getelementptr %arg2[%87] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %87, %arg3 : i64, !llvm.ptr
-    %89 = llvm.load %88 : !llvm.ptr -> i256
-    %90 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_45 = arith.constant 1 : i64
-    %91 = arith.subi %90, %c1_i64_45 : i64
-    %92 = llvm.getelementptr %arg2[%91] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %91, %arg3 : i64, !llvm.ptr
-    %93 = llvm.load %92 : !llvm.ptr -> i256
+    llvm.store %76, %0 : !llvm.ptr, !llvm.ptr
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %79 = llvm.getelementptr %78[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %80 = llvm.load %79 : !llvm.ptr -> i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %94 = arith.cmpi sgt, %85, %c18446744073709551615_i256 : i256
+    %81 = arith.cmpi sgt, %74, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %94, ^bb1(%c84_i8 : i8), ^bb32
+    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %95 = arith.trunci %85 : i256 to i64
-    %c0_i64_46 = arith.constant 0 : i64
-    %96 = arith.cmpi slt, %95, %c0_i64_46 : i64
-    %c84_i8_47 = arith.constant 84 : i8
-    cf.cond_br %96, ^bb1(%c84_i8_47 : i8), ^bb33
+    %82 = arith.trunci %74 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %83 = arith.cmpi slt, %82, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %83, ^bb1(%c84_i8_34 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %c0_i64_48 = arith.constant 0 : i64
-    %97 = arith.cmpi ne, %95, %c0_i64_48 : i64
-    cf.cond_br %97, ^bb44, ^bb34
+    %c0_i64_35 = arith.constant 0 : i64
+    %84 = arith.cmpi ne, %82, %c0_i64_35 : i64
+    cf.cond_br %84, ^bb44, ^bb34
   ^bb34:  // 2 preds: ^bb33, ^bb48
-    %c18446744073709551615_i256_49 = arith.constant 18446744073709551615 : i256
-    %98 = arith.cmpi sgt, %93, %c18446744073709551615_i256_49 : i256
-    %c84_i8_50 = arith.constant 84 : i8
-    cf.cond_br %98, ^bb1(%c84_i8_50 : i8), ^bb35
+    %c18446744073709551615_i256_36 = arith.constant 18446744073709551615 : i256
+    %85 = arith.cmpi sgt, %80, %c18446744073709551615_i256_36 : i256
+    %c84_i8_37 = arith.constant 84 : i8
+    cf.cond_br %85, ^bb1(%c84_i8_37 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %99 = arith.trunci %93 : i256 to i64
-    %c0_i64_51 = arith.constant 0 : i64
-    %100 = arith.cmpi slt, %99, %c0_i64_51 : i64
-    %c84_i8_52 = arith.constant 84 : i8
-    cf.cond_br %100, ^bb1(%c84_i8_52 : i8), ^bb36
+    %86 = arith.trunci %80 : i256 to i64
+    %c0_i64_38 = arith.constant 0 : i64
+    %87 = arith.cmpi slt, %86, %c0_i64_38 : i64
+    %c84_i8_39 = arith.constant 84 : i8
+    cf.cond_br %87, ^bb1(%c84_i8_39 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %c0_i64_53 = arith.constant 0 : i64
-    %101 = arith.cmpi ne, %99, %c0_i64_53 : i64
-    cf.cond_br %101, ^bb52, ^bb37
+    %c0_i64_40 = arith.constant 0 : i64
+    %88 = arith.cmpi ne, %86, %c0_i64_40 : i64
+    cf.cond_br %88, ^bb52, ^bb37
   ^bb37:  // 2 preds: ^bb36, ^bb56
-    %102 = arith.trunci %81 : i256 to i64
-    %103 = arith.trunci %89 : i256 to i64
-    %104 = llvm.load %arg1 : !llvm.ptr -> i64
+    %89 = arith.trunci %71 : i256 to i64
+    %90 = arith.trunci %77 : i256 to i64
+    %91 = llvm.load %arg1 : !llvm.ptr -> i64
     %c1_i256 = arith.constant 1 : i256
-    %105 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %77, %105 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_54 = arith.constant 1 : i256
-    %106 = llvm.alloca %c1_i256_54 x i256 : (i256) -> !llvm.ptr
-    llvm.store %69, %106 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_55 = arith.constant 1 : i256
-    %107 = llvm.alloca %c1_i256_55 x i256 : (i256) -> !llvm.ptr
-    llvm.store %73, %107 {alignment = 1 : i64} : i256, !llvm.ptr
+    %92 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %68, %92 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_41 = arith.constant 1 : i256
+    %93 = llvm.alloca %c1_i256_41 x i256 : (i256) -> !llvm.ptr
+    llvm.store %62, %93 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_42 = arith.constant 1 : i256
+    %94 = llvm.alloca %c1_i256_42 x i256 : (i256) -> !llvm.ptr
+    llvm.store %65, %94 {alignment = 1 : i64} : i256, !llvm.ptr
     %c3_i8 = arith.constant 3 : i8
-    %108 = call @dora_fn_call(%arg0, %106, %107, %105, %102, %95, %103, %99, %104, %c3_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %109 = llvm.getelementptr %108[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %110 = llvm.load %109 : !llvm.ptr -> i8
-    %111 = llvm.getelementptr %108[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %112 = llvm.load %111 : !llvm.ptr -> i8
+    %95 = call @dora_fn_call(%arg0, %93, %94, %92, %89, %82, %90, %86, %91, %c3_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %96 = llvm.getelementptr %95[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %97 = llvm.load %96 : !llvm.ptr -> i8
+    %98 = llvm.getelementptr %95[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %99 = llvm.load %98 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %113 = arith.cmpi ne, %112, %c0_i8 : i8
-    cf.cond_br %113, ^bb1(%112 : i8), ^bb38
+    %100 = arith.cmpi ne, %99, %c0_i8 : i8
+    cf.cond_br %100, ^bb1(%99 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %114 = llvm.getelementptr %108[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %115 = llvm.load %114 : !llvm.ptr -> i64
-    %116 = llvm.load %arg1 : !llvm.ptr -> i64
-    %117 = arith.cmpi ult, %116, %115 : i64
-    scf.if %117 {
+    %101 = llvm.getelementptr %95[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %102 = llvm.load %101 : !llvm.ptr -> i64
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    %104 = arith.cmpi ult, %103, %102 : i64
+    scf.if %104 {
     } else {
-      %185 = arith.subi %116, %115 : i64
-      llvm.store %185, %arg1 : i64, !llvm.ptr
+      %171 = arith.subi %103, %102 : i64
+      llvm.store %171, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_56 = arith.constant 80 : i8
-    cf.cond_br %117, ^bb1(%c80_i8_56 : i8), ^bb39
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %104, ^bb1(%c80_i8_43 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %118 = arith.extui %110 : i8 to i256
-    %119 = llvm.load %arg3 : !llvm.ptr -> i64
-    %120 = llvm.getelementptr %arg2[%119] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_57 = arith.constant 1 : i64
-    %121 = arith.addi %119, %c1_i64_57 : i64
-    llvm.store %121, %arg3 : i64, !llvm.ptr
-    llvm.store %118, %120 : i256, !llvm.ptr
+    %105 = arith.extui %97 : i8 to i256
+    %106 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %105, %106 : i256, !llvm.ptr
+    %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %107, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb43
   ^bb40:  // pred: ^bb42
-    %c1024_i64_58 = arith.constant 1024 : i64
-    %122 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_44 = arith.constant 1024 : i64
+    %108 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %123 = arith.addi %122, %c-6_i64 : i64
+    %109 = arith.addi %108, %c-6_i64 : i64
+    llvm.store %109, %arg3 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %124 = arith.cmpi ult, %122, %c7_i64 : i64
+    %110 = arith.cmpi ult, %108, %c7_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %124, ^bb1(%c91_i8 : i8), ^bb31
+    cf.cond_br %110, ^bb1(%c91_i8 : i8), ^bb31
   ^bb41:  // pred: ^bb27
-    %125 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_59 = arith.constant 0 : i64
+    %111 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_45 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %126 = arith.cmpi uge, %125, %c0_i64_59 : i64
-    %c80_i8_60 = arith.constant 80 : i8
-    cf.cond_br %126, ^bb42, ^bb1(%c80_i8_60 : i8)
+    %112 = arith.cmpi uge, %111, %c0_i64_45 : i64
+    %c80_i8_46 = arith.constant 80 : i8
+    cf.cond_br %112, ^bb42, ^bb1(%c80_i8_46 : i8)
   ^bb42:  // pred: ^bb41
-    %127 = arith.subi %125, %c0_i64_59 : i64
-    llvm.store %127, %arg1 : i64, !llvm.ptr
+    %113 = arith.subi %111, %c0_i64_45 : i64
+    llvm.store %113, %arg1 : i64, !llvm.ptr
     cf.br ^bb40
   ^bb43:  // pred: ^bb39
-    %c0_i64_61 = arith.constant 0 : i64
+    %c0_i64_47 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %128 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_61, %c0_i64_61, %128, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %114 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_47, %c0_i64_47, %114, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb44:  // pred: ^bb33
-    %c18446744073709551615_i256_62 = arith.constant 18446744073709551615 : i256
-    %129 = arith.cmpi sgt, %81, %c18446744073709551615_i256_62 : i256
-    %c84_i8_63 = arith.constant 84 : i8
-    cf.cond_br %129, ^bb1(%c84_i8_63 : i8), ^bb45
+    %c18446744073709551615_i256_48 = arith.constant 18446744073709551615 : i256
+    %115 = arith.cmpi sgt, %71, %c18446744073709551615_i256_48 : i256
+    %c84_i8_49 = arith.constant 84 : i8
+    cf.cond_br %115, ^bb1(%c84_i8_49 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %130 = arith.trunci %81 : i256 to i64
-    %c0_i64_64 = arith.constant 0 : i64
-    %131 = arith.cmpi slt, %130, %c0_i64_64 : i64
-    %c84_i8_65 = arith.constant 84 : i8
-    cf.cond_br %131, ^bb1(%c84_i8_65 : i8), ^bb46
+    %116 = arith.trunci %71 : i256 to i64
+    %c0_i64_50 = arith.constant 0 : i64
+    %117 = arith.cmpi slt, %116, %c0_i64_50 : i64
+    %c84_i8_51 = arith.constant 84 : i8
+    cf.cond_br %117, ^bb1(%c84_i8_51 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %132 = arith.addi %130, %95 : i64
-    %c0_i64_66 = arith.constant 0 : i64
-    %133 = arith.cmpi slt, %132, %c0_i64_66 : i64
-    %c84_i8_67 = arith.constant 84 : i8
-    cf.cond_br %133, ^bb1(%c84_i8_67 : i8), ^bb47
+    %118 = arith.addi %116, %82 : i64
+    %c0_i64_52 = arith.constant 0 : i64
+    %119 = arith.cmpi slt, %118, %c0_i64_52 : i64
+    %c84_i8_53 = arith.constant 84 : i8
+    cf.cond_br %119, ^bb1(%c84_i8_53 : i8), ^bb47
   ^bb47:  // pred: ^bb46
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %134 = arith.addi %132, %c31_i64 : i64
-    %135 = arith.divui %134, %c32_i64 : i64
-    %c32_i64_68 = arith.constant 32 : i64
-    %136 = arith.muli %135, %c32_i64_68 : i64
-    %137 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_69 = arith.constant 31 : i64
-    %c32_i64_70 = arith.constant 32 : i64
-    %138 = arith.addi %137, %c31_i64_69 : i64
-    %139 = arith.divui %138, %c32_i64_70 : i64
-    %140 = arith.muli %139, %c32_i64_68 : i64
-    %141 = arith.cmpi ult, %140, %136 : i64
-    cf.cond_br %141, ^bb49, ^bb48
+    %120 = arith.addi %118, %c31_i64 : i64
+    %121 = arith.divui %120, %c32_i64 : i64
+    %c32_i64_54 = arith.constant 32 : i64
+    %122 = arith.muli %121, %c32_i64_54 : i64
+    %123 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_55 = arith.constant 31 : i64
+    %c32_i64_56 = arith.constant 32 : i64
+    %124 = arith.addi %123, %c31_i64_55 : i64
+    %125 = arith.divui %124, %c32_i64_56 : i64
+    %126 = arith.muli %125, %c32_i64_54 : i64
+    %127 = arith.cmpi ult, %126, %122 : i64
+    cf.cond_br %127, ^bb49, ^bb48
   ^bb48:  // 2 preds: ^bb47, ^bb51
     cf.br ^bb34
   ^bb49:  // pred: ^bb47
-    %c3_i64_71 = arith.constant 3 : i64
+    %c3_i64_57 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %142 = arith.muli %139, %139 : i64
-    %143 = arith.divui %142, %c512_i64 : i64
-    %144 = arith.muli %139, %c3_i64_71 : i64
-    %145 = arith.addi %143, %144 : i64
-    %c3_i64_72 = arith.constant 3 : i64
-    %c512_i64_73 = arith.constant 512 : i64
-    %146 = arith.muli %135, %135 : i64
-    %147 = arith.divui %146, %c512_i64_73 : i64
-    %148 = arith.muli %135, %c3_i64_72 : i64
-    %149 = arith.addi %147, %148 : i64
-    %150 = arith.subi %149, %145 : i64
-    %151 = llvm.load %arg1 : !llvm.ptr -> i64
-    %152 = arith.cmpi ult, %151, %150 : i64
-    scf.if %152 {
+    %128 = arith.muli %125, %125 : i64
+    %129 = arith.divui %128, %c512_i64 : i64
+    %130 = arith.muli %125, %c3_i64_57 : i64
+    %131 = arith.addi %129, %130 : i64
+    %c3_i64_58 = arith.constant 3 : i64
+    %c512_i64_59 = arith.constant 512 : i64
+    %132 = arith.muli %121, %121 : i64
+    %133 = arith.divui %132, %c512_i64_59 : i64
+    %134 = arith.muli %121, %c3_i64_58 : i64
+    %135 = arith.addi %133, %134 : i64
+    %136 = arith.subi %135, %131 : i64
+    %137 = llvm.load %arg1 : !llvm.ptr -> i64
+    %138 = arith.cmpi ult, %137, %136 : i64
+    scf.if %138 {
     } else {
-      %185 = arith.subi %151, %150 : i64
-      llvm.store %185, %arg1 : i64, !llvm.ptr
+      %171 = arith.subi %137, %136 : i64
+      llvm.store %171, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_74 = arith.constant 80 : i8
-    cf.cond_br %152, ^bb1(%c80_i8_74 : i8), ^bb50
+    %c80_i8_60 = arith.constant 80 : i8
+    cf.cond_br %138, ^bb1(%c80_i8_60 : i8), ^bb50
   ^bb50:  // pred: ^bb49
-    %153 = call @dora_fn_extend_memory(%arg0, %136) : (!llvm.ptr, i64) -> !llvm.ptr
-    %154 = llvm.getelementptr %153[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %155 = llvm.load %154 : !llvm.ptr -> i8
-    %c0_i8_75 = arith.constant 0 : i8
-    %156 = arith.cmpi ne, %155, %c0_i8_75 : i8
-    cf.cond_br %156, ^bb1(%155 : i8), ^bb51
+    %139 = call @dora_fn_extend_memory(%arg0, %122) : (!llvm.ptr, i64) -> !llvm.ptr
+    %140 = llvm.getelementptr %139[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %141 = llvm.load %140 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %142 = arith.cmpi ne, %141, %c0_i8_61 : i8
+    cf.cond_br %142, ^bb1(%141 : i8), ^bb51
   ^bb51:  // pred: ^bb50
     cf.br ^bb48
   ^bb52:  // pred: ^bb36
-    %c18446744073709551615_i256_76 = arith.constant 18446744073709551615 : i256
-    %157 = arith.cmpi sgt, %89, %c18446744073709551615_i256_76 : i256
-    %c84_i8_77 = arith.constant 84 : i8
-    cf.cond_br %157, ^bb1(%c84_i8_77 : i8), ^bb53
+    %c18446744073709551615_i256_62 = arith.constant 18446744073709551615 : i256
+    %143 = arith.cmpi sgt, %77, %c18446744073709551615_i256_62 : i256
+    %c84_i8_63 = arith.constant 84 : i8
+    cf.cond_br %143, ^bb1(%c84_i8_63 : i8), ^bb53
   ^bb53:  // pred: ^bb52
-    %158 = arith.trunci %89 : i256 to i64
-    %c0_i64_78 = arith.constant 0 : i64
-    %159 = arith.cmpi slt, %158, %c0_i64_78 : i64
-    %c84_i8_79 = arith.constant 84 : i8
-    cf.cond_br %159, ^bb1(%c84_i8_79 : i8), ^bb54
+    %144 = arith.trunci %77 : i256 to i64
+    %c0_i64_64 = arith.constant 0 : i64
+    %145 = arith.cmpi slt, %144, %c0_i64_64 : i64
+    %c84_i8_65 = arith.constant 84 : i8
+    cf.cond_br %145, ^bb1(%c84_i8_65 : i8), ^bb54
   ^bb54:  // pred: ^bb53
-    %160 = arith.addi %158, %99 : i64
-    %c0_i64_80 = arith.constant 0 : i64
-    %161 = arith.cmpi slt, %160, %c0_i64_80 : i64
-    %c84_i8_81 = arith.constant 84 : i8
-    cf.cond_br %161, ^bb1(%c84_i8_81 : i8), ^bb55
+    %146 = arith.addi %144, %86 : i64
+    %c0_i64_66 = arith.constant 0 : i64
+    %147 = arith.cmpi slt, %146, %c0_i64_66 : i64
+    %c84_i8_67 = arith.constant 84 : i8
+    cf.cond_br %147, ^bb1(%c84_i8_67 : i8), ^bb55
   ^bb55:  // pred: ^bb54
-    %c31_i64_82 = arith.constant 31 : i64
-    %c32_i64_83 = arith.constant 32 : i64
-    %162 = arith.addi %160, %c31_i64_82 : i64
-    %163 = arith.divui %162, %c32_i64_83 : i64
-    %c32_i64_84 = arith.constant 32 : i64
-    %164 = arith.muli %163, %c32_i64_84 : i64
-    %165 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_85 = arith.constant 31 : i64
-    %c32_i64_86 = arith.constant 32 : i64
-    %166 = arith.addi %165, %c31_i64_85 : i64
-    %167 = arith.divui %166, %c32_i64_86 : i64
-    %168 = arith.muli %167, %c32_i64_84 : i64
-    %169 = arith.cmpi ult, %168, %164 : i64
-    cf.cond_br %169, ^bb57, ^bb56
+    %c31_i64_68 = arith.constant 31 : i64
+    %c32_i64_69 = arith.constant 32 : i64
+    %148 = arith.addi %146, %c31_i64_68 : i64
+    %149 = arith.divui %148, %c32_i64_69 : i64
+    %c32_i64_70 = arith.constant 32 : i64
+    %150 = arith.muli %149, %c32_i64_70 : i64
+    %151 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_71 = arith.constant 31 : i64
+    %c32_i64_72 = arith.constant 32 : i64
+    %152 = arith.addi %151, %c31_i64_71 : i64
+    %153 = arith.divui %152, %c32_i64_72 : i64
+    %154 = arith.muli %153, %c32_i64_70 : i64
+    %155 = arith.cmpi ult, %154, %150 : i64
+    cf.cond_br %155, ^bb57, ^bb56
   ^bb56:  // 2 preds: ^bb55, ^bb59
     cf.br ^bb37
   ^bb57:  // pred: ^bb55
-    %c3_i64_87 = arith.constant 3 : i64
-    %c512_i64_88 = arith.constant 512 : i64
-    %170 = arith.muli %167, %167 : i64
-    %171 = arith.divui %170, %c512_i64_88 : i64
-    %172 = arith.muli %167, %c3_i64_87 : i64
-    %173 = arith.addi %171, %172 : i64
-    %c3_i64_89 = arith.constant 3 : i64
-    %c512_i64_90 = arith.constant 512 : i64
-    %174 = arith.muli %163, %163 : i64
-    %175 = arith.divui %174, %c512_i64_90 : i64
-    %176 = arith.muli %163, %c3_i64_89 : i64
-    %177 = arith.addi %175, %176 : i64
-    %178 = arith.subi %177, %173 : i64
-    %179 = llvm.load %arg1 : !llvm.ptr -> i64
-    %180 = arith.cmpi ult, %179, %178 : i64
-    scf.if %180 {
+    %c3_i64_73 = arith.constant 3 : i64
+    %c512_i64_74 = arith.constant 512 : i64
+    %156 = arith.muli %153, %153 : i64
+    %157 = arith.divui %156, %c512_i64_74 : i64
+    %158 = arith.muli %153, %c3_i64_73 : i64
+    %159 = arith.addi %157, %158 : i64
+    %c3_i64_75 = arith.constant 3 : i64
+    %c512_i64_76 = arith.constant 512 : i64
+    %160 = arith.muli %149, %149 : i64
+    %161 = arith.divui %160, %c512_i64_76 : i64
+    %162 = arith.muli %149, %c3_i64_75 : i64
+    %163 = arith.addi %161, %162 : i64
+    %164 = arith.subi %163, %159 : i64
+    %165 = llvm.load %arg1 : !llvm.ptr -> i64
+    %166 = arith.cmpi ult, %165, %164 : i64
+    scf.if %166 {
     } else {
-      %185 = arith.subi %179, %178 : i64
-      llvm.store %185, %arg1 : i64, !llvm.ptr
+      %171 = arith.subi %165, %164 : i64
+      llvm.store %171, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_91 = arith.constant 80 : i8
-    cf.cond_br %180, ^bb1(%c80_i8_91 : i8), ^bb58
+    %c80_i8_77 = arith.constant 80 : i8
+    cf.cond_br %166, ^bb1(%c80_i8_77 : i8), ^bb58
   ^bb58:  // pred: ^bb57
-    %181 = call @dora_fn_extend_memory(%arg0, %164) : (!llvm.ptr, i64) -> !llvm.ptr
-    %182 = llvm.getelementptr %181[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %183 = llvm.load %182 : !llvm.ptr -> i8
-    %c0_i8_92 = arith.constant 0 : i8
-    %184 = arith.cmpi ne, %183, %c0_i8_92 : i8
-    cf.cond_br %184, ^bb1(%183 : i8), ^bb59
+    %167 = call @dora_fn_extend_memory(%arg0, %150) : (!llvm.ptr, i64) -> !llvm.ptr
+    %168 = llvm.getelementptr %167[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %169 = llvm.load %168 : !llvm.ptr -> i8
+    %c0_i8_78 = arith.constant 0 : i8
+    %170 = arith.cmpi ne, %169, %c0_i8_78 : i8
+    cf.cond_br %170, ^bb1(%169 : i8), ^bb59
   ^bb59:  // pred: ^bb58
     cf.br ^bb56
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,206 +96,199 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %c0_i256_7 = arith.constant 0 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_7, %22 : i256, !llvm.ptr
+    %c0_i256_6 = arith.constant 0 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_6, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb19
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_17 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_17 : i64
-    %c84_i8_18 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_18 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_12 : i64
+    %c84_i8_13 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_13 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i64_19 = arith.constant 0 : i64
-    %45 = arith.cmpi ne, %43, %c0_i64_19 : i64
-    cf.cond_br %45, ^bb23, ^bb18
+    %c0_i64_14 = arith.constant 0 : i64
+    %40 = arith.cmpi ne, %38, %c0_i64_14 : i64
+    cf.cond_br %40, ^bb23, ^bb18
   ^bb18:  // 2 preds: ^bb17, ^bb28
-    %46 = arith.trunci %33 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %47 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %47 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_calldata_copy(%arg0, %46, %47, %43) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()
+    %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %42 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_calldata_copy(%arg0, %41, %42, %38) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()
     cf.br ^bb22
   ^bb19:  // pred: ^bb21
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %49 = arith.addi %48, %c-3_i64 : i64
-    %c3_i64_21 = arith.constant 3 : i64
-    %50 = arith.cmpi ult, %48, %c3_i64_21 : i64
+    %44 = arith.addi %43, %c-3_i64 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %c3_i64_16 = arith.constant 3 : i64
+    %45 = arith.cmpi ult, %43, %c3_i64_16 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb15
   ^bb20:  // pred: ^bb11
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_22 = arith.constant 3 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_17 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_22 : i64
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb21, ^bb1(%c80_i8_23 : i8)
+    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb21, ^bb1(%c80_i8_18 : i8)
   ^bb21:  // pred: ^bb20
-    %53 = arith.subi %51, %c3_i64_22 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c3_i64_17 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb19
   ^bb22:  // pred: ^bb18
-    %c0_i64_24 = arith.constant 0 : i64
+    %c0_i64_19 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_19, %c0_i64_19, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb23:  // pred: ^bb17
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %43, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %c3_i64_25 = arith.constant 3 : i64
-    %57 = arith.muli %56, %c3_i64_25 : i64
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %59 = arith.cmpi ult, %58, %57 : i64
-    scf.if %59 {
+    %50 = arith.addi %38, %c31_i64 : i64
+    %51 = arith.divui %50, %c32_i64 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %52 = arith.muli %51, %c3_i64_20 : i64
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    %54 = arith.cmpi ult, %53, %52 : i64
+    scf.if %54 {
     } else {
-      %88 = arith.subi %58, %57 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %53, %52 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb1(%c80_i8_26 : i8), ^bb24
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %54, ^bb1(%c80_i8_21 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c18446744073709551615_i256_27 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_27 : i256
-    %c84_i8_28 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_28 : i8), ^bb25
+    %c18446744073709551615_i256_22 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_22 : i256
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_23 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_29 : i64
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_30 : i8), ^bb26
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_24 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_24 : i64
+    %c84_i8_25 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %63 = arith.addi %61, %43 : i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_32 : i8), ^bb27
+    %58 = arith.addi %56, %38 : i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_27 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c31_i64_33 = arith.constant 31 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64_33 : i64
-    %66 = arith.divui %65, %c32_i64_34 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_35 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_36 : i64
-    %70 = arith.divui %69, %c32_i64_37 : i64
-    %71 = arith.muli %70, %c32_i64_35 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb29, ^bb28
+    %c31_i64_28 = arith.constant 31 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %60 = arith.addi %58, %c31_i64_28 : i64
+    %61 = arith.divui %60, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_30 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_31 : i64
+    %65 = arith.divui %64, %c32_i64_32 : i64
+    %66 = arith.muli %65, %c32_i64_30 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb29, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb31
     cf.br ^bb18
   ^bb29:  // pred: ^bb27
-    %c3_i64_38 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_38 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_39 = arith.constant 3 : i64
-    %c512_i64_40 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_40 : i64
-    %79 = arith.muli %66, %c3_i64_39 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_33 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_35 : i64
+    %74 = arith.muli %61, %c3_i64_34 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_41 : i8), ^bb30
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_36 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb31
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb31
   ^bb31:  // pred: ^bb30
     cf.br ^bb28
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_out_of_bounds.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,206 +96,199 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c100_i256 = arith.constant 100 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c100_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c100_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c10_i256 = arith.constant 10 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb19
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_17 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_12 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i64_18 = arith.constant 0 : i64
-    %45 = arith.cmpi ne, %43, %c0_i64_18 : i64
-    cf.cond_br %45, ^bb23, ^bb18
+    %c0_i64_13 = arith.constant 0 : i64
+    %40 = arith.cmpi ne, %38, %c0_i64_13 : i64
+    cf.cond_br %40, ^bb23, ^bb18
   ^bb18:  // 2 preds: ^bb17, ^bb28
-    %46 = arith.trunci %33 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %47 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %47 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_calldata_copy(%arg0, %46, %47, %43) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()
+    %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %42 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_calldata_copy(%arg0, %41, %42, %38) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()
     cf.br ^bb22
   ^bb19:  // pred: ^bb21
-    %c1024_i64_19 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %49 = arith.addi %48, %c-3_i64 : i64
-    %c3_i64_20 = arith.constant 3 : i64
-    %50 = arith.cmpi ult, %48, %c3_i64_20 : i64
+    %44 = arith.addi %43, %c-3_i64 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %c3_i64_15 = arith.constant 3 : i64
+    %45 = arith.cmpi ult, %43, %c3_i64_15 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb15
   ^bb20:  // pred: ^bb11
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_21 = arith.constant 3 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_16 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_21 : i64
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb21, ^bb1(%c80_i8_22 : i8)
+    %47 = arith.cmpi uge, %46, %c3_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb21, ^bb1(%c80_i8_17 : i8)
   ^bb21:  // pred: ^bb20
-    %53 = arith.subi %51, %c3_i64_21 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c3_i64_16 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb19
   ^bb22:  // pred: ^bb18
-    %c0_i64_23 = arith.constant 0 : i64
+    %c0_i64_18 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_18, %c0_i64_18, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb23:  // pred: ^bb17
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %43, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %c3_i64_24 = arith.constant 3 : i64
-    %57 = arith.muli %56, %c3_i64_24 : i64
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %59 = arith.cmpi ult, %58, %57 : i64
-    scf.if %59 {
+    %50 = arith.addi %38, %c31_i64 : i64
+    %51 = arith.divui %50, %c32_i64 : i64
+    %c3_i64_19 = arith.constant 3 : i64
+    %52 = arith.muli %51, %c3_i64_19 : i64
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    %54 = arith.cmpi ult, %53, %52 : i64
+    scf.if %54 {
     } else {
-      %88 = arith.subi %58, %57 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %53, %52 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb1(%c80_i8_25 : i8), ^bb24
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %54, ^bb1(%c80_i8_20 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c18446744073709551615_i256_26 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_26 : i256
-    %c84_i8_27 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_27 : i8), ^bb25
+    %c18446744073709551615_i256_21 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_21 : i256
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_22 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_29 : i8), ^bb26
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_23 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_23 : i64
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_24 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %63 = arith.addi %61, %43 : i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_31 : i8), ^bb27
+    %58 = arith.addi %56, %38 : i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_26 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64_32 : i64
-    %66 = arith.divui %65, %c32_i64_33 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_34 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_35 : i64
-    %70 = arith.divui %69, %c32_i64_36 : i64
-    %71 = arith.muli %70, %c32_i64_34 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb29, ^bb28
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %60 = arith.addi %58, %c31_i64_27 : i64
+    %61 = arith.divui %60, %c32_i64_28 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_29 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_30 = arith.constant 31 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_30 : i64
+    %65 = arith.divui %64, %c32_i64_31 : i64
+    %66 = arith.muli %65, %c32_i64_29 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb29, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb31
     cf.br ^bb18
   ^bb29:  // pred: ^bb27
-    %c3_i64_37 = arith.constant 3 : i64
+    %c3_i64_32 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_37 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_38 = arith.constant 3 : i64
-    %c512_i64_39 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_39 : i64
-    %79 = arith.muli %66, %c3_i64_38 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_32 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_33 = arith.constant 3 : i64
+    %c512_i64_34 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_34 : i64
+    %74 = arith.muli %61, %c3_i64_33 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_40 : i8), ^bb30
+    %c80_i8_35 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_35 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb31
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb31
   ^bb31:  // pred: ^bb30
     cf.br ^bb28
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatacopy_partial.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,206 +96,199 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c20_i256 = arith.constant 20 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb19
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_17 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_12 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i64_18 = arith.constant 0 : i64
-    %45 = arith.cmpi ne, %43, %c0_i64_18 : i64
-    cf.cond_br %45, ^bb23, ^bb18
+    %c0_i64_13 = arith.constant 0 : i64
+    %40 = arith.cmpi ne, %38, %c0_i64_13 : i64
+    cf.cond_br %40, ^bb23, ^bb18
   ^bb18:  // 2 preds: ^bb17, ^bb28
-    %46 = arith.trunci %33 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %47 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %47 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_calldata_copy(%arg0, %46, %47, %43) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()
+    %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %42 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_calldata_copy(%arg0, %41, %42, %38) : (!llvm.ptr, i64, !llvm.ptr, i64) -> ()
     cf.br ^bb22
   ^bb19:  // pred: ^bb21
-    %c1024_i64_19 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %49 = arith.addi %48, %c-3_i64 : i64
-    %c3_i64_20 = arith.constant 3 : i64
-    %50 = arith.cmpi ult, %48, %c3_i64_20 : i64
+    %44 = arith.addi %43, %c-3_i64 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %c3_i64_15 = arith.constant 3 : i64
+    %45 = arith.cmpi ult, %43, %c3_i64_15 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb15
   ^bb20:  // pred: ^bb11
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_21 = arith.constant 3 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_16 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_21 : i64
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb21, ^bb1(%c80_i8_22 : i8)
+    %47 = arith.cmpi uge, %46, %c3_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb21, ^bb1(%c80_i8_17 : i8)
   ^bb21:  // pred: ^bb20
-    %53 = arith.subi %51, %c3_i64_21 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c3_i64_16 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb19
   ^bb22:  // pred: ^bb18
-    %c0_i64_23 = arith.constant 0 : i64
+    %c0_i64_18 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_18, %c0_i64_18, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb23:  // pred: ^bb17
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %43, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %c3_i64_24 = arith.constant 3 : i64
-    %57 = arith.muli %56, %c3_i64_24 : i64
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %59 = arith.cmpi ult, %58, %57 : i64
-    scf.if %59 {
+    %50 = arith.addi %38, %c31_i64 : i64
+    %51 = arith.divui %50, %c32_i64 : i64
+    %c3_i64_19 = arith.constant 3 : i64
+    %52 = arith.muli %51, %c3_i64_19 : i64
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    %54 = arith.cmpi ult, %53, %52 : i64
+    scf.if %54 {
     } else {
-      %88 = arith.subi %58, %57 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %53, %52 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb1(%c80_i8_25 : i8), ^bb24
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %54, ^bb1(%c80_i8_20 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c18446744073709551615_i256_26 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_26 : i256
-    %c84_i8_27 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_27 : i8), ^bb25
+    %c18446744073709551615_i256_21 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_21 : i256
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_22 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_29 : i8), ^bb26
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_23 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_23 : i64
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_24 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %63 = arith.addi %61, %43 : i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_31 : i8), ^bb27
+    %58 = arith.addi %56, %38 : i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_26 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64_32 : i64
-    %66 = arith.divui %65, %c32_i64_33 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_34 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_35 : i64
-    %70 = arith.divui %69, %c32_i64_36 : i64
-    %71 = arith.muli %70, %c32_i64_34 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb29, ^bb28
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %60 = arith.addi %58, %c31_i64_27 : i64
+    %61 = arith.divui %60, %c32_i64_28 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_29 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_30 = arith.constant 31 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_30 : i64
+    %65 = arith.divui %64, %c32_i64_31 : i64
+    %66 = arith.muli %65, %c32_i64_29 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb29, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb31
     cf.br ^bb18
   ^bb29:  // pred: ^bb27
-    %c3_i64_37 = arith.constant 3 : i64
+    %c3_i64_32 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_37 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_38 = arith.constant 3 : i64
-    %c512_i64_39 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_39 : i64
-    %79 = arith.muli %66, %c3_i64_38 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_32 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_33 = arith.constant 3 : i64
+    %c512_i64_34 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_34 : i64
+    %74 = arith.muli %61, %c3_i64_33 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_40 : i8), ^bb30
+    %c80_i8_35 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_35 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb31
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb31
   ^bb31:  // pred: ^bb30
     cf.br ^bb28
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,64 +95,61 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %16 = call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %17 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
-    %18 = arith.extui %17 : i64 to i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    %15 = call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %16 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %17 = arith.extui %16 : i64 to i256
     %c32_i256 = arith.constant 32 : i256
-    %19 = arith.cmpi ult, %15, %18 : i256
-    %c0_i256_2 = arith.constant 0 : i256
-    %20 = scf.if %19 -> (i256) {
+    %18 = arith.cmpi ult, %14, %17 : i256
+    %c0_i256_1 = arith.constant 0 : i256
+    %19 = scf.if %18 -> (i256) {
       %c1_i256 = arith.constant 1 : i256
-      %31 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-      llvm.store %c0_i256_2, %31 : i256, !llvm.ptr
-      %32 = llvm.getelementptr %16[%15] : (!llvm.ptr, i256) -> !llvm.ptr, i8
-      %33 = arith.subi %18, %15 : i256
-      %34 = arith.minui %33, %c32_i256 : i256
-      "llvm.intr.memcpy"(%31, %32, %34) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i256) -> ()
-      %35 = llvm.load %31 : !llvm.ptr -> i256
-      %36 = llvm.intr.bswap(%35)  : (i256) -> i256
-      scf.yield %36 : i256
+      %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+      llvm.store %c0_i256_1, %29 : i256, !llvm.ptr
+      %30 = llvm.getelementptr %15[%14] : (!llvm.ptr, i256) -> !llvm.ptr, i8
+      %31 = arith.subi %17, %14 : i256
+      %32 = arith.minui %31, %c32_i256 : i256
+      "llvm.intr.memcpy"(%29, %30, %32) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i256) -> ()
+      %33 = llvm.load %29 : !llvm.ptr -> i256
+      %34 = llvm.intr.bswap(%33)  : (i256) -> i256
+      scf.yield %34 : i256
     } else {
-      scf.yield %c0_i256_2 : i256
+      scf.yield %c0_i256_1 : i256
     }
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_3 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %20, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %19, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %25 = arith.addi %24, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %26 = arith.cmpi ult, %24, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %23 = arith.addi %22, %c0_i64_3 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %24 = arith.cmpi ult, %22, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %26, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %24, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_7 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb10, ^bb1(%c80_i8_8 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %29 = arith.subi %27, %c3_i64_7 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_5 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %30 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %30, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %28, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldataload_edge_case.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c100_i256 = arith.constant 100 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c100_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,64 +95,61 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %16 = call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %17 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
-    %18 = arith.extui %17 : i64 to i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    %15 = call @dora_fn_calldata(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %16 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %17 = arith.extui %16 : i64 to i256
     %c32_i256 = arith.constant 32 : i256
-    %19 = arith.cmpi ult, %15, %18 : i256
+    %18 = arith.cmpi ult, %14, %17 : i256
     %c0_i256 = arith.constant 0 : i256
-    %20 = scf.if %19 -> (i256) {
+    %19 = scf.if %18 -> (i256) {
       %c1_i256 = arith.constant 1 : i256
-      %31 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-      llvm.store %c0_i256, %31 : i256, !llvm.ptr
-      %32 = llvm.getelementptr %16[%15] : (!llvm.ptr, i256) -> !llvm.ptr, i8
-      %33 = arith.subi %18, %15 : i256
-      %34 = arith.minui %33, %c32_i256 : i256
-      "llvm.intr.memcpy"(%31, %32, %34) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i256) -> ()
-      %35 = llvm.load %31 : !llvm.ptr -> i256
-      %36 = llvm.intr.bswap(%35)  : (i256) -> i256
-      scf.yield %36 : i256
+      %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+      llvm.store %c0_i256, %29 : i256, !llvm.ptr
+      %30 = llvm.getelementptr %15[%14] : (!llvm.ptr, i256) -> !llvm.ptr, i8
+      %31 = arith.subi %17, %14 : i256
+      %32 = arith.minui %31, %c32_i256 : i256
+      "llvm.intr.memcpy"(%29, %30, %32) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i256) -> ()
+      %33 = llvm.load %29 : !llvm.ptr -> i256
+      %34 = llvm.intr.bswap(%33)  : (i256) -> i256
+      scf.yield %34 : i256
     } else {
       scf.yield %c0_i256 : i256
     }
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_2 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %20, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %19, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_4 = arith.constant 0 : i64
-    %25 = arith.addi %24, %c0_i64_4 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %26 = arith.cmpi ult, %24, %c1_i64_5 : i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %23 = arith.addi %22, %c0_i64_2 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %c1_i64_3 = arith.constant 1 : i64
+    %24 = arith.cmpi ult, %22, %c1_i64_3 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %26, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %24, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %29 = arith.subi %27, %c3_i64_6 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_4 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %30 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %30, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %28, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_calldatasize.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
-    %4 = arith.extui %3 : i64 to i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = call @dora_fn_calldata_size(%arg0) : (!llvm.ptr) -> i64
+    %5 = arith.extui %4 : i64 to i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 25 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb31, ^bb32, ^bb35, ^bb36, ^bb39, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 25 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb31, ^bb32, ^bb35, ^bb36, ^bb39, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1329227995784915872903807060280344575_i256 = arith.constant 1329227995784915872903807060280344575 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1329227995784915872903807060280344575_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,318 +96,307 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %26 = arith.addi %25, %c-1_i64 : i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %27 = arith.cmpi ult, %25, %c1_i64_9 : i64
+    %24 = arith.addi %23, %c-1_i64 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %c1_i64_7 = arith.constant 1 : i64
+    %25 = arith.cmpi ult, %23, %c1_i64_7 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %25, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c2_i64 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb14, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c2_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %30 = arith.subi %28, %c2_i64 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c2_i64 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_11 = arith.constant 1 : i64
-    %32 = arith.subi %31, %c1_i64_11 : i64
-    %33 = llvm.getelementptr %arg2[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    %34 = llvm.load %33 : !llvm.ptr -> i256
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %30 = llvm.getelementptr %29[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %31 = llvm.load %30 : !llvm.ptr -> i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_13 = arith.constant -1 : i64
-    %36 = arith.addi %35, %c-1_i64_13 : i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %37 = arith.cmpi ult, %35, %c1_i64_14 : i64
-    %c91_i8_15 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8_15 : i8), ^bb15
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %32 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_10 = arith.constant -1 : i64
+    %33 = arith.addi %32, %c-1_i64_10 : i64
+    llvm.store %33, %arg3 : i64, !llvm.ptr
+    %c1_i64_11 = arith.constant 1 : i64
+    %34 = arith.cmpi ult, %32, %c1_i64_11 : i64
+    %c91_i8_12 = arith.constant 91 : i8
+    cf.cond_br %34, ^bb1(%c91_i8_12 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_16 = arith.constant 2 : i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_13 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c2_i64_16 : i64
-    %c80_i8_17 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb18, ^bb1(%c80_i8_17 : i8)
+    %36 = arith.cmpi uge, %35, %c2_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb18, ^bb1(%c80_i8_14 : i8)
   ^bb18:  // pred: ^bb17
-    %40 = arith.subi %38, %c2_i64_16 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %37 = arith.subi %35, %c2_i64_13 : i64
+    llvm.store %37, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
     %c32_i256 = arith.constant 32 : i256
-    %41 = llvm.load %arg3 : !llvm.ptr -> i64
-    %42 = llvm.getelementptr %arg2[%41] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_18 = arith.constant 1 : i64
-    %43 = arith.addi %41, %c1_i64_18 : i64
-    llvm.store %43, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %42 : i256, !llvm.ptr
+    %38 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %38 : i256, !llvm.ptr
+    %39 = llvm.getelementptr %38[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %39, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_19 = arith.constant 1024 : i64
-    %44 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %45 = arith.addi %44, %c1_i64_20 : i64
-    %46 = arith.cmpi ult, %c1024_i64_19, %45 : i64
-    %c92_i8_21 = arith.constant 92 : i8
-    cf.cond_br %46, ^bb1(%c92_i8_21 : i8), ^bb19
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %41 = arith.addi %40, %c1_i64_16 : i64
+    llvm.store %41, %arg3 : i64, !llvm.ptr
+    %42 = arith.cmpi ult, %c1024_i64_15, %41 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %42, ^bb1(%c92_i8_17 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %47 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_22 = arith.constant 3 : i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %48 = arith.cmpi uge, %47, %c3_i64_22 : i64
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %48, ^bb22, ^bb1(%c80_i8_23 : i8)
+    %44 = arith.cmpi uge, %43, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb22, ^bb1(%c80_i8_19 : i8)
   ^bb22:  // pred: ^bb21
-    %49 = arith.subi %47, %c3_i64_22 : i64
-    llvm.store %49, %arg1 : i64, !llvm.ptr
+    %45 = arith.subi %43, %c3_i64_18 : i64
+    llvm.store %45, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
-    %c0_i256_24 = arith.constant 0 : i256
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_25 = arith.constant 1 : i64
-    %52 = arith.addi %50, %c1_i64_25 : i64
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_24, %51 : i256, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %46 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %46 : i256, !llvm.ptr
+    %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %47, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb24:  // pred: ^bb26
-    %c1024_i64_26 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %54 = arith.addi %53, %c1_i64_27 : i64
-    %55 = arith.cmpi ult, %c1024_i64_26, %54 : i64
-    %c92_i8_28 = arith.constant 92 : i8
-    cf.cond_br %55, ^bb1(%c92_i8_28 : i8), ^bb23
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %49 = arith.addi %48, %c1_i64_22 : i64
+    llvm.store %49, %arg3 : i64, !llvm.ptr
+    %50 = arith.cmpi ult, %c1024_i64_21, %49 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %50, ^bb1(%c92_i8_23 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_29 = arith.constant 3 : i64
+    %51 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c3_i64_29 : i64
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb26, ^bb1(%c80_i8_30 : i8)
+    %52 = arith.cmpi uge, %51, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %52, ^bb26, ^bb1(%c80_i8_25 : i8)
   ^bb26:  // pred: ^bb25
-    %58 = arith.subi %56, %c3_i64_29 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %53 = arith.subi %51, %c3_i64_24 : i64
+    llvm.store %53, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb28
-    %c0_i256_31 = arith.constant 0 : i256
-    %59 = llvm.load %arg3 : !llvm.ptr -> i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_32 = arith.constant 1 : i64
-    %61 = arith.addi %59, %c1_i64_32 : i64
-    llvm.store %61, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_31, %60 : i256, !llvm.ptr
+    %c0_i256_26 = arith.constant 0 : i256
+    %54 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_26, %54 : i256, !llvm.ptr
+    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %55, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb36
   ^bb28:  // pred: ^bb30
-    %c1024_i64_33 = arith.constant 1024 : i64
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %63 = arith.addi %62, %c1_i64_34 : i64
-    %64 = arith.cmpi ult, %c1024_i64_33, %63 : i64
-    %c92_i8_35 = arith.constant 92 : i8
-    cf.cond_br %64, ^bb1(%c92_i8_35 : i8), ^bb27
+    %c1024_i64_27 = arith.constant 1024 : i64
+    %56 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_28 = arith.constant 1 : i64
+    %57 = arith.addi %56, %c1_i64_28 : i64
+    llvm.store %57, %arg3 : i64, !llvm.ptr
+    %58 = arith.cmpi ult, %c1024_i64_27, %57 : i64
+    %c92_i8_29 = arith.constant 92 : i8
+    cf.cond_br %58, ^bb1(%c92_i8_29 : i8), ^bb27
   ^bb29:  // pred: ^bb23
-    %65 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_36 = arith.constant 3 : i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_30 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %66 = arith.cmpi uge, %65, %c3_i64_36 : i64
-    %c80_i8_37 = arith.constant 80 : i8
-    cf.cond_br %66, ^bb30, ^bb1(%c80_i8_37 : i8)
+    %60 = arith.cmpi uge, %59, %c3_i64_30 : i64
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb30, ^bb1(%c80_i8_31 : i8)
   ^bb30:  // pred: ^bb29
-    %67 = arith.subi %65, %c3_i64_36 : i64
-    llvm.store %67, %arg1 : i64, !llvm.ptr
+    %61 = arith.subi %59, %c3_i64_30 : i64
+    llvm.store %61, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb35
-    %68 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %69 = arith.subi %68, %c1_i64_38 : i64
-    %70 = llvm.getelementptr %arg2[%69] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> i256
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_39 = arith.constant 1 : i64
-    %73 = arith.subi %72, %c1_i64_39 : i64
-    %74 = llvm.getelementptr %arg2[%73] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %73, %arg3 : i64, !llvm.ptr
-    %75 = llvm.load %74 : !llvm.ptr -> i256
-    %76 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_40 = arith.constant 1 : i64
-    %77 = arith.subi %76, %c1_i64_40 : i64
-    %78 = llvm.getelementptr %arg2[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %77, %arg3 : i64, !llvm.ptr
-    %79 = llvm.load %78 : !llvm.ptr -> i256
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %63 = llvm.getelementptr %62[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %64 = llvm.load %63 : !llvm.ptr -> i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
+    %65 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %66 = llvm.getelementptr %65[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %67 = llvm.load %66 : !llvm.ptr -> i256
+    llvm.store %66, %0 : !llvm.ptr, !llvm.ptr
+    %68 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %69 = llvm.getelementptr %68[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %70 = llvm.load %69 : !llvm.ptr -> i256
+    llvm.store %69, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %80 = arith.cmpi sgt, %79, %c18446744073709551615_i256 : i256
+    %71 = arith.cmpi sgt, %70, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %80, ^bb1(%c84_i8 : i8), ^bb32
+    cf.cond_br %71, ^bb1(%c84_i8 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %81 = arith.trunci %79 : i256 to i64
-    %c0_i64_41 = arith.constant 0 : i64
-    %82 = arith.cmpi slt, %81, %c0_i64_41 : i64
-    %c84_i8_42 = arith.constant 84 : i8
-    cf.cond_br %82, ^bb1(%c84_i8_42 : i8), ^bb33
+    %72 = arith.trunci %70 : i256 to i64
+    %c0_i64_32 = arith.constant 0 : i64
+    %73 = arith.cmpi slt, %72, %c0_i64_32 : i64
+    %c84_i8_33 = arith.constant 84 : i8
+    cf.cond_br %73, ^bb1(%c84_i8_33 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %c0_i64_43 = arith.constant 0 : i64
-    %83 = arith.cmpi ne, %81, %c0_i64_43 : i64
-    cf.cond_br %83, ^bb39, ^bb34
+    %c0_i64_34 = arith.constant 0 : i64
+    %74 = arith.cmpi ne, %72, %c0_i64_34 : i64
+    cf.cond_br %74, ^bb39, ^bb34
   ^bb34:  // 2 preds: ^bb33, ^bb44
-    %84 = arith.trunci %71 : i256 to i64
+    %75 = arith.trunci %64 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %85 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %75, %85 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_code_copy(%arg0, %85, %81, %84) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
+    %76 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %67, %76 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_code_copy(%arg0, %76, %72, %75) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
     cf.br ^bb38
   ^bb35:  // pred: ^bb37
-    %c1024_i64_44 = arith.constant 1024 : i64
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_35 = arith.constant 1024 : i64
+    %77 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %87 = arith.addi %86, %c-3_i64 : i64
-    %c3_i64_45 = arith.constant 3 : i64
-    %88 = arith.cmpi ult, %86, %c3_i64_45 : i64
-    %c91_i8_46 = arith.constant 91 : i8
-    cf.cond_br %88, ^bb1(%c91_i8_46 : i8), ^bb31
+    %78 = arith.addi %77, %c-3_i64 : i64
+    llvm.store %78, %arg3 : i64, !llvm.ptr
+    %c3_i64_36 = arith.constant 3 : i64
+    %79 = arith.cmpi ult, %77, %c3_i64_36 : i64
+    %c91_i8_37 = arith.constant 91 : i8
+    cf.cond_br %79, ^bb1(%c91_i8_37 : i8), ^bb31
   ^bb36:  // pred: ^bb27
-    %89 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_47 = arith.constant 3 : i64
+    %80 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_38 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %90 = arith.cmpi uge, %89, %c3_i64_47 : i64
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %90, ^bb37, ^bb1(%c80_i8_48 : i8)
+    %81 = arith.cmpi uge, %80, %c3_i64_38 : i64
+    %c80_i8_39 = arith.constant 80 : i8
+    cf.cond_br %81, ^bb37, ^bb1(%c80_i8_39 : i8)
   ^bb37:  // pred: ^bb36
-    %91 = arith.subi %89, %c3_i64_47 : i64
-    llvm.store %91, %arg1 : i64, !llvm.ptr
+    %82 = arith.subi %80, %c3_i64_38 : i64
+    llvm.store %82, %arg1 : i64, !llvm.ptr
     cf.br ^bb35
   ^bb38:  // pred: ^bb34
-    %c0_i64_49 = arith.constant 0 : i64
+    %c0_i64_40 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %92 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_49, %c0_i64_49, %92, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %83 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_40, %c0_i64_40, %83, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb39:  // pred: ^bb33
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %93 = arith.addi %81, %c31_i64 : i64
-    %94 = arith.divui %93, %c32_i64 : i64
-    %c3_i64_50 = arith.constant 3 : i64
-    %95 = arith.muli %94, %c3_i64_50 : i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %84 = arith.addi %72, %c31_i64 : i64
+    %85 = arith.divui %84, %c32_i64 : i64
+    %c3_i64_41 = arith.constant 3 : i64
+    %86 = arith.muli %85, %c3_i64_41 : i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %126 = arith.subi %96, %95 : i64
-      llvm.store %126, %arg1 : i64, !llvm.ptr
+      %117 = arith.subi %87, %86 : i64
+      llvm.store %117, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_51 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_51 : i8), ^bb40
+    %c80_i8_42 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_42 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %c18446744073709551615_i256_52 = arith.constant 18446744073709551615 : i256
-    %98 = arith.cmpi sgt, %71, %c18446744073709551615_i256_52 : i256
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %98, ^bb1(%c84_i8_53 : i8), ^bb41
+    %c18446744073709551615_i256_43 = arith.constant 18446744073709551615 : i256
+    %89 = arith.cmpi sgt, %64, %c18446744073709551615_i256_43 : i256
+    %c84_i8_44 = arith.constant 84 : i8
+    cf.cond_br %89, ^bb1(%c84_i8_44 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %99 = arith.trunci %71 : i256 to i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %100 = arith.cmpi slt, %99, %c0_i64_54 : i64
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %100, ^bb1(%c84_i8_55 : i8), ^bb42
+    %90 = arith.trunci %64 : i256 to i64
+    %c0_i64_45 = arith.constant 0 : i64
+    %91 = arith.cmpi slt, %90, %c0_i64_45 : i64
+    %c84_i8_46 = arith.constant 84 : i8
+    cf.cond_br %91, ^bb1(%c84_i8_46 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %101 = arith.addi %99, %81 : i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %102 = arith.cmpi slt, %101, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %102, ^bb1(%c84_i8_57 : i8), ^bb43
+    %92 = arith.addi %90, %72 : i64
+    %c0_i64_47 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_47 : i64
+    %c84_i8_48 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_48 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %c31_i64_58 = arith.constant 31 : i64
-    %c32_i64_59 = arith.constant 32 : i64
-    %103 = arith.addi %101, %c31_i64_58 : i64
-    %104 = arith.divui %103, %c32_i64_59 : i64
-    %c32_i64_60 = arith.constant 32 : i64
-    %105 = arith.muli %104, %c32_i64_60 : i64
-    %106 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_61 = arith.constant 31 : i64
-    %c32_i64_62 = arith.constant 32 : i64
-    %107 = arith.addi %106, %c31_i64_61 : i64
-    %108 = arith.divui %107, %c32_i64_62 : i64
-    %109 = arith.muli %108, %c32_i64_60 : i64
-    %110 = arith.cmpi ult, %109, %105 : i64
-    cf.cond_br %110, ^bb45, ^bb44
+    %c31_i64_49 = arith.constant 31 : i64
+    %c32_i64_50 = arith.constant 32 : i64
+    %94 = arith.addi %92, %c31_i64_49 : i64
+    %95 = arith.divui %94, %c32_i64_50 : i64
+    %c32_i64_51 = arith.constant 32 : i64
+    %96 = arith.muli %95, %c32_i64_51 : i64
+    %97 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_52 = arith.constant 31 : i64
+    %c32_i64_53 = arith.constant 32 : i64
+    %98 = arith.addi %97, %c31_i64_52 : i64
+    %99 = arith.divui %98, %c32_i64_53 : i64
+    %100 = arith.muli %99, %c32_i64_51 : i64
+    %101 = arith.cmpi ult, %100, %96 : i64
+    cf.cond_br %101, ^bb45, ^bb44
   ^bb44:  // 2 preds: ^bb43, ^bb47
     cf.br ^bb34
   ^bb45:  // pred: ^bb43
-    %c3_i64_63 = arith.constant 3 : i64
+    %c3_i64_54 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %111 = arith.muli %108, %108 : i64
-    %112 = arith.divui %111, %c512_i64 : i64
-    %113 = arith.muli %108, %c3_i64_63 : i64
-    %114 = arith.addi %112, %113 : i64
-    %c3_i64_64 = arith.constant 3 : i64
-    %c512_i64_65 = arith.constant 512 : i64
-    %115 = arith.muli %104, %104 : i64
-    %116 = arith.divui %115, %c512_i64_65 : i64
-    %117 = arith.muli %104, %c3_i64_64 : i64
-    %118 = arith.addi %116, %117 : i64
-    %119 = arith.subi %118, %114 : i64
-    %120 = llvm.load %arg1 : !llvm.ptr -> i64
-    %121 = arith.cmpi ult, %120, %119 : i64
-    scf.if %121 {
+    %102 = arith.muli %99, %99 : i64
+    %103 = arith.divui %102, %c512_i64 : i64
+    %104 = arith.muli %99, %c3_i64_54 : i64
+    %105 = arith.addi %103, %104 : i64
+    %c3_i64_55 = arith.constant 3 : i64
+    %c512_i64_56 = arith.constant 512 : i64
+    %106 = arith.muli %95, %95 : i64
+    %107 = arith.divui %106, %c512_i64_56 : i64
+    %108 = arith.muli %95, %c3_i64_55 : i64
+    %109 = arith.addi %107, %108 : i64
+    %110 = arith.subi %109, %105 : i64
+    %111 = llvm.load %arg1 : !llvm.ptr -> i64
+    %112 = arith.cmpi ult, %111, %110 : i64
+    scf.if %112 {
     } else {
-      %126 = arith.subi %120, %119 : i64
-      llvm.store %126, %arg1 : i64, !llvm.ptr
+      %117 = arith.subi %111, %110 : i64
+      llvm.store %117, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_66 = arith.constant 80 : i8
-    cf.cond_br %121, ^bb1(%c80_i8_66 : i8), ^bb46
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %112, ^bb1(%c80_i8_57 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %122 = call @dora_fn_extend_memory(%arg0, %105) : (!llvm.ptr, i64) -> !llvm.ptr
-    %123 = llvm.getelementptr %122[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %124 = llvm.load %123 : !llvm.ptr -> i8
+    %113 = call @dora_fn_extend_memory(%arg0, %96) : (!llvm.ptr, i64) -> !llvm.ptr
+    %114 = llvm.getelementptr %113[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %115 = llvm.load %114 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %125 = arith.cmpi ne, %124, %c0_i8 : i8
-    cf.cond_br %125, ^bb1(%124 : i8), ^bb47
+    %116 = arith.cmpi ne, %115, %c0_i8 : i8
+    cf.cond_br %116, ^bb1(%115 : i8), ^bb47
   ^bb47:  // pred: ^bb46
     cf.br ^bb44
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,206 +96,199 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256_1 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c10_i256 = arith.constant 10 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb19
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_17 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_17 : i64
-    %c84_i8_18 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_18 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_12 : i64
+    %c84_i8_13 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_13 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i64_19 = arith.constant 0 : i64
-    %45 = arith.cmpi ne, %43, %c0_i64_19 : i64
-    cf.cond_br %45, ^bb23, ^bb18
+    %c0_i64_14 = arith.constant 0 : i64
+    %40 = arith.cmpi ne, %38, %c0_i64_14 : i64
+    cf.cond_br %40, ^bb23, ^bb18
   ^bb18:  // 2 preds: ^bb17, ^bb28
-    %46 = arith.trunci %33 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %47 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %47 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_code_copy(%arg0, %47, %43, %46) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
+    %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %42 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_code_copy(%arg0, %42, %38, %41) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
     cf.br ^bb22
   ^bb19:  // pred: ^bb21
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %49 = arith.addi %48, %c-3_i64 : i64
-    %c3_i64_21 = arith.constant 3 : i64
-    %50 = arith.cmpi ult, %48, %c3_i64_21 : i64
+    %44 = arith.addi %43, %c-3_i64 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %c3_i64_16 = arith.constant 3 : i64
+    %45 = arith.cmpi ult, %43, %c3_i64_16 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb15
   ^bb20:  // pred: ^bb11
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_22 = arith.constant 3 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_17 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_22 : i64
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb21, ^bb1(%c80_i8_23 : i8)
+    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb21, ^bb1(%c80_i8_18 : i8)
   ^bb21:  // pred: ^bb20
-    %53 = arith.subi %51, %c3_i64_22 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c3_i64_17 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb19
   ^bb22:  // pred: ^bb18
-    %c0_i64_24 = arith.constant 0 : i64
+    %c0_i64_19 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_19, %c0_i64_19, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb23:  // pred: ^bb17
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %43, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %c3_i64_25 = arith.constant 3 : i64
-    %57 = arith.muli %56, %c3_i64_25 : i64
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %59 = arith.cmpi ult, %58, %57 : i64
-    scf.if %59 {
+    %50 = arith.addi %38, %c31_i64 : i64
+    %51 = arith.divui %50, %c32_i64 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %52 = arith.muli %51, %c3_i64_20 : i64
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    %54 = arith.cmpi ult, %53, %52 : i64
+    scf.if %54 {
     } else {
-      %88 = arith.subi %58, %57 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %53, %52 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb1(%c80_i8_26 : i8), ^bb24
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %54, ^bb1(%c80_i8_21 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c18446744073709551615_i256_27 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_27 : i256
-    %c84_i8_28 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_28 : i8), ^bb25
+    %c18446744073709551615_i256_22 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_22 : i256
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_23 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_29 : i64
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_30 : i8), ^bb26
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_24 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_24 : i64
+    %c84_i8_25 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %63 = arith.addi %61, %43 : i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_32 : i8), ^bb27
+    %58 = arith.addi %56, %38 : i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_27 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c31_i64_33 = arith.constant 31 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64_33 : i64
-    %66 = arith.divui %65, %c32_i64_34 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_35 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_36 : i64
-    %70 = arith.divui %69, %c32_i64_37 : i64
-    %71 = arith.muli %70, %c32_i64_35 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb29, ^bb28
+    %c31_i64_28 = arith.constant 31 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %60 = arith.addi %58, %c31_i64_28 : i64
+    %61 = arith.divui %60, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_30 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_31 : i64
+    %65 = arith.divui %64, %c32_i64_32 : i64
+    %66 = arith.muli %65, %c32_i64_30 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb29, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb31
     cf.br ^bb18
   ^bb29:  // pred: ^bb27
-    %c3_i64_38 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_38 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_39 = arith.constant 3 : i64
-    %c512_i64_40 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_40 : i64
-    %79 = arith.muli %66, %c3_i64_39 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_33 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_35 : i64
+    %74 = arith.muli %61, %c3_i64_34 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_41 : i8), ^bb30
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_36 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb31
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb31
   ^bb31:  // pred: ^bb30
     cf.br ^bb28
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_out_of_bounds.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,206 +96,199 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c50_i256 = arith.constant 50 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c50_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c50_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c10_i256 = arith.constant 10 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb19
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_17 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_12 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i64_18 = arith.constant 0 : i64
-    %45 = arith.cmpi ne, %43, %c0_i64_18 : i64
-    cf.cond_br %45, ^bb23, ^bb18
+    %c0_i64_13 = arith.constant 0 : i64
+    %40 = arith.cmpi ne, %38, %c0_i64_13 : i64
+    cf.cond_br %40, ^bb23, ^bb18
   ^bb18:  // 2 preds: ^bb17, ^bb28
-    %46 = arith.trunci %33 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %47 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %47 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_code_copy(%arg0, %47, %43, %46) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
+    %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %42 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_code_copy(%arg0, %42, %38, %41) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
     cf.br ^bb22
   ^bb19:  // pred: ^bb21
-    %c1024_i64_19 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %49 = arith.addi %48, %c-3_i64 : i64
-    %c3_i64_20 = arith.constant 3 : i64
-    %50 = arith.cmpi ult, %48, %c3_i64_20 : i64
+    %44 = arith.addi %43, %c-3_i64 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %c3_i64_15 = arith.constant 3 : i64
+    %45 = arith.cmpi ult, %43, %c3_i64_15 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb15
   ^bb20:  // pred: ^bb11
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_21 = arith.constant 3 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_16 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_21 : i64
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb21, ^bb1(%c80_i8_22 : i8)
+    %47 = arith.cmpi uge, %46, %c3_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb21, ^bb1(%c80_i8_17 : i8)
   ^bb21:  // pred: ^bb20
-    %53 = arith.subi %51, %c3_i64_21 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c3_i64_16 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb19
   ^bb22:  // pred: ^bb18
-    %c0_i64_23 = arith.constant 0 : i64
+    %c0_i64_18 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_18, %c0_i64_18, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb23:  // pred: ^bb17
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %43, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %c3_i64_24 = arith.constant 3 : i64
-    %57 = arith.muli %56, %c3_i64_24 : i64
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %59 = arith.cmpi ult, %58, %57 : i64
-    scf.if %59 {
+    %50 = arith.addi %38, %c31_i64 : i64
+    %51 = arith.divui %50, %c32_i64 : i64
+    %c3_i64_19 = arith.constant 3 : i64
+    %52 = arith.muli %51, %c3_i64_19 : i64
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    %54 = arith.cmpi ult, %53, %52 : i64
+    scf.if %54 {
     } else {
-      %88 = arith.subi %58, %57 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %53, %52 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb1(%c80_i8_25 : i8), ^bb24
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %54, ^bb1(%c80_i8_20 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c18446744073709551615_i256_26 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_26 : i256
-    %c84_i8_27 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_27 : i8), ^bb25
+    %c18446744073709551615_i256_21 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_21 : i256
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_22 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_29 : i8), ^bb26
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_23 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_23 : i64
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_24 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %63 = arith.addi %61, %43 : i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_31 : i8), ^bb27
+    %58 = arith.addi %56, %38 : i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_26 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64_32 : i64
-    %66 = arith.divui %65, %c32_i64_33 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_34 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_35 : i64
-    %70 = arith.divui %69, %c32_i64_36 : i64
-    %71 = arith.muli %70, %c32_i64_34 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb29, ^bb28
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %60 = arith.addi %58, %c31_i64_27 : i64
+    %61 = arith.divui %60, %c32_i64_28 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_29 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_30 = arith.constant 31 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_30 : i64
+    %65 = arith.divui %64, %c32_i64_31 : i64
+    %66 = arith.muli %65, %c32_i64_29 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb29, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb31
     cf.br ^bb18
   ^bb29:  // pred: ^bb27
-    %c3_i64_37 = arith.constant 3 : i64
+    %c3_i64_32 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_37 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_38 = arith.constant 3 : i64
-    %c512_i64_39 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_39 : i64
-    %79 = arith.muli %66, %c3_i64_38 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_32 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_33 = arith.constant 3 : i64
+    %c512_i64_34 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_34 : i64
+    %74 = arith.muli %61, %c3_i64_33 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_40 : i8), ^bb30
+    %c80_i8_35 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_35 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb31
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb31
   ^bb31:  // pred: ^bb30
     cf.br ^bb28
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_codecopy_partial.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb19, ^bb20, ^bb23, ^bb24, ^bb25, ^bb26, ^bb29, ^bb30
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,206 +96,199 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c5_i256 = arith.constant 5 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c5_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c5_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %c5_i256_7 = arith.constant 5 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c5_i256_7, %22 : i256, !llvm.ptr
+    %c5_i256_6 = arith.constant 5 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c5_i256_6, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb20
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb19
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_17 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_17 : i64
-    %c84_i8_18 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_18 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_12 : i64
+    %c84_i8_13 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_13 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %c0_i64_19 = arith.constant 0 : i64
-    %45 = arith.cmpi ne, %43, %c0_i64_19 : i64
-    cf.cond_br %45, ^bb23, ^bb18
+    %c0_i64_14 = arith.constant 0 : i64
+    %40 = arith.cmpi ne, %38, %c0_i64_14 : i64
+    cf.cond_br %40, ^bb23, ^bb18
   ^bb18:  // 2 preds: ^bb17, ^bb28
-    %46 = arith.trunci %33 : i256 to i64
+    %41 = arith.trunci %30 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %47 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %47 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_code_copy(%arg0, %47, %43, %46) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
+    %42 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %42 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_code_copy(%arg0, %42, %38, %41) : (!llvm.ptr, !llvm.ptr, i64, i64) -> ()
     cf.br ^bb22
   ^bb19:  // pred: ^bb21
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %43 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %49 = arith.addi %48, %c-3_i64 : i64
-    %c3_i64_21 = arith.constant 3 : i64
-    %50 = arith.cmpi ult, %48, %c3_i64_21 : i64
+    %44 = arith.addi %43, %c-3_i64 : i64
+    llvm.store %44, %arg3 : i64, !llvm.ptr
+    %c3_i64_16 = arith.constant 3 : i64
+    %45 = arith.cmpi ult, %43, %c3_i64_16 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %50, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb15
   ^bb20:  // pred: ^bb11
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_22 = arith.constant 3 : i64
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_17 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %52 = arith.cmpi uge, %51, %c3_i64_22 : i64
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %52, ^bb21, ^bb1(%c80_i8_23 : i8)
+    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %47, ^bb21, ^bb1(%c80_i8_18 : i8)
   ^bb21:  // pred: ^bb20
-    %53 = arith.subi %51, %c3_i64_22 : i64
-    llvm.store %53, %arg1 : i64, !llvm.ptr
+    %48 = arith.subi %46, %c3_i64_17 : i64
+    llvm.store %48, %arg1 : i64, !llvm.ptr
     cf.br ^bb19
   ^bb22:  // pred: ^bb18
-    %c0_i64_24 = arith.constant 0 : i64
+    %c0_i64_19 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_19, %c0_i64_19, %49, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb23:  // pred: ^bb17
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %55 = arith.addi %43, %c31_i64 : i64
-    %56 = arith.divui %55, %c32_i64 : i64
-    %c3_i64_25 = arith.constant 3 : i64
-    %57 = arith.muli %56, %c3_i64_25 : i64
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %59 = arith.cmpi ult, %58, %57 : i64
-    scf.if %59 {
+    %50 = arith.addi %38, %c31_i64 : i64
+    %51 = arith.divui %50, %c32_i64 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %52 = arith.muli %51, %c3_i64_20 : i64
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    %54 = arith.cmpi ult, %53, %52 : i64
+    scf.if %54 {
     } else {
-      %88 = arith.subi %58, %57 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %53, %52 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb1(%c80_i8_26 : i8), ^bb24
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %54, ^bb1(%c80_i8_21 : i8), ^bb24
   ^bb24:  // pred: ^bb23
-    %c18446744073709551615_i256_27 = arith.constant 18446744073709551615 : i256
-    %60 = arith.cmpi sgt, %33, %c18446744073709551615_i256_27 : i256
-    %c84_i8_28 = arith.constant 84 : i8
-    cf.cond_br %60, ^bb1(%c84_i8_28 : i8), ^bb25
+    %c18446744073709551615_i256_22 = arith.constant 18446744073709551615 : i256
+    %55 = arith.cmpi sgt, %30, %c18446744073709551615_i256_22 : i256
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %55, ^bb1(%c84_i8_23 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %61 = arith.trunci %33 : i256 to i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %62 = arith.cmpi slt, %61, %c0_i64_29 : i64
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %62, ^bb1(%c84_i8_30 : i8), ^bb26
+    %56 = arith.trunci %30 : i256 to i64
+    %c0_i64_24 = arith.constant 0 : i64
+    %57 = arith.cmpi slt, %56, %c0_i64_24 : i64
+    %c84_i8_25 = arith.constant 84 : i8
+    cf.cond_br %57, ^bb1(%c84_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %63 = arith.addi %61, %43 : i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %64 = arith.cmpi slt, %63, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_32 : i8), ^bb27
+    %58 = arith.addi %56, %38 : i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %59 = arith.cmpi slt, %58, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_27 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %c31_i64_33 = arith.constant 31 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %65 = arith.addi %63, %c31_i64_33 : i64
-    %66 = arith.divui %65, %c32_i64_34 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %67 = arith.muli %66, %c32_i64_35 : i64
-    %68 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %69 = arith.addi %68, %c31_i64_36 : i64
-    %70 = arith.divui %69, %c32_i64_37 : i64
-    %71 = arith.muli %70, %c32_i64_35 : i64
-    %72 = arith.cmpi ult, %71, %67 : i64
-    cf.cond_br %72, ^bb29, ^bb28
+    %c31_i64_28 = arith.constant 31 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %60 = arith.addi %58, %c31_i64_28 : i64
+    %61 = arith.divui %60, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %62 = arith.muli %61, %c32_i64_30 : i64
+    %63 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %64 = arith.addi %63, %c31_i64_31 : i64
+    %65 = arith.divui %64, %c32_i64_32 : i64
+    %66 = arith.muli %65, %c32_i64_30 : i64
+    %67 = arith.cmpi ult, %66, %62 : i64
+    cf.cond_br %67, ^bb29, ^bb28
   ^bb28:  // 2 preds: ^bb27, ^bb31
     cf.br ^bb18
   ^bb29:  // pred: ^bb27
-    %c3_i64_38 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %73 = arith.muli %70, %70 : i64
-    %74 = arith.divui %73, %c512_i64 : i64
-    %75 = arith.muli %70, %c3_i64_38 : i64
-    %76 = arith.addi %74, %75 : i64
-    %c3_i64_39 = arith.constant 3 : i64
-    %c512_i64_40 = arith.constant 512 : i64
-    %77 = arith.muli %66, %66 : i64
-    %78 = arith.divui %77, %c512_i64_40 : i64
-    %79 = arith.muli %66, %c3_i64_39 : i64
-    %80 = arith.addi %78, %79 : i64
-    %81 = arith.subi %80, %76 : i64
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    %83 = arith.cmpi ult, %82, %81 : i64
-    scf.if %83 {
+    %68 = arith.muli %65, %65 : i64
+    %69 = arith.divui %68, %c512_i64 : i64
+    %70 = arith.muli %65, %c3_i64_33 : i64
+    %71 = arith.addi %69, %70 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %72 = arith.muli %61, %61 : i64
+    %73 = arith.divui %72, %c512_i64_35 : i64
+    %74 = arith.muli %61, %c3_i64_34 : i64
+    %75 = arith.addi %73, %74 : i64
+    %76 = arith.subi %75, %71 : i64
+    %77 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.cmpi ult, %77, %76 : i64
+    scf.if %78 {
     } else {
-      %88 = arith.subi %82, %81 : i64
-      llvm.store %88, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %77, %76 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %83, ^bb1(%c80_i8_41 : i8), ^bb30
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %78, ^bb1(%c80_i8_36 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %84 = call @dora_fn_extend_memory(%arg0, %67) : (!llvm.ptr, i64) -> !llvm.ptr
-    %85 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %79 = call @dora_fn_extend_memory(%arg0, %62) : (!llvm.ptr, i64) -> !llvm.ptr
+    %80 = llvm.getelementptr %79[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %81 = llvm.load %80 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %87 = arith.cmpi ne, %86, %c0_i8 : i8
-    cf.cond_br %87, ^bb1(%86 : i8), ^bb31
+    %82 = arith.cmpi ne, %81, %c0_i8 : i8
+    cf.cond_br %82, ^bb1(%81 : i8), ^bb31
   ^bb31:  // pred: ^bb30
     cf.br ^bb28
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,254 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c20_i256 = arith.constant 20 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb23
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %43 = arith.cmpi ne, %42, %c0_i8 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %43, ^bb1(%c87_i8 : i8), ^bb16
+    cf.cond_br %38, ^bb1(%c87_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %44 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %39 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb17
+    cf.cond_br %39, ^bb1(%c84_i8 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %45 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_17 : i8), ^bb18
+    %40 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_12 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i64_18 = arith.constant 0 : i64
-    %47 = arith.cmpi ne, %45, %c0_i64_18 : i64
-    cf.cond_br %47, ^bb27, ^bb19
+    %c0_i64_13 = arith.constant 0 : i64
+    %42 = arith.cmpi ne, %40, %c0_i64_13 : i64
+    cf.cond_br %42, ^bb27, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb33
     %c32000_i64 = arith.constant 32000 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %c32000_i64 : i64
-    scf.if %49 {
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %c32000_i64 : i64
+    scf.if %44 {
     } else {
-      %106 = arith.subi %48, %c32000_i64 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %43, %c32000_i64 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_19 : i8), ^bb20
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_14 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %33, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %52 = arith.trunci %37 : i256 to i64
-    %53 = call @dora_fn_create(%arg0, %45, %52, %50, %51) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
-    %c0_i8_20 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8_20 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb21
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %30, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %47 = arith.trunci %33 : i256 to i64
+    %48 = call @dora_fn_create(%arg0, %40, %47, %45, %46) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %c0_i8_15 = arith.constant 0 : i8
+    %51 = arith.cmpi ne, %50, %c0_i8_15 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %57 = llvm.getelementptr %53[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i64
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    %60 = arith.cmpi ult, %59, %58 : i64
-    scf.if %60 {
+    %52 = llvm.getelementptr %48[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %53 = llvm.load %52 : !llvm.ptr -> i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %106 = arith.subi %59, %58 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_21 = arith.constant 80 : i8
-    cf.cond_br %60, ^bb1(%c80_i8_21 : i8), ^bb22
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_16 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %61 = llvm.load %50 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_22 = arith.constant 1 : i64
-    %64 = arith.addi %62, %c1_i64_22 : i64
-    llvm.store %64, %arg3 : i64, !llvm.ptr
-    llvm.store %61, %63 : i256, !llvm.ptr
+    %56 = llvm.load %45 : !llvm.ptr -> i256
+    %57 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %56, %57 : i256, !llvm.ptr
+    %58 = llvm.getelementptr %57[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %58, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_23 = arith.constant 1024 : i64
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %59 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %66 = arith.addi %65, %c-2_i64 : i64
-    %c3_i64_24 = arith.constant 3 : i64
-    %67 = arith.cmpi ult, %65, %c3_i64_24 : i64
+    %60 = arith.addi %59, %c-2_i64 : i64
+    llvm.store %60, %arg3 : i64, !llvm.ptr
+    %c3_i64_18 = arith.constant 3 : i64
+    %61 = arith.cmpi ult, %59, %c3_i64_18 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %61, ^bb1(%c91_i8 : i8), ^bb15
   ^bb24:  // pred: ^bb11
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_19 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %69 = arith.cmpi uge, %68, %c0_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %69, ^bb25, ^bb1(%c80_i8_26 : i8)
+    %63 = arith.cmpi uge, %62, %c0_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %63, ^bb25, ^bb1(%c80_i8_20 : i8)
   ^bb25:  // pred: ^bb24
-    %70 = arith.subi %68, %c0_i64_25 : i64
-    llvm.store %70, %arg1 : i64, !llvm.ptr
+    %64 = arith.subi %62, %c0_i64_19 : i64
+    llvm.store %64, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_27 = arith.constant 0 : i64
+    %c0_i64_21 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %71 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %65 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %65, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb27:  // pred: ^bb18
     %c49152_i64 = arith.constant 49152 : i64
-    %72 = arith.cmpi ugt, %45, %c49152_i64 : i64
+    %66 = arith.cmpi ugt, %40, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %72, ^bb1(%c100_i8 : i8), ^bb28
+    cf.cond_br %66, ^bb1(%c100_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %73 = arith.addi %45, %c31_i64 : i64
-    %74 = arith.divui %73, %c32_i64 : i64
+    %67 = arith.addi %40, %c31_i64 : i64
+    %68 = arith.divui %67, %c32_i64 : i64
     %c2_i64 = arith.constant 2 : i64
-    %75 = arith.muli %74, %c2_i64 : i64
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    %77 = arith.cmpi ult, %76, %75 : i64
-    scf.if %77 {
+    %69 = arith.muli %68, %c2_i64 : i64
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = arith.cmpi ult, %70, %69 : i64
+    scf.if %71 {
     } else {
-      %106 = arith.subi %76, %75 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %70, %69 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %77, ^bb1(%c80_i8_28 : i8), ^bb29
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %71, ^bb1(%c80_i8_22 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c18446744073709551615_i256_29 = arith.constant 18446744073709551615 : i256
-    %78 = arith.cmpi sgt, %37, %c18446744073709551615_i256_29 : i256
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %78, ^bb1(%c84_i8_30 : i8), ^bb30
+    %c18446744073709551615_i256_23 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %33, %c18446744073709551615_i256_23 : i256
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_24 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %79 = arith.trunci %37 : i256 to i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %80 = arith.cmpi slt, %79, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %80, ^bb1(%c84_i8_32 : i8), ^bb31
+    %73 = arith.trunci %33 : i256 to i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_26 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %81 = arith.addi %79, %45 : i64
-    %c0_i64_33 = arith.constant 0 : i64
-    %82 = arith.cmpi slt, %81, %c0_i64_33 : i64
-    %c84_i8_34 = arith.constant 84 : i8
-    cf.cond_br %82, ^bb1(%c84_i8_34 : i8), ^bb32
+    %75 = arith.addi %73, %40 : i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_28 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %83 = arith.addi %81, %c31_i64_35 : i64
-    %84 = arith.divui %83, %c32_i64_36 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %85 = arith.muli %84, %c32_i64_37 : i64
-    %86 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_38 = arith.constant 31 : i64
-    %c32_i64_39 = arith.constant 32 : i64
-    %87 = arith.addi %86, %c31_i64_38 : i64
-    %88 = arith.divui %87, %c32_i64_39 : i64
-    %89 = arith.muli %88, %c32_i64_37 : i64
-    %90 = arith.cmpi ult, %89, %85 : i64
-    cf.cond_br %90, ^bb34, ^bb33
+    %c31_i64_29 = arith.constant 31 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_29 : i64
+    %78 = arith.divui %77, %c32_i64_30 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_31 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_32 = arith.constant 31 : i64
+    %c32_i64_33 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_32 : i64
+    %82 = arith.divui %81, %c32_i64_33 : i64
+    %83 = arith.muli %82, %c32_i64_31 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb19
   ^bb34:  // pred: ^bb32
-    %c3_i64_40 = arith.constant 3 : i64
+    %c3_i64_34 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %91 = arith.muli %88, %88 : i64
-    %92 = arith.divui %91, %c512_i64 : i64
-    %93 = arith.muli %88, %c3_i64_40 : i64
-    %94 = arith.addi %92, %93 : i64
-    %c3_i64_41 = arith.constant 3 : i64
-    %c512_i64_42 = arith.constant 512 : i64
-    %95 = arith.muli %84, %84 : i64
-    %96 = arith.divui %95, %c512_i64_42 : i64
-    %97 = arith.muli %84, %c3_i64_41 : i64
-    %98 = arith.addi %96, %97 : i64
-    %99 = arith.subi %98, %94 : i64
-    %100 = llvm.load %arg1 : !llvm.ptr -> i64
-    %101 = arith.cmpi ult, %100, %99 : i64
-    scf.if %101 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_34 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_35 = arith.constant 3 : i64
+    %c512_i64_36 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_36 : i64
+    %91 = arith.muli %78, %c3_i64_35 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %106 = arith.subi %100, %99 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_43 = arith.constant 80 : i8
-    cf.cond_br %101, ^bb1(%c80_i8_43 : i8), ^bb35
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_37 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %102 = call @dora_fn_extend_memory(%arg0, %85) : (!llvm.ptr, i64) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8_44 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %104, %c0_i8_44 : i8
-    cf.cond_br %105, ^bb1(%104 : i8), ^bb36
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
+    %c0_i8_38 = arith.constant 0 : i8
+    %99 = arith.cmpi ne, %98, %c0_i8_38 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_large_salt.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 24 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb25, ^bb27, ^bb28, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 24 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb25, ^bb27, ^bb28, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c-1_i256 = arith.constant -1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c-1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,298 +96,286 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c64_i256 = arith.constant 64 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c50_i256 = arith.constant 50 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c50_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c50_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb28
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb27
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_19 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %44 = arith.subi %43, %c1_i64_20 : i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %44, %arg3 : i64, !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %48 = arith.subi %47, %c1_i64_21 : i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i256
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %52 = arith.subi %51, %c1_i64_22 : i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i256
-    %55 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
+    %48 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8 : i8
+    %49 = arith.cmpi ne, %48, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %56, ^bb1(%c87_i8 : i8), ^bb20
+    cf.cond_br %49, ^bb1(%c87_i8 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %57 = arith.cmpi sgt, %50, %c18446744073709551615_i256 : i256
+    %50 = arith.cmpi sgt, %44, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8 : i8), ^bb21
+    cf.cond_br %50, ^bb1(%c84_i8 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %58 = arith.trunci %50 : i256 to i64
-    %c0_i64_23 = arith.constant 0 : i64
-    %59 = arith.cmpi slt, %58, %c0_i64_23 : i64
-    %c84_i8_24 = arith.constant 84 : i8
-    cf.cond_br %59, ^bb1(%c84_i8_24 : i8), ^bb22
+    %51 = arith.trunci %44 : i256 to i64
+    %c0_i64_16 = arith.constant 0 : i64
+    %52 = arith.cmpi slt, %51, %c0_i64_16 : i64
+    %c84_i8_17 = arith.constant 84 : i8
+    cf.cond_br %52, ^bb1(%c84_i8_17 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i64_25 = arith.constant 0 : i64
-    %60 = arith.cmpi ne, %58, %c0_i64_25 : i64
-    cf.cond_br %60, ^bb31, ^bb23
+    %c0_i64_18 = arith.constant 0 : i64
+    %53 = arith.cmpi ne, %51, %c0_i64_18 : i64
+    cf.cond_br %53, ^bb31, ^bb23
   ^bb23:  // 2 preds: ^bb22, ^bb37
     %c32000_i64 = arith.constant 32000 : i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %61 = arith.addi %58, %c31_i64 : i64
-    %62 = arith.divui %61, %c32_i64 : i64
+    %54 = arith.addi %51, %c31_i64 : i64
+    %55 = arith.divui %54, %c32_i64 : i64
     %c6_i64 = arith.constant 6 : i64
-    %63 = arith.muli %62, %c6_i64 : i64
-    %64 = arith.addi %c32000_i64, %63 : i64
-    %65 = llvm.load %arg1 : !llvm.ptr -> i64
-    %66 = arith.cmpi ult, %65, %64 : i64
-    scf.if %66 {
+    %56 = arith.muli %55, %c6_i64 : i64
+    %57 = arith.addi %c32000_i64, %56 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %59 = arith.cmpi ult, %58, %57 : i64
+    scf.if %59 {
     } else {
-      %124 = arith.subi %65, %64 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %58, %57 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %66, ^bb1(%c80_i8_26 : i8), ^bb24
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb1(%c80_i8_19 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     %c1_i256 = arith.constant 1 : i256
-    %67 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %42, %67 {alignment = 1 : i64} : i256, !llvm.ptr
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %69 = arith.trunci %46 : i256 to i64
-    %c1_i256_27 = arith.constant 1 : i256
-    %70 = llvm.alloca %c1_i256_27 x i256 : (i256) -> !llvm.ptr
-    llvm.store %54, %70 {alignment = 1 : i64} : i256, !llvm.ptr
-    %71 = call @dora_fn_create2(%arg0, %58, %69, %67, %68, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> !llvm.ptr
-    %72 = llvm.getelementptr %71[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %73 = llvm.load %72 : !llvm.ptr -> i8
-    %c0_i8_28 = arith.constant 0 : i8
-    %74 = arith.cmpi ne, %73, %c0_i8_28 : i8
-    cf.cond_br %74, ^bb1(%73 : i8), ^bb25
+    %60 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %60 {alignment = 1 : i64} : i256, !llvm.ptr
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %62 = arith.trunci %41 : i256 to i64
+    %c1_i256_20 = arith.constant 1 : i256
+    %63 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
+    llvm.store %47, %63 {alignment = 1 : i64} : i256, !llvm.ptr
+    %64 = call @dora_fn_create2(%arg0, %51, %62, %60, %61, %63) : (!llvm.ptr, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> !llvm.ptr
+    %65 = llvm.getelementptr %64[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %66 = llvm.load %65 : !llvm.ptr -> i8
+    %c0_i8_21 = arith.constant 0 : i8
+    %67 = arith.cmpi ne, %66, %c0_i8_21 : i8
+    cf.cond_br %67, ^bb1(%66 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %75 = llvm.getelementptr %71[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %76 = llvm.load %75 : !llvm.ptr -> i64
-    %77 = llvm.load %arg1 : !llvm.ptr -> i64
-    %78 = arith.cmpi ult, %77, %76 : i64
-    scf.if %78 {
+    %68 = llvm.getelementptr %64[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i64
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = arith.cmpi ult, %70, %69 : i64
+    scf.if %71 {
     } else {
-      %124 = arith.subi %77, %76 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %70, %69 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %78, ^bb1(%c80_i8_29 : i8), ^bb26
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %71, ^bb1(%c80_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %79 = llvm.load %67 : !llvm.ptr -> i256
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %81 = llvm.getelementptr %arg2[%80] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_30 = arith.constant 1 : i64
-    %82 = arith.addi %80, %c1_i64_30 : i64
-    llvm.store %82, %arg3 : i64, !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
+    %72 = llvm.load %60 : !llvm.ptr -> i256
+    %73 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %72, %73 : i256, !llvm.ptr
+    %74 = llvm.getelementptr %73[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %74, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb27:  // pred: ^bb29
-    %c1024_i64_31 = arith.constant 1024 : i64
-    %83 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %75 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %84 = arith.addi %83, %c-3_i64 : i64
+    %76 = arith.addi %75, %c-3_i64 : i64
+    llvm.store %76, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %85 = arith.cmpi ult, %83, %c4_i64 : i64
+    %77 = arith.cmpi ult, %75, %c4_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %85, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %77, ^bb1(%c91_i8 : i8), ^bb19
   ^bb28:  // pred: ^bb15
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_32 = arith.constant 0 : i64
+    %78 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_24 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %87 = arith.cmpi uge, %86, %c0_i64_32 : i64
-    %c80_i8_33 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb29, ^bb1(%c80_i8_33 : i8)
+    %79 = arith.cmpi uge, %78, %c0_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %79, ^bb29, ^bb1(%c80_i8_25 : i8)
   ^bb29:  // pred: ^bb28
-    %88 = arith.subi %86, %c0_i64_32 : i64
-    llvm.store %88, %arg1 : i64, !llvm.ptr
+    %80 = arith.subi %78, %c0_i64_24 : i64
+    llvm.store %80, %arg1 : i64, !llvm.ptr
     cf.br ^bb27
   ^bb30:  // pred: ^bb26
-    %c0_i64_34 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %89 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_34, %c0_i64_34, %89, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %81 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %81, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb31:  // pred: ^bb22
     %c49152_i64 = arith.constant 49152 : i64
-    %90 = arith.cmpi ugt, %58, %c49152_i64 : i64
+    %82 = arith.cmpi ugt, %51, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %90, ^bb1(%c100_i8 : i8), ^bb32
+    cf.cond_br %82, ^bb1(%c100_i8 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %91 = arith.addi %58, %c31_i64_35 : i64
-    %92 = arith.divui %91, %c32_i64_36 : i64
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %83 = arith.addi %51, %c31_i64_27 : i64
+    %84 = arith.divui %83, %c32_i64_28 : i64
     %c2_i64 = arith.constant 2 : i64
-    %93 = arith.muli %92, %c2_i64 : i64
-    %94 = llvm.load %arg1 : !llvm.ptr -> i64
-    %95 = arith.cmpi ult, %94, %93 : i64
-    scf.if %95 {
+    %85 = arith.muli %84, %c2_i64 : i64
+    %86 = llvm.load %arg1 : !llvm.ptr -> i64
+    %87 = arith.cmpi ult, %86, %85 : i64
+    scf.if %87 {
     } else {
-      %124 = arith.subi %94, %93 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %86, %85 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_37 = arith.constant 80 : i8
-    cf.cond_br %95, ^bb1(%c80_i8_37 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %87, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %c18446744073709551615_i256_38 = arith.constant 18446744073709551615 : i256
-    %96 = arith.cmpi sgt, %46, %c18446744073709551615_i256_38 : i256
-    %c84_i8_39 = arith.constant 84 : i8
-    cf.cond_br %96, ^bb1(%c84_i8_39 : i8), ^bb34
+    %c18446744073709551615_i256_30 = arith.constant 18446744073709551615 : i256
+    %88 = arith.cmpi sgt, %41, %c18446744073709551615_i256_30 : i256
+    %c84_i8_31 = arith.constant 84 : i8
+    cf.cond_br %88, ^bb1(%c84_i8_31 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %97 = arith.trunci %46 : i256 to i64
-    %c0_i64_40 = arith.constant 0 : i64
-    %98 = arith.cmpi slt, %97, %c0_i64_40 : i64
-    %c84_i8_41 = arith.constant 84 : i8
-    cf.cond_br %98, ^bb1(%c84_i8_41 : i8), ^bb35
+    %89 = arith.trunci %41 : i256 to i64
+    %c0_i64_32 = arith.constant 0 : i64
+    %90 = arith.cmpi slt, %89, %c0_i64_32 : i64
+    %c84_i8_33 = arith.constant 84 : i8
+    cf.cond_br %90, ^bb1(%c84_i8_33 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %99 = arith.addi %97, %58 : i64
-    %c0_i64_42 = arith.constant 0 : i64
-    %100 = arith.cmpi slt, %99, %c0_i64_42 : i64
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %100, ^bb1(%c84_i8_43 : i8), ^bb36
+    %91 = arith.addi %89, %51 : i64
+    %c0_i64_34 = arith.constant 0 : i64
+    %92 = arith.cmpi slt, %91, %c0_i64_34 : i64
+    %c84_i8_35 = arith.constant 84 : i8
+    cf.cond_br %92, ^bb1(%c84_i8_35 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %c31_i64_44 = arith.constant 31 : i64
-    %c32_i64_45 = arith.constant 32 : i64
-    %101 = arith.addi %99, %c31_i64_44 : i64
-    %102 = arith.divui %101, %c32_i64_45 : i64
-    %c32_i64_46 = arith.constant 32 : i64
-    %103 = arith.muli %102, %c32_i64_46 : i64
-    %104 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_47 = arith.constant 31 : i64
-    %c32_i64_48 = arith.constant 32 : i64
-    %105 = arith.addi %104, %c31_i64_47 : i64
-    %106 = arith.divui %105, %c32_i64_48 : i64
-    %107 = arith.muli %106, %c32_i64_46 : i64
-    %108 = arith.cmpi ult, %107, %103 : i64
-    cf.cond_br %108, ^bb38, ^bb37
+    %c31_i64_36 = arith.constant 31 : i64
+    %c32_i64_37 = arith.constant 32 : i64
+    %93 = arith.addi %91, %c31_i64_36 : i64
+    %94 = arith.divui %93, %c32_i64_37 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %95 = arith.muli %94, %c32_i64_38 : i64
+    %96 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_39 = arith.constant 31 : i64
+    %c32_i64_40 = arith.constant 32 : i64
+    %97 = arith.addi %96, %c31_i64_39 : i64
+    %98 = arith.divui %97, %c32_i64_40 : i64
+    %99 = arith.muli %98, %c32_i64_38 : i64
+    %100 = arith.cmpi ult, %99, %95 : i64
+    cf.cond_br %100, ^bb38, ^bb37
   ^bb37:  // 2 preds: ^bb36, ^bb40
     cf.br ^bb23
   ^bb38:  // pred: ^bb36
-    %c3_i64_49 = arith.constant 3 : i64
+    %c3_i64_41 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %109 = arith.muli %106, %106 : i64
-    %110 = arith.divui %109, %c512_i64 : i64
-    %111 = arith.muli %106, %c3_i64_49 : i64
-    %112 = arith.addi %110, %111 : i64
-    %c3_i64_50 = arith.constant 3 : i64
-    %c512_i64_51 = arith.constant 512 : i64
-    %113 = arith.muli %102, %102 : i64
-    %114 = arith.divui %113, %c512_i64_51 : i64
-    %115 = arith.muli %102, %c3_i64_50 : i64
-    %116 = arith.addi %114, %115 : i64
-    %117 = arith.subi %116, %112 : i64
-    %118 = llvm.load %arg1 : !llvm.ptr -> i64
-    %119 = arith.cmpi ult, %118, %117 : i64
-    scf.if %119 {
+    %101 = arith.muli %98, %98 : i64
+    %102 = arith.divui %101, %c512_i64 : i64
+    %103 = arith.muli %98, %c3_i64_41 : i64
+    %104 = arith.addi %102, %103 : i64
+    %c3_i64_42 = arith.constant 3 : i64
+    %c512_i64_43 = arith.constant 512 : i64
+    %105 = arith.muli %94, %94 : i64
+    %106 = arith.divui %105, %c512_i64_43 : i64
+    %107 = arith.muli %94, %c3_i64_42 : i64
+    %108 = arith.addi %106, %107 : i64
+    %109 = arith.subi %108, %104 : i64
+    %110 = llvm.load %arg1 : !llvm.ptr -> i64
+    %111 = arith.cmpi ult, %110, %109 : i64
+    scf.if %111 {
     } else {
-      %124 = arith.subi %118, %117 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %110, %109 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_52 = arith.constant 80 : i8
-    cf.cond_br %119, ^bb1(%c80_i8_52 : i8), ^bb39
+    %c80_i8_44 = arith.constant 80 : i8
+    cf.cond_br %111, ^bb1(%c80_i8_44 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %120 = call @dora_fn_extend_memory(%arg0, %103) : (!llvm.ptr, i64) -> !llvm.ptr
-    %121 = llvm.getelementptr %120[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %122 = llvm.load %121 : !llvm.ptr -> i8
-    %c0_i8_53 = arith.constant 0 : i8
-    %123 = arith.cmpi ne, %122, %c0_i8_53 : i8
-    cf.cond_br %123, ^bb1(%122 : i8), ^bb40
+    %112 = call @dora_fn_extend_memory(%arg0, %95) : (!llvm.ptr, i64) -> !llvm.ptr
+    %113 = llvm.getelementptr %112[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %114 = llvm.load %113 : !llvm.ptr -> i8
+    %c0_i8_45 = arith.constant 0 : i8
+    %115 = arith.cmpi ne, %114, %c0_i8_45 : i8
+    cf.cond_br %115, ^bb1(%114 : i8), ^bb40
   ^bb40:  // pred: ^bb39
     cf.br ^bb37
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create2_with_salt.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 24 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb25, ^bb27, ^bb28, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 24 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb25, ^bb27, ^bb28, ^bb31, ^bb32, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c4660_i256 = arith.constant 4660 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c4660_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,298 +96,286 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c20_i256 = arith.constant 20 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c10_i256 = arith.constant 10 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb28
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb27
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_19 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %44 = arith.subi %43, %c1_i64_20 : i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %44, %arg3 : i64, !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %48 = arith.subi %47, %c1_i64_21 : i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i256
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %52 = arith.subi %51, %c1_i64_22 : i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i256
-    %55 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
+    %48 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8 : i8
+    %49 = arith.cmpi ne, %48, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %56, ^bb1(%c87_i8 : i8), ^bb20
+    cf.cond_br %49, ^bb1(%c87_i8 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %57 = arith.cmpi sgt, %50, %c18446744073709551615_i256 : i256
+    %50 = arith.cmpi sgt, %44, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8 : i8), ^bb21
+    cf.cond_br %50, ^bb1(%c84_i8 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %58 = arith.trunci %50 : i256 to i64
-    %c0_i64_23 = arith.constant 0 : i64
-    %59 = arith.cmpi slt, %58, %c0_i64_23 : i64
-    %c84_i8_24 = arith.constant 84 : i8
-    cf.cond_br %59, ^bb1(%c84_i8_24 : i8), ^bb22
+    %51 = arith.trunci %44 : i256 to i64
+    %c0_i64_16 = arith.constant 0 : i64
+    %52 = arith.cmpi slt, %51, %c0_i64_16 : i64
+    %c84_i8_17 = arith.constant 84 : i8
+    cf.cond_br %52, ^bb1(%c84_i8_17 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i64_25 = arith.constant 0 : i64
-    %60 = arith.cmpi ne, %58, %c0_i64_25 : i64
-    cf.cond_br %60, ^bb31, ^bb23
+    %c0_i64_18 = arith.constant 0 : i64
+    %53 = arith.cmpi ne, %51, %c0_i64_18 : i64
+    cf.cond_br %53, ^bb31, ^bb23
   ^bb23:  // 2 preds: ^bb22, ^bb37
     %c32000_i64 = arith.constant 32000 : i64
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %61 = arith.addi %58, %c31_i64 : i64
-    %62 = arith.divui %61, %c32_i64 : i64
+    %54 = arith.addi %51, %c31_i64 : i64
+    %55 = arith.divui %54, %c32_i64 : i64
     %c6_i64 = arith.constant 6 : i64
-    %63 = arith.muli %62, %c6_i64 : i64
-    %64 = arith.addi %c32000_i64, %63 : i64
-    %65 = llvm.load %arg1 : !llvm.ptr -> i64
-    %66 = arith.cmpi ult, %65, %64 : i64
-    scf.if %66 {
+    %56 = arith.muli %55, %c6_i64 : i64
+    %57 = arith.addi %c32000_i64, %56 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %59 = arith.cmpi ult, %58, %57 : i64
+    scf.if %59 {
     } else {
-      %124 = arith.subi %65, %64 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %58, %57 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %66, ^bb1(%c80_i8_26 : i8), ^bb24
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb1(%c80_i8_19 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     %c1_i256 = arith.constant 1 : i256
-    %67 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %42, %67 {alignment = 1 : i64} : i256, !llvm.ptr
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %69 = arith.trunci %46 : i256 to i64
-    %c1_i256_27 = arith.constant 1 : i256
-    %70 = llvm.alloca %c1_i256_27 x i256 : (i256) -> !llvm.ptr
-    llvm.store %54, %70 {alignment = 1 : i64} : i256, !llvm.ptr
-    %71 = call @dora_fn_create2(%arg0, %58, %69, %67, %68, %70) : (!llvm.ptr, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> !llvm.ptr
-    %72 = llvm.getelementptr %71[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %73 = llvm.load %72 : !llvm.ptr -> i8
-    %c0_i8_28 = arith.constant 0 : i8
-    %74 = arith.cmpi ne, %73, %c0_i8_28 : i8
-    cf.cond_br %74, ^bb1(%73 : i8), ^bb25
+    %60 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %60 {alignment = 1 : i64} : i256, !llvm.ptr
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %62 = arith.trunci %41 : i256 to i64
+    %c1_i256_20 = arith.constant 1 : i256
+    %63 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
+    llvm.store %47, %63 {alignment = 1 : i64} : i256, !llvm.ptr
+    %64 = call @dora_fn_create2(%arg0, %51, %62, %60, %61, %63) : (!llvm.ptr, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> !llvm.ptr
+    %65 = llvm.getelementptr %64[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %66 = llvm.load %65 : !llvm.ptr -> i8
+    %c0_i8_21 = arith.constant 0 : i8
+    %67 = arith.cmpi ne, %66, %c0_i8_21 : i8
+    cf.cond_br %67, ^bb1(%66 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %75 = llvm.getelementptr %71[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %76 = llvm.load %75 : !llvm.ptr -> i64
-    %77 = llvm.load %arg1 : !llvm.ptr -> i64
-    %78 = arith.cmpi ult, %77, %76 : i64
-    scf.if %78 {
+    %68 = llvm.getelementptr %64[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %69 = llvm.load %68 : !llvm.ptr -> i64
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = arith.cmpi ult, %70, %69 : i64
+    scf.if %71 {
     } else {
-      %124 = arith.subi %77, %76 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %70, %69 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %78, ^bb1(%c80_i8_29 : i8), ^bb26
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %71, ^bb1(%c80_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %79 = llvm.load %67 : !llvm.ptr -> i256
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %81 = llvm.getelementptr %arg2[%80] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_30 = arith.constant 1 : i64
-    %82 = arith.addi %80, %c1_i64_30 : i64
-    llvm.store %82, %arg3 : i64, !llvm.ptr
-    llvm.store %79, %81 : i256, !llvm.ptr
+    %72 = llvm.load %60 : !llvm.ptr -> i256
+    %73 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %72, %73 : i256, !llvm.ptr
+    %74 = llvm.getelementptr %73[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %74, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb27:  // pred: ^bb29
-    %c1024_i64_31 = arith.constant 1024 : i64
-    %83 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %75 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %84 = arith.addi %83, %c-3_i64 : i64
+    %76 = arith.addi %75, %c-3_i64 : i64
+    llvm.store %76, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %85 = arith.cmpi ult, %83, %c4_i64 : i64
+    %77 = arith.cmpi ult, %75, %c4_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %85, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %77, ^bb1(%c91_i8 : i8), ^bb19
   ^bb28:  // pred: ^bb15
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_32 = arith.constant 0 : i64
+    %78 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_24 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %87 = arith.cmpi uge, %86, %c0_i64_32 : i64
-    %c80_i8_33 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb29, ^bb1(%c80_i8_33 : i8)
+    %79 = arith.cmpi uge, %78, %c0_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %79, ^bb29, ^bb1(%c80_i8_25 : i8)
   ^bb29:  // pred: ^bb28
-    %88 = arith.subi %86, %c0_i64_32 : i64
-    llvm.store %88, %arg1 : i64, !llvm.ptr
+    %80 = arith.subi %78, %c0_i64_24 : i64
+    llvm.store %80, %arg1 : i64, !llvm.ptr
     cf.br ^bb27
   ^bb30:  // pred: ^bb26
-    %c0_i64_34 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %89 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_34, %c0_i64_34, %89, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %81 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %81, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb31:  // pred: ^bb22
     %c49152_i64 = arith.constant 49152 : i64
-    %90 = arith.cmpi ugt, %58, %c49152_i64 : i64
+    %82 = arith.cmpi ugt, %51, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %90, ^bb1(%c100_i8 : i8), ^bb32
+    cf.cond_br %82, ^bb1(%c100_i8 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %91 = arith.addi %58, %c31_i64_35 : i64
-    %92 = arith.divui %91, %c32_i64_36 : i64
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %83 = arith.addi %51, %c31_i64_27 : i64
+    %84 = arith.divui %83, %c32_i64_28 : i64
     %c2_i64 = arith.constant 2 : i64
-    %93 = arith.muli %92, %c2_i64 : i64
-    %94 = llvm.load %arg1 : !llvm.ptr -> i64
-    %95 = arith.cmpi ult, %94, %93 : i64
-    scf.if %95 {
+    %85 = arith.muli %84, %c2_i64 : i64
+    %86 = llvm.load %arg1 : !llvm.ptr -> i64
+    %87 = arith.cmpi ult, %86, %85 : i64
+    scf.if %87 {
     } else {
-      %124 = arith.subi %94, %93 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %86, %85 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_37 = arith.constant 80 : i8
-    cf.cond_br %95, ^bb1(%c80_i8_37 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %87, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %c18446744073709551615_i256_38 = arith.constant 18446744073709551615 : i256
-    %96 = arith.cmpi sgt, %46, %c18446744073709551615_i256_38 : i256
-    %c84_i8_39 = arith.constant 84 : i8
-    cf.cond_br %96, ^bb1(%c84_i8_39 : i8), ^bb34
+    %c18446744073709551615_i256_30 = arith.constant 18446744073709551615 : i256
+    %88 = arith.cmpi sgt, %41, %c18446744073709551615_i256_30 : i256
+    %c84_i8_31 = arith.constant 84 : i8
+    cf.cond_br %88, ^bb1(%c84_i8_31 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %97 = arith.trunci %46 : i256 to i64
-    %c0_i64_40 = arith.constant 0 : i64
-    %98 = arith.cmpi slt, %97, %c0_i64_40 : i64
-    %c84_i8_41 = arith.constant 84 : i8
-    cf.cond_br %98, ^bb1(%c84_i8_41 : i8), ^bb35
+    %89 = arith.trunci %41 : i256 to i64
+    %c0_i64_32 = arith.constant 0 : i64
+    %90 = arith.cmpi slt, %89, %c0_i64_32 : i64
+    %c84_i8_33 = arith.constant 84 : i8
+    cf.cond_br %90, ^bb1(%c84_i8_33 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %99 = arith.addi %97, %58 : i64
-    %c0_i64_42 = arith.constant 0 : i64
-    %100 = arith.cmpi slt, %99, %c0_i64_42 : i64
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %100, ^bb1(%c84_i8_43 : i8), ^bb36
+    %91 = arith.addi %89, %51 : i64
+    %c0_i64_34 = arith.constant 0 : i64
+    %92 = arith.cmpi slt, %91, %c0_i64_34 : i64
+    %c84_i8_35 = arith.constant 84 : i8
+    cf.cond_br %92, ^bb1(%c84_i8_35 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %c31_i64_44 = arith.constant 31 : i64
-    %c32_i64_45 = arith.constant 32 : i64
-    %101 = arith.addi %99, %c31_i64_44 : i64
-    %102 = arith.divui %101, %c32_i64_45 : i64
-    %c32_i64_46 = arith.constant 32 : i64
-    %103 = arith.muli %102, %c32_i64_46 : i64
-    %104 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_47 = arith.constant 31 : i64
-    %c32_i64_48 = arith.constant 32 : i64
-    %105 = arith.addi %104, %c31_i64_47 : i64
-    %106 = arith.divui %105, %c32_i64_48 : i64
-    %107 = arith.muli %106, %c32_i64_46 : i64
-    %108 = arith.cmpi ult, %107, %103 : i64
-    cf.cond_br %108, ^bb38, ^bb37
+    %c31_i64_36 = arith.constant 31 : i64
+    %c32_i64_37 = arith.constant 32 : i64
+    %93 = arith.addi %91, %c31_i64_36 : i64
+    %94 = arith.divui %93, %c32_i64_37 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %95 = arith.muli %94, %c32_i64_38 : i64
+    %96 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_39 = arith.constant 31 : i64
+    %c32_i64_40 = arith.constant 32 : i64
+    %97 = arith.addi %96, %c31_i64_39 : i64
+    %98 = arith.divui %97, %c32_i64_40 : i64
+    %99 = arith.muli %98, %c32_i64_38 : i64
+    %100 = arith.cmpi ult, %99, %95 : i64
+    cf.cond_br %100, ^bb38, ^bb37
   ^bb37:  // 2 preds: ^bb36, ^bb40
     cf.br ^bb23
   ^bb38:  // pred: ^bb36
-    %c3_i64_49 = arith.constant 3 : i64
+    %c3_i64_41 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %109 = arith.muli %106, %106 : i64
-    %110 = arith.divui %109, %c512_i64 : i64
-    %111 = arith.muli %106, %c3_i64_49 : i64
-    %112 = arith.addi %110, %111 : i64
-    %c3_i64_50 = arith.constant 3 : i64
-    %c512_i64_51 = arith.constant 512 : i64
-    %113 = arith.muli %102, %102 : i64
-    %114 = arith.divui %113, %c512_i64_51 : i64
-    %115 = arith.muli %102, %c3_i64_50 : i64
-    %116 = arith.addi %114, %115 : i64
-    %117 = arith.subi %116, %112 : i64
-    %118 = llvm.load %arg1 : !llvm.ptr -> i64
-    %119 = arith.cmpi ult, %118, %117 : i64
-    scf.if %119 {
+    %101 = arith.muli %98, %98 : i64
+    %102 = arith.divui %101, %c512_i64 : i64
+    %103 = arith.muli %98, %c3_i64_41 : i64
+    %104 = arith.addi %102, %103 : i64
+    %c3_i64_42 = arith.constant 3 : i64
+    %c512_i64_43 = arith.constant 512 : i64
+    %105 = arith.muli %94, %94 : i64
+    %106 = arith.divui %105, %c512_i64_43 : i64
+    %107 = arith.muli %94, %c3_i64_42 : i64
+    %108 = arith.addi %106, %107 : i64
+    %109 = arith.subi %108, %104 : i64
+    %110 = llvm.load %arg1 : !llvm.ptr -> i64
+    %111 = arith.cmpi ult, %110, %109 : i64
+    scf.if %111 {
     } else {
-      %124 = arith.subi %118, %117 : i64
-      llvm.store %124, %arg1 : i64, !llvm.ptr
+      %116 = arith.subi %110, %109 : i64
+      llvm.store %116, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_52 = arith.constant 80 : i8
-    cf.cond_br %119, ^bb1(%c80_i8_52 : i8), ^bb39
+    %c80_i8_44 = arith.constant 80 : i8
+    cf.cond_br %111, ^bb1(%c80_i8_44 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %120 = call @dora_fn_extend_memory(%arg0, %103) : (!llvm.ptr, i64) -> !llvm.ptr
-    %121 = llvm.getelementptr %120[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %122 = llvm.load %121 : !llvm.ptr -> i8
-    %c0_i8_53 = arith.constant 0 : i8
-    %123 = arith.cmpi ne, %122, %c0_i8_53 : i8
-    cf.cond_br %123, ^bb1(%122 : i8), ^bb40
+    %112 = call @dora_fn_extend_memory(%arg0, %95) : (!llvm.ptr, i64) -> !llvm.ptr
+    %113 = llvm.getelementptr %112[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %114 = llvm.load %113 : !llvm.ptr -> i8
+    %c0_i8_45 = arith.constant 0 : i8
+    %115 = arith.cmpi ne, %114, %c0_i8_45 : i8
+    cf.cond_br %115, ^bb1(%114 : i8), ^bb40
   ^bb40:  // pred: ^bb39
     cf.br ^bb37
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,254 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256_1 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %c0_i256_8 = arith.constant 0 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_9 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_8, %22 : i256, !llvm.ptr
+    %c0_i256_7 = arith.constant 0 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_7, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_11 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_11 : i64
-    %26 = arith.cmpi ult, %c1024_i64_10, %25 : i64
-    %c92_i8_12 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_12 : i8), ^bb11
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_9 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_9 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_8, %23 : i64
+    %c92_i8_10 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_10 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_13 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_11 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_14 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_11 : i64
+    %c80_i8_12 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_12 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_13 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_11 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb23
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_15 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_16 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_17 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %43 = arith.cmpi ne, %42, %c0_i8 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %43, ^bb1(%c87_i8 : i8), ^bb16
+    cf.cond_br %38, ^bb1(%c87_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %44 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %39 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb17
+    cf.cond_br %39, ^bb1(%c84_i8 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %45 = arith.trunci %41 : i256 to i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_18 : i64
-    %c84_i8_19 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_19 : i8), ^bb18
+    %40 = arith.trunci %36 : i256 to i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_14 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i64_20 = arith.constant 0 : i64
-    %47 = arith.cmpi ne, %45, %c0_i64_20 : i64
-    cf.cond_br %47, ^bb27, ^bb19
+    %c0_i64_15 = arith.constant 0 : i64
+    %42 = arith.cmpi ne, %40, %c0_i64_15 : i64
+    cf.cond_br %42, ^bb27, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb33
     %c32000_i64 = arith.constant 32000 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %c32000_i64 : i64
-    scf.if %49 {
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %c32000_i64 : i64
+    scf.if %44 {
     } else {
-      %106 = arith.subi %48, %c32000_i64 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %43, %c32000_i64 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_21 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_21 : i8), ^bb20
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_16 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %33, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %52 = arith.trunci %37 : i256 to i64
-    %53 = call @dora_fn_create(%arg0, %45, %52, %50, %51) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
-    %c0_i8_22 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8_22 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb21
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %30, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %47 = arith.trunci %33 : i256 to i64
+    %48 = call @dora_fn_create(%arg0, %40, %47, %45, %46) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %c0_i8_17 = arith.constant 0 : i8
+    %51 = arith.cmpi ne, %50, %c0_i8_17 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %57 = llvm.getelementptr %53[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i64
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    %60 = arith.cmpi ult, %59, %58 : i64
-    scf.if %60 {
+    %52 = llvm.getelementptr %48[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %53 = llvm.load %52 : !llvm.ptr -> i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %106 = arith.subi %59, %58 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %60, ^bb1(%c80_i8_23 : i8), ^bb22
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_18 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %61 = llvm.load %50 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_24 = arith.constant 1 : i64
-    %64 = arith.addi %62, %c1_i64_24 : i64
-    llvm.store %64, %arg3 : i64, !llvm.ptr
-    llvm.store %61, %63 : i256, !llvm.ptr
+    %56 = llvm.load %45 : !llvm.ptr -> i256
+    %57 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %56, %57 : i256, !llvm.ptr
+    %58 = llvm.getelementptr %57[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %58, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_25 = arith.constant 1024 : i64
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_19 = arith.constant 1024 : i64
+    %59 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %66 = arith.addi %65, %c-2_i64 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %67 = arith.cmpi ult, %65, %c3_i64_26 : i64
+    %60 = arith.addi %59, %c-2_i64 : i64
+    llvm.store %60, %arg3 : i64, !llvm.ptr
+    %c3_i64_20 = arith.constant 3 : i64
+    %61 = arith.cmpi ult, %59, %c3_i64_20 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %61, ^bb1(%c91_i8 : i8), ^bb15
   ^bb24:  // pred: ^bb11
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_27 = arith.constant 0 : i64
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_21 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %69 = arith.cmpi uge, %68, %c0_i64_27 : i64
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %69, ^bb25, ^bb1(%c80_i8_28 : i8)
+    %63 = arith.cmpi uge, %62, %c0_i64_21 : i64
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %63, ^bb25, ^bb1(%c80_i8_22 : i8)
   ^bb25:  // pred: ^bb24
-    %70 = arith.subi %68, %c0_i64_27 : i64
-    llvm.store %70, %arg1 : i64, !llvm.ptr
+    %64 = arith.subi %62, %c0_i64_21 : i64
+    llvm.store %64, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_29 = arith.constant 0 : i64
+    %c0_i64_23 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %71 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_29, %c0_i64_29, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %65 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %65, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb27:  // pred: ^bb18
     %c49152_i64 = arith.constant 49152 : i64
-    %72 = arith.cmpi ugt, %45, %c49152_i64 : i64
+    %66 = arith.cmpi ugt, %40, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %72, ^bb1(%c100_i8 : i8), ^bb28
+    cf.cond_br %66, ^bb1(%c100_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %73 = arith.addi %45, %c31_i64 : i64
-    %74 = arith.divui %73, %c32_i64 : i64
+    %67 = arith.addi %40, %c31_i64 : i64
+    %68 = arith.divui %67, %c32_i64 : i64
     %c2_i64 = arith.constant 2 : i64
-    %75 = arith.muli %74, %c2_i64 : i64
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    %77 = arith.cmpi ult, %76, %75 : i64
-    scf.if %77 {
+    %69 = arith.muli %68, %c2_i64 : i64
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = arith.cmpi ult, %70, %69 : i64
+    scf.if %71 {
     } else {
-      %106 = arith.subi %76, %75 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %70, %69 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %77, ^bb1(%c80_i8_30 : i8), ^bb29
+    %c80_i8_24 = arith.constant 80 : i8
+    cf.cond_br %71, ^bb1(%c80_i8_24 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c18446744073709551615_i256_31 = arith.constant 18446744073709551615 : i256
-    %78 = arith.cmpi sgt, %37, %c18446744073709551615_i256_31 : i256
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %78, ^bb1(%c84_i8_32 : i8), ^bb30
+    %c18446744073709551615_i256_25 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %33, %c18446744073709551615_i256_25 : i256
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_26 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %79 = arith.trunci %37 : i256 to i64
-    %c0_i64_33 = arith.constant 0 : i64
-    %80 = arith.cmpi slt, %79, %c0_i64_33 : i64
-    %c84_i8_34 = arith.constant 84 : i8
-    cf.cond_br %80, ^bb1(%c84_i8_34 : i8), ^bb31
+    %73 = arith.trunci %33 : i256 to i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_28 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %81 = arith.addi %79, %45 : i64
-    %c0_i64_35 = arith.constant 0 : i64
-    %82 = arith.cmpi slt, %81, %c0_i64_35 : i64
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %82, ^bb1(%c84_i8_36 : i8), ^bb32
+    %75 = arith.addi %73, %40 : i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_29 : i64
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_30 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_37 = arith.constant 31 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %83 = arith.addi %81, %c31_i64_37 : i64
-    %84 = arith.divui %83, %c32_i64_38 : i64
-    %c32_i64_39 = arith.constant 32 : i64
-    %85 = arith.muli %84, %c32_i64_39 : i64
-    %86 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_40 = arith.constant 31 : i64
-    %c32_i64_41 = arith.constant 32 : i64
-    %87 = arith.addi %86, %c31_i64_40 : i64
-    %88 = arith.divui %87, %c32_i64_41 : i64
-    %89 = arith.muli %88, %c32_i64_39 : i64
-    %90 = arith.cmpi ult, %89, %85 : i64
-    cf.cond_br %90, ^bb34, ^bb33
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_31 : i64
+    %78 = arith.divui %77, %c32_i64_32 : i64
+    %c32_i64_33 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_33 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_34 = arith.constant 31 : i64
+    %c32_i64_35 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_34 : i64
+    %82 = arith.divui %81, %c32_i64_35 : i64
+    %83 = arith.muli %82, %c32_i64_33 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb19
   ^bb34:  // pred: ^bb32
-    %c3_i64_42 = arith.constant 3 : i64
+    %c3_i64_36 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %91 = arith.muli %88, %88 : i64
-    %92 = arith.divui %91, %c512_i64 : i64
-    %93 = arith.muli %88, %c3_i64_42 : i64
-    %94 = arith.addi %92, %93 : i64
-    %c3_i64_43 = arith.constant 3 : i64
-    %c512_i64_44 = arith.constant 512 : i64
-    %95 = arith.muli %84, %84 : i64
-    %96 = arith.divui %95, %c512_i64_44 : i64
-    %97 = arith.muli %84, %c3_i64_43 : i64
-    %98 = arith.addi %96, %97 : i64
-    %99 = arith.subi %98, %94 : i64
-    %100 = llvm.load %arg1 : !llvm.ptr -> i64
-    %101 = arith.cmpi ult, %100, %99 : i64
-    scf.if %101 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_36 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_37 = arith.constant 3 : i64
+    %c512_i64_38 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_38 : i64
+    %91 = arith.muli %78, %c3_i64_37 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %106 = arith.subi %100, %99 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_45 = arith.constant 80 : i8
-    cf.cond_br %101, ^bb1(%c80_i8_45 : i8), ^bb35
+    %c80_i8_39 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_39 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %102 = call @dora_fn_extend_memory(%arg0, %85) : (!llvm.ptr, i64) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8_46 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %104, %c0_i8_46 : i8
-    cf.cond_br %105, ^bb1(%104 : i8), ^bb36
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
+    %c0_i8_40 = arith.constant 0 : i8
+    %99 = arith.cmpi ne, %98, %c0_i8_40 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,254 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256_1 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c9_i256 = arith.constant 9 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c9_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c9_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb23
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %43 = arith.cmpi ne, %42, %c0_i8 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %43, ^bb1(%c87_i8 : i8), ^bb16
+    cf.cond_br %38, ^bb1(%c87_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %44 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %39 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb17
+    cf.cond_br %39, ^bb1(%c84_i8 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %45 = arith.trunci %41 : i256 to i64
-    %c0_i64_17 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_17 : i64
-    %c84_i8_18 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_18 : i8), ^bb18
+    %40 = arith.trunci %36 : i256 to i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_12 : i64
+    %c84_i8_13 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_13 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i64_19 = arith.constant 0 : i64
-    %47 = arith.cmpi ne, %45, %c0_i64_19 : i64
-    cf.cond_br %47, ^bb27, ^bb19
+    %c0_i64_14 = arith.constant 0 : i64
+    %42 = arith.cmpi ne, %40, %c0_i64_14 : i64
+    cf.cond_br %42, ^bb27, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb33
     %c32000_i64 = arith.constant 32000 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %c32000_i64 : i64
-    scf.if %49 {
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %c32000_i64 : i64
+    scf.if %44 {
     } else {
-      %106 = arith.subi %48, %c32000_i64 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %43, %c32000_i64 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_20 : i8), ^bb20
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_15 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %33, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %52 = arith.trunci %37 : i256 to i64
-    %53 = call @dora_fn_create(%arg0, %45, %52, %50, %51) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
-    %c0_i8_21 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8_21 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb21
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %30, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %47 = arith.trunci %33 : i256 to i64
+    %48 = call @dora_fn_create(%arg0, %40, %47, %45, %46) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %c0_i8_16 = arith.constant 0 : i8
+    %51 = arith.cmpi ne, %50, %c0_i8_16 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %57 = llvm.getelementptr %53[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i64
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    %60 = arith.cmpi ult, %59, %58 : i64
-    scf.if %60 {
+    %52 = llvm.getelementptr %48[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %53 = llvm.load %52 : !llvm.ptr -> i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %106 = arith.subi %59, %58 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %60, ^bb1(%c80_i8_22 : i8), ^bb22
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_17 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %61 = llvm.load %50 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_23 = arith.constant 1 : i64
-    %64 = arith.addi %62, %c1_i64_23 : i64
-    llvm.store %64, %arg3 : i64, !llvm.ptr
-    llvm.store %61, %63 : i256, !llvm.ptr
+    %56 = llvm.load %45 : !llvm.ptr -> i256
+    %57 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %56, %57 : i256, !llvm.ptr
+    %58 = llvm.getelementptr %57[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %58, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_24 = arith.constant 1024 : i64
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %59 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %66 = arith.addi %65, %c-2_i64 : i64
-    %c3_i64_25 = arith.constant 3 : i64
-    %67 = arith.cmpi ult, %65, %c3_i64_25 : i64
+    %60 = arith.addi %59, %c-2_i64 : i64
+    llvm.store %60, %arg3 : i64, !llvm.ptr
+    %c3_i64_19 = arith.constant 3 : i64
+    %61 = arith.cmpi ult, %59, %c3_i64_19 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %61, ^bb1(%c91_i8 : i8), ^bb15
   ^bb24:  // pred: ^bb11
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_26 = arith.constant 0 : i64
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_20 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %69 = arith.cmpi uge, %68, %c0_i64_26 : i64
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %69, ^bb25, ^bb1(%c80_i8_27 : i8)
+    %63 = arith.cmpi uge, %62, %c0_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %63, ^bb25, ^bb1(%c80_i8_21 : i8)
   ^bb25:  // pred: ^bb24
-    %70 = arith.subi %68, %c0_i64_26 : i64
-    llvm.store %70, %arg1 : i64, !llvm.ptr
+    %64 = arith.subi %62, %c0_i64_20 : i64
+    llvm.store %64, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_28 = arith.constant 0 : i64
+    %c0_i64_22 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %71 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_28, %c0_i64_28, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %65 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_22, %c0_i64_22, %65, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb27:  // pred: ^bb18
     %c49152_i64 = arith.constant 49152 : i64
-    %72 = arith.cmpi ugt, %45, %c49152_i64 : i64
+    %66 = arith.cmpi ugt, %40, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %72, ^bb1(%c100_i8 : i8), ^bb28
+    cf.cond_br %66, ^bb1(%c100_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %73 = arith.addi %45, %c31_i64 : i64
-    %74 = arith.divui %73, %c32_i64 : i64
+    %67 = arith.addi %40, %c31_i64 : i64
+    %68 = arith.divui %67, %c32_i64 : i64
     %c2_i64 = arith.constant 2 : i64
-    %75 = arith.muli %74, %c2_i64 : i64
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    %77 = arith.cmpi ult, %76, %75 : i64
-    scf.if %77 {
+    %69 = arith.muli %68, %c2_i64 : i64
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = arith.cmpi ult, %70, %69 : i64
+    scf.if %71 {
     } else {
-      %106 = arith.subi %76, %75 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %70, %69 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %77, ^bb1(%c80_i8_29 : i8), ^bb29
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %71, ^bb1(%c80_i8_23 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c18446744073709551615_i256_30 = arith.constant 18446744073709551615 : i256
-    %78 = arith.cmpi sgt, %37, %c18446744073709551615_i256_30 : i256
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %78, ^bb1(%c84_i8_31 : i8), ^bb30
+    %c18446744073709551615_i256_24 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %33, %c18446744073709551615_i256_24 : i256
+    %c84_i8_25 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_25 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %79 = arith.trunci %37 : i256 to i64
-    %c0_i64_32 = arith.constant 0 : i64
-    %80 = arith.cmpi slt, %79, %c0_i64_32 : i64
-    %c84_i8_33 = arith.constant 84 : i8
-    cf.cond_br %80, ^bb1(%c84_i8_33 : i8), ^bb31
+    %73 = arith.trunci %33 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %81 = arith.addi %79, %45 : i64
-    %c0_i64_34 = arith.constant 0 : i64
-    %82 = arith.cmpi slt, %81, %c0_i64_34 : i64
-    %c84_i8_35 = arith.constant 84 : i8
-    cf.cond_br %82, ^bb1(%c84_i8_35 : i8), ^bb32
+    %75 = arith.addi %73, %40 : i64
+    %c0_i64_28 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_28 : i64
+    %c84_i8_29 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_29 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %83 = arith.addi %81, %c31_i64_36 : i64
-    %84 = arith.divui %83, %c32_i64_37 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %85 = arith.muli %84, %c32_i64_38 : i64
-    %86 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_39 = arith.constant 31 : i64
-    %c32_i64_40 = arith.constant 32 : i64
-    %87 = arith.addi %86, %c31_i64_39 : i64
-    %88 = arith.divui %87, %c32_i64_40 : i64
-    %89 = arith.muli %88, %c32_i64_38 : i64
-    %90 = arith.cmpi ult, %89, %85 : i64
-    cf.cond_br %90, ^bb34, ^bb33
+    %c31_i64_30 = arith.constant 31 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_30 : i64
+    %78 = arith.divui %77, %c32_i64_31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_32 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_33 = arith.constant 31 : i64
+    %c32_i64_34 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_33 : i64
+    %82 = arith.divui %81, %c32_i64_34 : i64
+    %83 = arith.muli %82, %c32_i64_32 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb19
   ^bb34:  // pred: ^bb32
-    %c3_i64_41 = arith.constant 3 : i64
+    %c3_i64_35 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %91 = arith.muli %88, %88 : i64
-    %92 = arith.divui %91, %c512_i64 : i64
-    %93 = arith.muli %88, %c3_i64_41 : i64
-    %94 = arith.addi %92, %93 : i64
-    %c3_i64_42 = arith.constant 3 : i64
-    %c512_i64_43 = arith.constant 512 : i64
-    %95 = arith.muli %84, %84 : i64
-    %96 = arith.divui %95, %c512_i64_43 : i64
-    %97 = arith.muli %84, %c3_i64_42 : i64
-    %98 = arith.addi %96, %97 : i64
-    %99 = arith.subi %98, %94 : i64
-    %100 = llvm.load %arg1 : !llvm.ptr -> i64
-    %101 = arith.cmpi ult, %100, %99 : i64
-    scf.if %101 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_35 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_36 = arith.constant 3 : i64
+    %c512_i64_37 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_37 : i64
+    %91 = arith.muli %78, %c3_i64_36 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %106 = arith.subi %100, %99 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_44 = arith.constant 80 : i8
-    cf.cond_br %101, ^bb1(%c80_i8_44 : i8), ^bb35
+    %c80_i8_38 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_38 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %102 = call @dora_fn_extend_memory(%arg0, %85) : (!llvm.ptr, i64) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8_45 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %104, %c0_i8_45 : i8
-    cf.cond_br %105, ^bb1(%104 : i8), ^bb36
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
+    %c0_i8_39 = arith.constant 0 : i8
+    %99 = arith.cmpi ne, %98, %c0_i8_39 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_2.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 33 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46, ^bb48, ^bb49, ^bb50, ^bb51, ^bb52, ^bb55, ^bb56
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 33 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46, ^bb48, ^bb49, ^bb50, ^bb51, ^bb52, ^bb55, ^bb56
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c30948500970605382398753381619_i256 = arith.constant 30948500970605382398753381619 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c30948500970605382398753381619_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,420 +96,406 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb40, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb40, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb44
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c13_i256 = arith.constant 13 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c13_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c13_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c19_i256 = arith.constant 19 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c19_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c19_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %c0_i256_25 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_26 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_25, %59 : i256, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb25:  // pred: ^bb27
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_28 : i64
-    %63 = arith.cmpi ult, %c1024_i64_27, %62 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_29 : i8), ^bb24
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_22 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_21, %56 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_23 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_31 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_30 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_24 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb36
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_32 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_33 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_34 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
-    %79 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %80 = arith.cmpi ne, %79, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %80, ^bb1(%c87_i8 : i8), ^bb29
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb30
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %82 = arith.trunci %78 : i256 to i64
-    %c0_i64_35 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_35 : i64
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_36 : i8), ^bb31
+    %73 = arith.trunci %69 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_37 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_37 : i64
-    cf.cond_br %84, ^bb48, ^bb32
+    %c0_i64_28 = arith.constant 0 : i64
+    %75 = arith.cmpi ne, %73, %c0_i64_28 : i64
+    cf.cond_br %75, ^bb48, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb54
     %c32000_i64 = arith.constant 32000 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %c32000_i64 : i64
-    scf.if %86 {
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %c32000_i64 : i64
+    scf.if %77 {
     } else {
-      %171 = arith.subi %85, %c32000_i64 : i64
-      llvm.store %171, %arg1 : i64, !llvm.ptr
+      %161 = arith.subi %76, %c32000_i64 : i64
+      llvm.store %161, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_38 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c1_i256 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %70, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %89 = arith.trunci %74 : i256 to i64
-    %90 = call @dora_fn_create(%arg0, %82, %89, %87, %88) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %91 = llvm.getelementptr %90[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %92 = llvm.load %91 : !llvm.ptr -> i8
-    %c0_i8_39 = arith.constant 0 : i8
-    %93 = arith.cmpi ne, %92, %c0_i8_39 : i8
-    cf.cond_br %93, ^bb1(%92 : i8), ^bb34
+    %78 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %80 = arith.trunci %66 : i256 to i64
+    %81 = call @dora_fn_create(%arg0, %73, %80, %78, %79) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %82 = llvm.getelementptr %81[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %83 = llvm.load %82 : !llvm.ptr -> i8
+    %c0_i8_30 = arith.constant 0 : i8
+    %84 = arith.cmpi ne, %83, %c0_i8_30 : i8
+    cf.cond_br %84, ^bb1(%83 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %94 = llvm.getelementptr %90[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %85 = llvm.getelementptr %81[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %171 = arith.subi %96, %95 : i64
-      llvm.store %171, %arg1 : i64, !llvm.ptr
+      %161 = arith.subi %87, %86 : i64
+      llvm.store %161, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_40 : i8), ^bb35
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_31 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = llvm.load %87 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %101 = arith.addi %99, %c1_i64_41 : i64
-    llvm.store %101, %arg3 : i64, !llvm.ptr
-    llvm.store %98, %100 : i256, !llvm.ptr
+    %89 = llvm.load %78 : !llvm.ptr -> i256
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %90 : i256, !llvm.ptr
+    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb36:  // pred: ^bb38
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_43 = arith.constant -2 : i64
-    %103 = arith.addi %102, %c-2_i64_43 : i64
-    %c3_i64_44 = arith.constant 3 : i64
-    %104 = arith.cmpi ult, %102, %c3_i64_44 : i64
-    %c91_i8_45 = arith.constant 91 : i8
-    cf.cond_br %104, ^bb1(%c91_i8_45 : i8), ^bb28
+    %c1024_i64_32 = arith.constant 1024 : i64
+    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_33 = arith.constant -2 : i64
+    %93 = arith.addi %92, %c-2_i64_33 : i64
+    llvm.store %93, %arg3 : i64, !llvm.ptr
+    %c3_i64_34 = arith.constant 3 : i64
+    %94 = arith.cmpi ult, %92, %c3_i64_34 : i64
+    %c91_i8_35 = arith.constant 91 : i8
+    cf.cond_br %94, ^bb1(%c91_i8_35 : i8), ^bb28
   ^bb37:  // pred: ^bb24
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_36 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %106 = arith.cmpi uge, %105, %c0_i64_46 : i64
-    %c80_i8_47 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb38, ^bb1(%c80_i8_47 : i8)
+    %96 = arith.cmpi uge, %95, %c0_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %96, ^bb38, ^bb1(%c80_i8_37 : i8)
   ^bb38:  // pred: ^bb37
-    %107 = arith.subi %105, %c0_i64_46 : i64
-    llvm.store %107, %arg1 : i64, !llvm.ptr
+    %97 = arith.subi %95, %c0_i64_36 : i64
+    llvm.store %97, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb35
-    %c0_i64_48 = arith.constant 0 : i64
+    %c0_i64_38 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %108 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_48, %c0_i64_48, %108, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %98 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_38, %c0_i64_38, %98, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb40:  // pred: ^bb11
-    %c18446744073709551615_i256_49 = arith.constant 18446744073709551615 : i256
-    %109 = arith.cmpi sgt, %24, %c18446744073709551615_i256_49 : i256
-    %c84_i8_50 = arith.constant 84 : i8
-    cf.cond_br %109, ^bb1(%c84_i8_50 : i8), ^bb41
+    %c18446744073709551615_i256_39 = arith.constant 18446744073709551615 : i256
+    %99 = arith.cmpi sgt, %22, %c18446744073709551615_i256_39 : i256
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %99, ^bb1(%c84_i8_40 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %110 = arith.trunci %24 : i256 to i64
-    %c0_i64_51 = arith.constant 0 : i64
-    %111 = arith.cmpi slt, %110, %c0_i64_51 : i64
-    %c84_i8_52 = arith.constant 84 : i8
-    cf.cond_br %111, ^bb1(%c84_i8_52 : i8), ^bb42
+    %100 = arith.trunci %22 : i256 to i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %101 = arith.cmpi slt, %100, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %101, ^bb1(%c84_i8_42 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %112 = arith.addi %110, %c32_i64 : i64
-    %c0_i64_53 = arith.constant 0 : i64
-    %113 = arith.cmpi slt, %112, %c0_i64_53 : i64
-    %c84_i8_54 = arith.constant 84 : i8
-    cf.cond_br %113, ^bb1(%c84_i8_54 : i8), ^bb43
+    %102 = arith.addi %100, %c32_i64 : i64
+    %c0_i64_43 = arith.constant 0 : i64
+    %103 = arith.cmpi slt, %102, %c0_i64_43 : i64
+    %c84_i8_44 = arith.constant 84 : i8
+    cf.cond_br %103, ^bb1(%c84_i8_44 : i8), ^bb43
   ^bb43:  // pred: ^bb42
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_55 = arith.constant 32 : i64
-    %114 = arith.addi %112, %c31_i64 : i64
-    %115 = arith.divui %114, %c32_i64_55 : i64
-    %c32_i64_56 = arith.constant 32 : i64
-    %116 = arith.muli %115, %c32_i64_56 : i64
-    %117 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_57 = arith.constant 31 : i64
-    %c32_i64_58 = arith.constant 32 : i64
-    %118 = arith.addi %117, %c31_i64_57 : i64
-    %119 = arith.divui %118, %c32_i64_58 : i64
-    %120 = arith.muli %119, %c32_i64_56 : i64
-    %121 = arith.cmpi ult, %120, %116 : i64
-    cf.cond_br %121, ^bb45, ^bb44
+    %c32_i64_45 = arith.constant 32 : i64
+    %104 = arith.addi %102, %c31_i64 : i64
+    %105 = arith.divui %104, %c32_i64_45 : i64
+    %c32_i64_46 = arith.constant 32 : i64
+    %106 = arith.muli %105, %c32_i64_46 : i64
+    %107 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_47 = arith.constant 31 : i64
+    %c32_i64_48 = arith.constant 32 : i64
+    %108 = arith.addi %107, %c31_i64_47 : i64
+    %109 = arith.divui %108, %c32_i64_48 : i64
+    %110 = arith.muli %109, %c32_i64_46 : i64
+    %111 = arith.cmpi ult, %110, %106 : i64
+    cf.cond_br %111, ^bb45, ^bb44
   ^bb44:  // 2 preds: ^bb43, ^bb47
     cf.br ^bb12
   ^bb45:  // pred: ^bb43
-    %c3_i64_59 = arith.constant 3 : i64
+    %c3_i64_49 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %122 = arith.muli %119, %119 : i64
-    %123 = arith.divui %122, %c512_i64 : i64
-    %124 = arith.muli %119, %c3_i64_59 : i64
-    %125 = arith.addi %123, %124 : i64
-    %c3_i64_60 = arith.constant 3 : i64
-    %c512_i64_61 = arith.constant 512 : i64
-    %126 = arith.muli %115, %115 : i64
-    %127 = arith.divui %126, %c512_i64_61 : i64
-    %128 = arith.muli %115, %c3_i64_60 : i64
-    %129 = arith.addi %127, %128 : i64
-    %130 = arith.subi %129, %125 : i64
-    %131 = llvm.load %arg1 : !llvm.ptr -> i64
-    %132 = arith.cmpi ult, %131, %130 : i64
-    scf.if %132 {
+    %112 = arith.muli %109, %109 : i64
+    %113 = arith.divui %112, %c512_i64 : i64
+    %114 = arith.muli %109, %c3_i64_49 : i64
+    %115 = arith.addi %113, %114 : i64
+    %c3_i64_50 = arith.constant 3 : i64
+    %c512_i64_51 = arith.constant 512 : i64
+    %116 = arith.muli %105, %105 : i64
+    %117 = arith.divui %116, %c512_i64_51 : i64
+    %118 = arith.muli %105, %c3_i64_50 : i64
+    %119 = arith.addi %117, %118 : i64
+    %120 = arith.subi %119, %115 : i64
+    %121 = llvm.load %arg1 : !llvm.ptr -> i64
+    %122 = arith.cmpi ult, %121, %120 : i64
+    scf.if %122 {
     } else {
-      %171 = arith.subi %131, %130 : i64
-      llvm.store %171, %arg1 : i64, !llvm.ptr
+      %161 = arith.subi %121, %120 : i64
+      llvm.store %161, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %132, ^bb1(%c80_i8_62 : i8), ^bb46
+    %c80_i8_52 = arith.constant 80 : i8
+    cf.cond_br %122, ^bb1(%c80_i8_52 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %133 = call @dora_fn_extend_memory(%arg0, %116) : (!llvm.ptr, i64) -> !llvm.ptr
-    %134 = llvm.getelementptr %133[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %135 = llvm.load %134 : !llvm.ptr -> i8
-    %c0_i8_63 = arith.constant 0 : i8
-    %136 = arith.cmpi ne, %135, %c0_i8_63 : i8
-    cf.cond_br %136, ^bb1(%135 : i8), ^bb47
+    %123 = call @dora_fn_extend_memory(%arg0, %106) : (!llvm.ptr, i64) -> !llvm.ptr
+    %124 = llvm.getelementptr %123[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %125 = llvm.load %124 : !llvm.ptr -> i8
+    %c0_i8_53 = arith.constant 0 : i8
+    %126 = arith.cmpi ne, %125, %c0_i8_53 : i8
+    cf.cond_br %126, ^bb1(%125 : i8), ^bb47
   ^bb47:  // pred: ^bb46
     cf.br ^bb44
   ^bb48:  // pred: ^bb31
     %c49152_i64 = arith.constant 49152 : i64
-    %137 = arith.cmpi ugt, %82, %c49152_i64 : i64
+    %127 = arith.cmpi ugt, %73, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %137, ^bb1(%c100_i8 : i8), ^bb49
+    cf.cond_br %127, ^bb1(%c100_i8 : i8), ^bb49
   ^bb49:  // pred: ^bb48
+    %c31_i64_54 = arith.constant 31 : i64
+    %c32_i64_55 = arith.constant 32 : i64
+    %128 = arith.addi %73, %c31_i64_54 : i64
+    %129 = arith.divui %128, %c32_i64_55 : i64
+    %c2_i64_56 = arith.constant 2 : i64
+    %130 = arith.muli %129, %c2_i64_56 : i64
+    %131 = llvm.load %arg1 : !llvm.ptr -> i64
+    %132 = arith.cmpi ult, %131, %130 : i64
+    scf.if %132 {
+    } else {
+      %161 = arith.subi %131, %130 : i64
+      llvm.store %161, %arg1 : i64, !llvm.ptr
+    }
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %132, ^bb1(%c80_i8_57 : i8), ^bb50
+  ^bb50:  // pred: ^bb49
+    %c18446744073709551615_i256_58 = arith.constant 18446744073709551615 : i256
+    %133 = arith.cmpi sgt, %66, %c18446744073709551615_i256_58 : i256
+    %c84_i8_59 = arith.constant 84 : i8
+    cf.cond_br %133, ^bb1(%c84_i8_59 : i8), ^bb51
+  ^bb51:  // pred: ^bb50
+    %134 = arith.trunci %66 : i256 to i64
+    %c0_i64_60 = arith.constant 0 : i64
+    %135 = arith.cmpi slt, %134, %c0_i64_60 : i64
+    %c84_i8_61 = arith.constant 84 : i8
+    cf.cond_br %135, ^bb1(%c84_i8_61 : i8), ^bb52
+  ^bb52:  // pred: ^bb51
+    %136 = arith.addi %134, %73 : i64
+    %c0_i64_62 = arith.constant 0 : i64
+    %137 = arith.cmpi slt, %136, %c0_i64_62 : i64
+    %c84_i8_63 = arith.constant 84 : i8
+    cf.cond_br %137, ^bb1(%c84_i8_63 : i8), ^bb53
+  ^bb53:  // pred: ^bb52
     %c31_i64_64 = arith.constant 31 : i64
     %c32_i64_65 = arith.constant 32 : i64
-    %138 = arith.addi %82, %c31_i64_64 : i64
+    %138 = arith.addi %136, %c31_i64_64 : i64
     %139 = arith.divui %138, %c32_i64_65 : i64
-    %c2_i64_66 = arith.constant 2 : i64
-    %140 = arith.muli %139, %c2_i64_66 : i64
-    %141 = llvm.load %arg1 : !llvm.ptr -> i64
-    %142 = arith.cmpi ult, %141, %140 : i64
-    scf.if %142 {
-    } else {
-      %171 = arith.subi %141, %140 : i64
-      llvm.store %171, %arg1 : i64, !llvm.ptr
-    }
-    %c80_i8_67 = arith.constant 80 : i8
-    cf.cond_br %142, ^bb1(%c80_i8_67 : i8), ^bb50
-  ^bb50:  // pred: ^bb49
-    %c18446744073709551615_i256_68 = arith.constant 18446744073709551615 : i256
-    %143 = arith.cmpi sgt, %74, %c18446744073709551615_i256_68 : i256
-    %c84_i8_69 = arith.constant 84 : i8
-    cf.cond_br %143, ^bb1(%c84_i8_69 : i8), ^bb51
-  ^bb51:  // pred: ^bb50
-    %144 = arith.trunci %74 : i256 to i64
-    %c0_i64_70 = arith.constant 0 : i64
-    %145 = arith.cmpi slt, %144, %c0_i64_70 : i64
-    %c84_i8_71 = arith.constant 84 : i8
-    cf.cond_br %145, ^bb1(%c84_i8_71 : i8), ^bb52
-  ^bb52:  // pred: ^bb51
-    %146 = arith.addi %144, %82 : i64
-    %c0_i64_72 = arith.constant 0 : i64
-    %147 = arith.cmpi slt, %146, %c0_i64_72 : i64
-    %c84_i8_73 = arith.constant 84 : i8
-    cf.cond_br %147, ^bb1(%c84_i8_73 : i8), ^bb53
-  ^bb53:  // pred: ^bb52
-    %c31_i64_74 = arith.constant 31 : i64
-    %c32_i64_75 = arith.constant 32 : i64
-    %148 = arith.addi %146, %c31_i64_74 : i64
-    %149 = arith.divui %148, %c32_i64_75 : i64
-    %c32_i64_76 = arith.constant 32 : i64
-    %150 = arith.muli %149, %c32_i64_76 : i64
-    %151 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_77 = arith.constant 31 : i64
-    %c32_i64_78 = arith.constant 32 : i64
-    %152 = arith.addi %151, %c31_i64_77 : i64
-    %153 = arith.divui %152, %c32_i64_78 : i64
-    %154 = arith.muli %153, %c32_i64_76 : i64
-    %155 = arith.cmpi ult, %154, %150 : i64
-    cf.cond_br %155, ^bb55, ^bb54
+    %c32_i64_66 = arith.constant 32 : i64
+    %140 = arith.muli %139, %c32_i64_66 : i64
+    %141 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_67 = arith.constant 31 : i64
+    %c32_i64_68 = arith.constant 32 : i64
+    %142 = arith.addi %141, %c31_i64_67 : i64
+    %143 = arith.divui %142, %c32_i64_68 : i64
+    %144 = arith.muli %143, %c32_i64_66 : i64
+    %145 = arith.cmpi ult, %144, %140 : i64
+    cf.cond_br %145, ^bb55, ^bb54
   ^bb54:  // 2 preds: ^bb53, ^bb57
     cf.br ^bb32
   ^bb55:  // pred: ^bb53
-    %c3_i64_79 = arith.constant 3 : i64
-    %c512_i64_80 = arith.constant 512 : i64
-    %156 = arith.muli %153, %153 : i64
-    %157 = arith.divui %156, %c512_i64_80 : i64
-    %158 = arith.muli %153, %c3_i64_79 : i64
-    %159 = arith.addi %157, %158 : i64
-    %c3_i64_81 = arith.constant 3 : i64
-    %c512_i64_82 = arith.constant 512 : i64
-    %160 = arith.muli %149, %149 : i64
-    %161 = arith.divui %160, %c512_i64_82 : i64
-    %162 = arith.muli %149, %c3_i64_81 : i64
-    %163 = arith.addi %161, %162 : i64
-    %164 = arith.subi %163, %159 : i64
-    %165 = llvm.load %arg1 : !llvm.ptr -> i64
-    %166 = arith.cmpi ult, %165, %164 : i64
-    scf.if %166 {
+    %c3_i64_69 = arith.constant 3 : i64
+    %c512_i64_70 = arith.constant 512 : i64
+    %146 = arith.muli %143, %143 : i64
+    %147 = arith.divui %146, %c512_i64_70 : i64
+    %148 = arith.muli %143, %c3_i64_69 : i64
+    %149 = arith.addi %147, %148 : i64
+    %c3_i64_71 = arith.constant 3 : i64
+    %c512_i64_72 = arith.constant 512 : i64
+    %150 = arith.muli %139, %139 : i64
+    %151 = arith.divui %150, %c512_i64_72 : i64
+    %152 = arith.muli %139, %c3_i64_71 : i64
+    %153 = arith.addi %151, %152 : i64
+    %154 = arith.subi %153, %149 : i64
+    %155 = llvm.load %arg1 : !llvm.ptr -> i64
+    %156 = arith.cmpi ult, %155, %154 : i64
+    scf.if %156 {
     } else {
-      %171 = arith.subi %165, %164 : i64
-      llvm.store %171, %arg1 : i64, !llvm.ptr
+      %161 = arith.subi %155, %154 : i64
+      llvm.store %161, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_83 = arith.constant 80 : i8
-    cf.cond_br %166, ^bb1(%c80_i8_83 : i8), ^bb56
+    %c80_i8_73 = arith.constant 80 : i8
+    cf.cond_br %156, ^bb1(%c80_i8_73 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %167 = call @dora_fn_extend_memory(%arg0, %150) : (!llvm.ptr, i64) -> !llvm.ptr
-    %168 = llvm.getelementptr %167[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %169 = llvm.load %168 : !llvm.ptr -> i8
-    %c0_i8_84 = arith.constant 0 : i8
-    %170 = arith.cmpi ne, %169, %c0_i8_84 : i8
-    cf.cond_br %170, ^bb1(%169 : i8), ^bb57
+    %157 = call @dora_fn_extend_memory(%arg0, %140) : (!llvm.ptr, i64) -> !llvm.ptr
+    %158 = llvm.getelementptr %157[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %159 = llvm.load %158 : !llvm.ptr -> i8
+    %c0_i8_74 = arith.constant 0 : i8
+    %160 = arith.cmpi ne, %159, %c0_i8_74 : i8
+    cf.cond_br %160, ^bb1(%159 : i8), ^bb57
   ^bb57:  // pred: ^bb56
     cf.br ^bb54
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_create_with_value.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 22 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb24, ^bb27, ^bb28, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c100_i256 = arith.constant 100 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c100_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,254 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c40_i256 = arith.constant 40 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c40_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c40_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb23
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %43 = arith.cmpi ne, %42, %c0_i8 : i8
+    %38 = arith.cmpi ne, %37, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %43, ^bb1(%c87_i8 : i8), ^bb16
+    cf.cond_br %38, ^bb1(%c87_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %44 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %39 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8 : i8), ^bb17
+    cf.cond_br %39, ^bb1(%c84_i8 : i8), ^bb17
   ^bb17:  // pred: ^bb16
-    %45 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_17 : i8), ^bb18
+    %40 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_12 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %c0_i64_18 = arith.constant 0 : i64
-    %47 = arith.cmpi ne, %45, %c0_i64_18 : i64
-    cf.cond_br %47, ^bb27, ^bb19
+    %c0_i64_13 = arith.constant 0 : i64
+    %42 = arith.cmpi ne, %40, %c0_i64_13 : i64
+    cf.cond_br %42, ^bb27, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb33
     %c32000_i64 = arith.constant 32000 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %c32000_i64 : i64
-    scf.if %49 {
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %c32000_i64 : i64
+    scf.if %44 {
     } else {
-      %106 = arith.subi %48, %c32000_i64 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %43, %c32000_i64 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_19 : i8), ^bb20
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_14 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %33, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %51 = llvm.load %arg1 : !llvm.ptr -> i64
-    %52 = arith.trunci %37 : i256 to i64
-    %53 = call @dora_fn_create(%arg0, %45, %52, %50, %51) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
-    %c0_i8_20 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8_20 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb21
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %30, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %47 = arith.trunci %33 : i256 to i64
+    %48 = call @dora_fn_create(%arg0, %40, %47, %45, %46) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
+    %c0_i8_15 = arith.constant 0 : i8
+    %51 = arith.cmpi ne, %50, %c0_i8_15 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %57 = llvm.getelementptr %53[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %58 = llvm.load %57 : !llvm.ptr -> i64
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    %60 = arith.cmpi ult, %59, %58 : i64
-    scf.if %60 {
+    %52 = llvm.getelementptr %48[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %53 = llvm.load %52 : !llvm.ptr -> i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %106 = arith.subi %59, %58 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_21 = arith.constant 80 : i8
-    cf.cond_br %60, ^bb1(%c80_i8_21 : i8), ^bb22
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_16 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %61 = llvm.load %50 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_22 = arith.constant 1 : i64
-    %64 = arith.addi %62, %c1_i64_22 : i64
-    llvm.store %64, %arg3 : i64, !llvm.ptr
-    llvm.store %61, %63 : i256, !llvm.ptr
+    %56 = llvm.load %45 : !llvm.ptr -> i256
+    %57 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %56, %57 : i256, !llvm.ptr
+    %58 = llvm.getelementptr %57[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %58, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_23 = arith.constant 1024 : i64
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %59 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %66 = arith.addi %65, %c-2_i64 : i64
-    %c3_i64_24 = arith.constant 3 : i64
-    %67 = arith.cmpi ult, %65, %c3_i64_24 : i64
+    %60 = arith.addi %59, %c-2_i64 : i64
+    llvm.store %60, %arg3 : i64, !llvm.ptr
+    %c3_i64_18 = arith.constant 3 : i64
+    %61 = arith.cmpi ult, %59, %c3_i64_18 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %61, ^bb1(%c91_i8 : i8), ^bb15
   ^bb24:  // pred: ^bb11
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_19 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %69 = arith.cmpi uge, %68, %c0_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %69, ^bb25, ^bb1(%c80_i8_26 : i8)
+    %63 = arith.cmpi uge, %62, %c0_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %63, ^bb25, ^bb1(%c80_i8_20 : i8)
   ^bb25:  // pred: ^bb24
-    %70 = arith.subi %68, %c0_i64_25 : i64
-    llvm.store %70, %arg1 : i64, !llvm.ptr
+    %64 = arith.subi %62, %c0_i64_19 : i64
+    llvm.store %64, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_27 = arith.constant 0 : i64
+    %c0_i64_21 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %71 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %65 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %65, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb27:  // pred: ^bb18
     %c49152_i64 = arith.constant 49152 : i64
-    %72 = arith.cmpi ugt, %45, %c49152_i64 : i64
+    %66 = arith.cmpi ugt, %40, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %72, ^bb1(%c100_i8 : i8), ^bb28
+    cf.cond_br %66, ^bb1(%c100_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %73 = arith.addi %45, %c31_i64 : i64
-    %74 = arith.divui %73, %c32_i64 : i64
+    %67 = arith.addi %40, %c31_i64 : i64
+    %68 = arith.divui %67, %c32_i64 : i64
     %c2_i64 = arith.constant 2 : i64
-    %75 = arith.muli %74, %c2_i64 : i64
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    %77 = arith.cmpi ult, %76, %75 : i64
-    scf.if %77 {
+    %69 = arith.muli %68, %c2_i64 : i64
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = arith.cmpi ult, %70, %69 : i64
+    scf.if %71 {
     } else {
-      %106 = arith.subi %76, %75 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %70, %69 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %77, ^bb1(%c80_i8_28 : i8), ^bb29
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %71, ^bb1(%c80_i8_22 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c18446744073709551615_i256_29 = arith.constant 18446744073709551615 : i256
-    %78 = arith.cmpi sgt, %37, %c18446744073709551615_i256_29 : i256
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %78, ^bb1(%c84_i8_30 : i8), ^bb30
+    %c18446744073709551615_i256_23 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %33, %c18446744073709551615_i256_23 : i256
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_24 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %79 = arith.trunci %37 : i256 to i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %80 = arith.cmpi slt, %79, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %80, ^bb1(%c84_i8_32 : i8), ^bb31
+    %73 = arith.trunci %33 : i256 to i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_26 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %81 = arith.addi %79, %45 : i64
-    %c0_i64_33 = arith.constant 0 : i64
-    %82 = arith.cmpi slt, %81, %c0_i64_33 : i64
-    %c84_i8_34 = arith.constant 84 : i8
-    cf.cond_br %82, ^bb1(%c84_i8_34 : i8), ^bb32
+    %75 = arith.addi %73, %40 : i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_28 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %83 = arith.addi %81, %c31_i64_35 : i64
-    %84 = arith.divui %83, %c32_i64_36 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %85 = arith.muli %84, %c32_i64_37 : i64
-    %86 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_38 = arith.constant 31 : i64
-    %c32_i64_39 = arith.constant 32 : i64
-    %87 = arith.addi %86, %c31_i64_38 : i64
-    %88 = arith.divui %87, %c32_i64_39 : i64
-    %89 = arith.muli %88, %c32_i64_37 : i64
-    %90 = arith.cmpi ult, %89, %85 : i64
-    cf.cond_br %90, ^bb34, ^bb33
+    %c31_i64_29 = arith.constant 31 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_29 : i64
+    %78 = arith.divui %77, %c32_i64_30 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_31 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_32 = arith.constant 31 : i64
+    %c32_i64_33 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_32 : i64
+    %82 = arith.divui %81, %c32_i64_33 : i64
+    %83 = arith.muli %82, %c32_i64_31 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb19
   ^bb34:  // pred: ^bb32
-    %c3_i64_40 = arith.constant 3 : i64
+    %c3_i64_34 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %91 = arith.muli %88, %88 : i64
-    %92 = arith.divui %91, %c512_i64 : i64
-    %93 = arith.muli %88, %c3_i64_40 : i64
-    %94 = arith.addi %92, %93 : i64
-    %c3_i64_41 = arith.constant 3 : i64
-    %c512_i64_42 = arith.constant 512 : i64
-    %95 = arith.muli %84, %84 : i64
-    %96 = arith.divui %95, %c512_i64_42 : i64
-    %97 = arith.muli %84, %c3_i64_41 : i64
-    %98 = arith.addi %96, %97 : i64
-    %99 = arith.subi %98, %94 : i64
-    %100 = llvm.load %arg1 : !llvm.ptr -> i64
-    %101 = arith.cmpi ult, %100, %99 : i64
-    scf.if %101 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_34 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_35 = arith.constant 3 : i64
+    %c512_i64_36 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_36 : i64
+    %91 = arith.muli %78, %c3_i64_35 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %106 = arith.subi %100, %99 : i64
-      llvm.store %106, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_43 = arith.constant 80 : i8
-    cf.cond_br %101, ^bb1(%c80_i8_43 : i8), ^bb35
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_37 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %102 = call @dora_fn_extend_memory(%arg0, %85) : (!llvm.ptr, i64) -> !llvm.ptr
-    %103 = llvm.getelementptr %102[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %104 = llvm.load %103 : !llvm.ptr -> i8
-    %c0_i8_44 = arith.constant 0 : i8
-    %105 = arith.cmpi ne, %104, %c0_i8_44 : i8
-    cf.cond_br %105, ^bb1(%104 : i8), ^bb36
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
+    %c0_i8_38 = arith.constant 0 : i8
+    %99 = arith.cmpi ne, %98, %c0_i8_38 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 31 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb27, ^bb28, ^bb30, ^bb31, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46, ^bb48, ^bb49, ^bb50, ^bb53, ^bb54
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 31 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb27, ^bb28, ^bb30, ^bb31, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46, ^bb48, ^bb49, ^bb50, ^bb53, ^bb54
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c7000_i256 = arith.constant 7000 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c7000_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,410 +96,392 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c12288_i256 = arith.constant 12288 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c12288_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c12288_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c32_i256 = arith.constant 32 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %c32_i256_13 = arith.constant 32 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_14 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_13, %31 : i256, !llvm.ptr
+    %c32_i256_11 = arith.constant 32 : i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_11, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_16 : i64
-    %35 = arith.cmpi ult, %c1024_i64_15, %34 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_17 : i8), ^bb15
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_13 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_12, %31 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_14 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_19 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_16 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_18 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_15 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
     %c64_i256 = arith.constant 64 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_20 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %40 : i256, !llvm.ptr
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_22 : i64
-    %44 = arith.cmpi ult, %c1024_i64_21, %43 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_23 : i8), ^bb19
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_18 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_17, %39 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_19 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb22, ^bb1(%c80_i8_25 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_21 : i8)
   ^bb22:  // pred: ^bb21
-    %47 = arith.subi %45, %c3_i64_24 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_20 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
-    %c64_i256_26 = arith.constant 64 : i256
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_27 = arith.constant 1 : i64
-    %50 = arith.addi %48, %c1_i64_27 : i64
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256_26, %49 : i256, !llvm.ptr
+    %c64_i256_22 = arith.constant 64 : i256
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_22, %44 : i256, !llvm.ptr
+    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb24:  // pred: ^bb26
-    %c1024_i64_28 = arith.constant 1024 : i64
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %52 = arith.addi %51, %c1_i64_29 : i64
-    %53 = arith.cmpi ult, %c1024_i64_28, %52 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %53, ^bb1(%c92_i8_30 : i8), ^bb23
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_24 = arith.constant 1 : i64
+    %47 = arith.addi %46, %c1_i64_24 : i64
+    llvm.store %47, %arg3 : i64, !llvm.ptr
+    %48 = arith.cmpi ult, %c1024_i64_23, %47 : i64
+    %c92_i8_25 = arith.constant 92 : i8
+    cf.cond_br %48, ^bb1(%c92_i8_25 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_31 = arith.constant 3 : i64
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_26 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %55 = arith.cmpi uge, %54, %c3_i64_31 : i64
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %55, ^bb26, ^bb1(%c80_i8_32 : i8)
+    %50 = arith.cmpi uge, %49, %c3_i64_26 : i64
+    %c80_i8_27 = arith.constant 80 : i8
+    cf.cond_br %50, ^bb26, ^bb1(%c80_i8_27 : i8)
   ^bb26:  // pred: ^bb25
-    %56 = arith.subi %54, %c3_i64_31 : i64
-    llvm.store %56, %arg1 : i64, !llvm.ptr
+    %51 = arith.subi %49, %c3_i64_26 : i64
+    llvm.store %51, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb36
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %58 = arith.subi %57, %c1_i64_33 : i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %58, %arg3 : i64, !llvm.ptr
+    %52 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %0 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %0 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %60 = llvm.load %59 : !llvm.ptr -> i256
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %62 = arith.subi %61, %c1_i64_34 : i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %62, %arg3 : i64, !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> i256
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %66 = arith.subi %65, %c1_i64_35 : i64
-    %67 = llvm.getelementptr %arg2[%66] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %66, %arg3 : i64, !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> i256
-    %69 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_36 = arith.constant 1 : i64
-    %70 = arith.subi %69, %c1_i64_36 : i64
-    %71 = llvm.getelementptr %arg2[%70] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %70, %arg3 : i64, !llvm.ptr
-    %72 = llvm.load %71 : !llvm.ptr -> i256
-    %73 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_37 = arith.constant 1 : i64
-    %74 = arith.subi %73, %c1_i64_37 : i64
-    %75 = llvm.getelementptr %arg2[%74] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %74, %arg3 : i64, !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %78 = arith.subi %77, %c1_i64_38 : i64
-    %79 = llvm.getelementptr %arg2[%78] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %78, %arg3 : i64, !llvm.ptr
-    %80 = llvm.load %79 : !llvm.ptr -> i256
+    llvm.store %59, %0 : !llvm.ptr, !llvm.ptr
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %72, %c18446744073709551615_i256 : i256
+    %70 = arith.cmpi sgt, %63, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb28
+    cf.cond_br %70, ^bb1(%c84_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %82 = arith.trunci %72 : i256 to i64
-    %c0_i64_39 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_39 : i64
-    %c84_i8_40 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_40 : i8), ^bb29
+    %71 = arith.trunci %63 : i256 to i64
+    %c0_i64_28 = arith.constant 0 : i64
+    %72 = arith.cmpi slt, %71, %c0_i64_28 : i64
+    %c84_i8_29 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_29 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i64_41 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_41 : i64
-    cf.cond_br %84, ^bb40, ^bb30
+    %c0_i64_30 = arith.constant 0 : i64
+    %73 = arith.cmpi ne, %71, %c0_i64_30 : i64
+    cf.cond_br %73, ^bb40, ^bb30
   ^bb30:  // 2 preds: ^bb29, ^bb44
-    %c18446744073709551615_i256_42 = arith.constant 18446744073709551615 : i256
-    %85 = arith.cmpi sgt, %80, %c18446744073709551615_i256_42 : i256
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %85, ^bb1(%c84_i8_43 : i8), ^bb31
+    %c18446744073709551615_i256_31 = arith.constant 18446744073709551615 : i256
+    %74 = arith.cmpi sgt, %69, %c18446744073709551615_i256_31 : i256
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_32 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %86 = arith.trunci %80 : i256 to i64
-    %c0_i64_44 = arith.constant 0 : i64
-    %87 = arith.cmpi slt, %86, %c0_i64_44 : i64
-    %c84_i8_45 = arith.constant 84 : i8
-    cf.cond_br %87, ^bb1(%c84_i8_45 : i8), ^bb32
+    %75 = arith.trunci %69 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_34 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i64_46 = arith.constant 0 : i64
-    %88 = arith.cmpi ne, %86, %c0_i64_46 : i64
-    cf.cond_br %88, ^bb48, ^bb33
+    %c0_i64_35 = arith.constant 0 : i64
+    %77 = arith.cmpi ne, %75, %c0_i64_35 : i64
+    cf.cond_br %77, ^bb48, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb52
-    %89 = arith.trunci %68 : i256 to i64
-    %90 = arith.trunci %76 : i256 to i64
-    %91 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.trunci %60 : i256 to i64
+    %79 = arith.trunci %66 : i256 to i64
+    %80 = llvm.load %arg1 : !llvm.ptr -> i64
     %c1_i256 = arith.constant 1 : i256
-    %92 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256, %92 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_47 = arith.constant 1 : i256
-    %93 = llvm.alloca %c1_i256_47 x i256 : (i256) -> !llvm.ptr
-    llvm.store %60, %93 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_48 = arith.constant 1 : i256
-    %94 = llvm.alloca %c1_i256_48 x i256 : (i256) -> !llvm.ptr
-    llvm.store %64, %94 {alignment = 1 : i64} : i256, !llvm.ptr
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_36 = arith.constant 1 : i256
+    %82 = llvm.alloca %c1_i256_36 x i256 : (i256) -> !llvm.ptr
+    llvm.store %54, %82 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_37 = arith.constant 1 : i256
+    %83 = llvm.alloca %c1_i256_37 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %83 {alignment = 1 : i64} : i256, !llvm.ptr
     %c2_i8 = arith.constant 2 : i8
-    %95 = call @dora_fn_call(%arg0, %93, %94, %92, %89, %82, %90, %86, %91, %c2_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %96 = llvm.getelementptr %95[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %97 = llvm.load %96 : !llvm.ptr -> i8
-    %98 = llvm.getelementptr %95[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %99 = llvm.load %98 : !llvm.ptr -> i8
+    %84 = call @dora_fn_call(%arg0, %82, %83, %81, %78, %71, %79, %75, %80, %c2_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %85 = llvm.getelementptr %84[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %87 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %88 = llvm.load %87 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %100 = arith.cmpi ne, %99, %c0_i8 : i8
-    cf.cond_br %100, ^bb1(%99 : i8), ^bb34
+    %89 = arith.cmpi ne, %88, %c0_i8 : i8
+    cf.cond_br %89, ^bb1(%88 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %101 = llvm.getelementptr %95[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %102 = llvm.load %101 : !llvm.ptr -> i64
-    %103 = llvm.load %arg1 : !llvm.ptr -> i64
-    %104 = arith.cmpi ult, %103, %102 : i64
-    scf.if %104 {
+    %90 = llvm.getelementptr %84[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %91 = llvm.load %90 : !llvm.ptr -> i64
+    %92 = llvm.load %arg1 : !llvm.ptr -> i64
+    %93 = arith.cmpi ult, %92, %91 : i64
+    scf.if %93 {
     } else {
-      %172 = arith.subi %103, %102 : i64
-      llvm.store %172, %arg1 : i64, !llvm.ptr
+      %160 = arith.subi %92, %91 : i64
+      llvm.store %160, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_49 = arith.constant 80 : i8
-    cf.cond_br %104, ^bb1(%c80_i8_49 : i8), ^bb35
+    %c80_i8_38 = arith.constant 80 : i8
+    cf.cond_br %93, ^bb1(%c80_i8_38 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %105 = arith.extui %97 : i8 to i256
-    %106 = llvm.load %arg3 : !llvm.ptr -> i64
-    %107 = llvm.getelementptr %arg2[%106] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_50 = arith.constant 1 : i64
-    %108 = arith.addi %106, %c1_i64_50 : i64
-    llvm.store %108, %arg3 : i64, !llvm.ptr
-    llvm.store %105, %107 : i256, !llvm.ptr
+    %94 = arith.extui %86 : i8 to i256
+    %95 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %94, %95 : i256, !llvm.ptr
+    %96 = llvm.getelementptr %95[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %96, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb36:  // pred: ^bb38
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %109 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %97 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %110 = arith.addi %109, %c-5_i64 : i64
+    %98 = arith.addi %97, %c-5_i64 : i64
+    llvm.store %98, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %111 = arith.cmpi ult, %109, %c6_i64 : i64
+    %99 = arith.cmpi ult, %97, %c6_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %111, ^bb1(%c91_i8 : i8), ^bb27
+    cf.cond_br %99, ^bb1(%c91_i8 : i8), ^bb27
   ^bb37:  // pred: ^bb23
-    %112 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_52 = arith.constant 0 : i64
+    %100 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_40 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %113 = arith.cmpi uge, %112, %c0_i64_52 : i64
-    %c80_i8_53 = arith.constant 80 : i8
-    cf.cond_br %113, ^bb38, ^bb1(%c80_i8_53 : i8)
+    %101 = arith.cmpi uge, %100, %c0_i64_40 : i64
+    %c80_i8_41 = arith.constant 80 : i8
+    cf.cond_br %101, ^bb38, ^bb1(%c80_i8_41 : i8)
   ^bb38:  // pred: ^bb37
-    %114 = arith.subi %112, %c0_i64_52 : i64
-    llvm.store %114, %arg1 : i64, !llvm.ptr
+    %102 = arith.subi %100, %c0_i64_40 : i64
+    llvm.store %102, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb35
-    %c0_i64_54 = arith.constant 0 : i64
+    %c0_i64_42 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %115 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_54, %c0_i64_54, %115, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_42, %c0_i64_42, %103, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb40:  // pred: ^bb29
-    %c18446744073709551615_i256_55 = arith.constant 18446744073709551615 : i256
-    %116 = arith.cmpi sgt, %68, %c18446744073709551615_i256_55 : i256
-    %c84_i8_56 = arith.constant 84 : i8
-    cf.cond_br %116, ^bb1(%c84_i8_56 : i8), ^bb41
+    %c18446744073709551615_i256_43 = arith.constant 18446744073709551615 : i256
+    %104 = arith.cmpi sgt, %60, %c18446744073709551615_i256_43 : i256
+    %c84_i8_44 = arith.constant 84 : i8
+    cf.cond_br %104, ^bb1(%c84_i8_44 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %117 = arith.trunci %68 : i256 to i64
-    %c0_i64_57 = arith.constant 0 : i64
-    %118 = arith.cmpi slt, %117, %c0_i64_57 : i64
-    %c84_i8_58 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8_58 : i8), ^bb42
+    %105 = arith.trunci %60 : i256 to i64
+    %c0_i64_45 = arith.constant 0 : i64
+    %106 = arith.cmpi slt, %105, %c0_i64_45 : i64
+    %c84_i8_46 = arith.constant 84 : i8
+    cf.cond_br %106, ^bb1(%c84_i8_46 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %119 = arith.addi %117, %82 : i64
-    %c0_i64_59 = arith.constant 0 : i64
-    %120 = arith.cmpi slt, %119, %c0_i64_59 : i64
-    %c84_i8_60 = arith.constant 84 : i8
-    cf.cond_br %120, ^bb1(%c84_i8_60 : i8), ^bb43
+    %107 = arith.addi %105, %71 : i64
+    %c0_i64_47 = arith.constant 0 : i64
+    %108 = arith.cmpi slt, %107, %c0_i64_47 : i64
+    %c84_i8_48 = arith.constant 84 : i8
+    cf.cond_br %108, ^bb1(%c84_i8_48 : i8), ^bb43
   ^bb43:  // pred: ^bb42
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %121 = arith.addi %119, %c31_i64 : i64
-    %122 = arith.divui %121, %c32_i64 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %123 = arith.muli %122, %c32_i64_61 : i64
-    %124 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_62 = arith.constant 31 : i64
-    %c32_i64_63 = arith.constant 32 : i64
-    %125 = arith.addi %124, %c31_i64_62 : i64
-    %126 = arith.divui %125, %c32_i64_63 : i64
-    %127 = arith.muli %126, %c32_i64_61 : i64
-    %128 = arith.cmpi ult, %127, %123 : i64
-    cf.cond_br %128, ^bb45, ^bb44
+    %109 = arith.addi %107, %c31_i64 : i64
+    %110 = arith.divui %109, %c32_i64 : i64
+    %c32_i64_49 = arith.constant 32 : i64
+    %111 = arith.muli %110, %c32_i64_49 : i64
+    %112 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_50 = arith.constant 31 : i64
+    %c32_i64_51 = arith.constant 32 : i64
+    %113 = arith.addi %112, %c31_i64_50 : i64
+    %114 = arith.divui %113, %c32_i64_51 : i64
+    %115 = arith.muli %114, %c32_i64_49 : i64
+    %116 = arith.cmpi ult, %115, %111 : i64
+    cf.cond_br %116, ^bb45, ^bb44
   ^bb44:  // 2 preds: ^bb43, ^bb47
     cf.br ^bb30
   ^bb45:  // pred: ^bb43
-    %c3_i64_64 = arith.constant 3 : i64
+    %c3_i64_52 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %129 = arith.muli %126, %126 : i64
-    %130 = arith.divui %129, %c512_i64 : i64
-    %131 = arith.muli %126, %c3_i64_64 : i64
-    %132 = arith.addi %130, %131 : i64
-    %c3_i64_65 = arith.constant 3 : i64
-    %c512_i64_66 = arith.constant 512 : i64
-    %133 = arith.muli %122, %122 : i64
-    %134 = arith.divui %133, %c512_i64_66 : i64
-    %135 = arith.muli %122, %c3_i64_65 : i64
-    %136 = arith.addi %134, %135 : i64
-    %137 = arith.subi %136, %132 : i64
-    %138 = llvm.load %arg1 : !llvm.ptr -> i64
-    %139 = arith.cmpi ult, %138, %137 : i64
-    scf.if %139 {
+    %117 = arith.muli %114, %114 : i64
+    %118 = arith.divui %117, %c512_i64 : i64
+    %119 = arith.muli %114, %c3_i64_52 : i64
+    %120 = arith.addi %118, %119 : i64
+    %c3_i64_53 = arith.constant 3 : i64
+    %c512_i64_54 = arith.constant 512 : i64
+    %121 = arith.muli %110, %110 : i64
+    %122 = arith.divui %121, %c512_i64_54 : i64
+    %123 = arith.muli %110, %c3_i64_53 : i64
+    %124 = arith.addi %122, %123 : i64
+    %125 = arith.subi %124, %120 : i64
+    %126 = llvm.load %arg1 : !llvm.ptr -> i64
+    %127 = arith.cmpi ult, %126, %125 : i64
+    scf.if %127 {
     } else {
-      %172 = arith.subi %138, %137 : i64
-      llvm.store %172, %arg1 : i64, !llvm.ptr
+      %160 = arith.subi %126, %125 : i64
+      llvm.store %160, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_67 = arith.constant 80 : i8
-    cf.cond_br %139, ^bb1(%c80_i8_67 : i8), ^bb46
+    %c80_i8_55 = arith.constant 80 : i8
+    cf.cond_br %127, ^bb1(%c80_i8_55 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %140 = call @dora_fn_extend_memory(%arg0, %123) : (!llvm.ptr, i64) -> !llvm.ptr
-    %141 = llvm.getelementptr %140[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %142 = llvm.load %141 : !llvm.ptr -> i8
-    %c0_i8_68 = arith.constant 0 : i8
-    %143 = arith.cmpi ne, %142, %c0_i8_68 : i8
-    cf.cond_br %143, ^bb1(%142 : i8), ^bb47
+    %128 = call @dora_fn_extend_memory(%arg0, %111) : (!llvm.ptr, i64) -> !llvm.ptr
+    %129 = llvm.getelementptr %128[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %130 = llvm.load %129 : !llvm.ptr -> i8
+    %c0_i8_56 = arith.constant 0 : i8
+    %131 = arith.cmpi ne, %130, %c0_i8_56 : i8
+    cf.cond_br %131, ^bb1(%130 : i8), ^bb47
   ^bb47:  // pred: ^bb46
     cf.br ^bb44
   ^bb48:  // pred: ^bb32
-    %c18446744073709551615_i256_69 = arith.constant 18446744073709551615 : i256
-    %144 = arith.cmpi sgt, %76, %c18446744073709551615_i256_69 : i256
-    %c84_i8_70 = arith.constant 84 : i8
-    cf.cond_br %144, ^bb1(%c84_i8_70 : i8), ^bb49
+    %c18446744073709551615_i256_57 = arith.constant 18446744073709551615 : i256
+    %132 = arith.cmpi sgt, %66, %c18446744073709551615_i256_57 : i256
+    %c84_i8_58 = arith.constant 84 : i8
+    cf.cond_br %132, ^bb1(%c84_i8_58 : i8), ^bb49
   ^bb49:  // pred: ^bb48
-    %145 = arith.trunci %76 : i256 to i64
-    %c0_i64_71 = arith.constant 0 : i64
-    %146 = arith.cmpi slt, %145, %c0_i64_71 : i64
-    %c84_i8_72 = arith.constant 84 : i8
-    cf.cond_br %146, ^bb1(%c84_i8_72 : i8), ^bb50
+    %133 = arith.trunci %66 : i256 to i64
+    %c0_i64_59 = arith.constant 0 : i64
+    %134 = arith.cmpi slt, %133, %c0_i64_59 : i64
+    %c84_i8_60 = arith.constant 84 : i8
+    cf.cond_br %134, ^bb1(%c84_i8_60 : i8), ^bb50
   ^bb50:  // pred: ^bb49
-    %147 = arith.addi %145, %86 : i64
-    %c0_i64_73 = arith.constant 0 : i64
-    %148 = arith.cmpi slt, %147, %c0_i64_73 : i64
-    %c84_i8_74 = arith.constant 84 : i8
-    cf.cond_br %148, ^bb1(%c84_i8_74 : i8), ^bb51
+    %135 = arith.addi %133, %75 : i64
+    %c0_i64_61 = arith.constant 0 : i64
+    %136 = arith.cmpi slt, %135, %c0_i64_61 : i64
+    %c84_i8_62 = arith.constant 84 : i8
+    cf.cond_br %136, ^bb1(%c84_i8_62 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %c31_i64_75 = arith.constant 31 : i64
-    %c32_i64_76 = arith.constant 32 : i64
-    %149 = arith.addi %147, %c31_i64_75 : i64
-    %150 = arith.divui %149, %c32_i64_76 : i64
-    %c32_i64_77 = arith.constant 32 : i64
-    %151 = arith.muli %150, %c32_i64_77 : i64
-    %152 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_78 = arith.constant 31 : i64
-    %c32_i64_79 = arith.constant 32 : i64
-    %153 = arith.addi %152, %c31_i64_78 : i64
-    %154 = arith.divui %153, %c32_i64_79 : i64
-    %155 = arith.muli %154, %c32_i64_77 : i64
-    %156 = arith.cmpi ult, %155, %151 : i64
-    cf.cond_br %156, ^bb53, ^bb52
+    %c31_i64_63 = arith.constant 31 : i64
+    %c32_i64_64 = arith.constant 32 : i64
+    %137 = arith.addi %135, %c31_i64_63 : i64
+    %138 = arith.divui %137, %c32_i64_64 : i64
+    %c32_i64_65 = arith.constant 32 : i64
+    %139 = arith.muli %138, %c32_i64_65 : i64
+    %140 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_66 = arith.constant 31 : i64
+    %c32_i64_67 = arith.constant 32 : i64
+    %141 = arith.addi %140, %c31_i64_66 : i64
+    %142 = arith.divui %141, %c32_i64_67 : i64
+    %143 = arith.muli %142, %c32_i64_65 : i64
+    %144 = arith.cmpi ult, %143, %139 : i64
+    cf.cond_br %144, ^bb53, ^bb52
   ^bb52:  // 2 preds: ^bb51, ^bb55
     cf.br ^bb33
   ^bb53:  // pred: ^bb51
-    %c3_i64_80 = arith.constant 3 : i64
-    %c512_i64_81 = arith.constant 512 : i64
-    %157 = arith.muli %154, %154 : i64
-    %158 = arith.divui %157, %c512_i64_81 : i64
-    %159 = arith.muli %154, %c3_i64_80 : i64
-    %160 = arith.addi %158, %159 : i64
-    %c3_i64_82 = arith.constant 3 : i64
-    %c512_i64_83 = arith.constant 512 : i64
-    %161 = arith.muli %150, %150 : i64
-    %162 = arith.divui %161, %c512_i64_83 : i64
-    %163 = arith.muli %150, %c3_i64_82 : i64
-    %164 = arith.addi %162, %163 : i64
-    %165 = arith.subi %164, %160 : i64
-    %166 = llvm.load %arg1 : !llvm.ptr -> i64
-    %167 = arith.cmpi ult, %166, %165 : i64
-    scf.if %167 {
+    %c3_i64_68 = arith.constant 3 : i64
+    %c512_i64_69 = arith.constant 512 : i64
+    %145 = arith.muli %142, %142 : i64
+    %146 = arith.divui %145, %c512_i64_69 : i64
+    %147 = arith.muli %142, %c3_i64_68 : i64
+    %148 = arith.addi %146, %147 : i64
+    %c3_i64_70 = arith.constant 3 : i64
+    %c512_i64_71 = arith.constant 512 : i64
+    %149 = arith.muli %138, %138 : i64
+    %150 = arith.divui %149, %c512_i64_71 : i64
+    %151 = arith.muli %138, %c3_i64_70 : i64
+    %152 = arith.addi %150, %151 : i64
+    %153 = arith.subi %152, %148 : i64
+    %154 = llvm.load %arg1 : !llvm.ptr -> i64
+    %155 = arith.cmpi ult, %154, %153 : i64
+    scf.if %155 {
     } else {
-      %172 = arith.subi %166, %165 : i64
-      llvm.store %172, %arg1 : i64, !llvm.ptr
+      %160 = arith.subi %154, %153 : i64
+      llvm.store %160, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_84 = arith.constant 80 : i8
-    cf.cond_br %167, ^bb1(%c80_i8_84 : i8), ^bb54
+    %c80_i8_72 = arith.constant 80 : i8
+    cf.cond_br %155, ^bb1(%c80_i8_72 : i8), ^bb54
   ^bb54:  // pred: ^bb53
-    %168 = call @dora_fn_extend_memory(%arg0, %151) : (!llvm.ptr, i64) -> !llvm.ptr
-    %169 = llvm.getelementptr %168[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %170 = llvm.load %169 : !llvm.ptr -> i8
-    %c0_i8_85 = arith.constant 0 : i8
-    %171 = arith.cmpi ne, %170, %c0_i8_85 : i8
-    cf.cond_br %171, ^bb1(%170 : i8), ^bb55
+    %156 = call @dora_fn_extend_memory(%arg0, %139) : (!llvm.ptr, i64) -> !llvm.ptr
+    %157 = llvm.getelementptr %156[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %158 = llvm.load %157 : !llvm.ptr -> i8
+    %c0_i8_73 = arith.constant 0 : i8
+    %159 = arith.cmpi ne, %158, %c0_i8_73 : i8
+    cf.cond_br %159, ^bb1(%158 : i8), ^bb55
   ^bb55:  // pred: ^bb54
     cf.br ^bb52
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,44 +95,42 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %14 = llvm.getelementptr %13[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
-    %17 = llvm.getelementptr %arg2[%16] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %18 = arith.addi %16, %c1_i64_1 : i64
-    llvm.store %18, %arg3 : i64, !llvm.ptr
-    llvm.store %15, %17 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    %15 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %14, %15 : i256, !llvm.ptr
+    %16 = llvm.getelementptr %15[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %16, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %19 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %17 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %18 = arith.addi %17, %c1_i64_2 : i64
+    llvm.store %18, %arg3 : i64, !llvm.ptr
     %c1_i64_3 = arith.constant 1 : i64
-    %20 = arith.addi %19, %c1_i64_3 : i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %21 = arith.cmpi ult, %19, %c1_i64_4 : i64
-    %22 = arith.cmpi ult, %c1024_i64_2, %20 : i64
-    %23 = arith.xori %21, %22 : i1
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %23, ^bb1(%c92_i8_5 : i8), ^bb7
+    %19 = arith.cmpi ult, %17, %c1_i64_3 : i64
+    %20 = arith.cmpi ult, %c1024_i64_1, %18 : i64
+    %21 = arith.xori %19, %20 : i1
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %21, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %22 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %25 = arith.cmpi uge, %24, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %25, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %23 = arith.cmpi uge, %22, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %23, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %26 = arith.subi %24, %c3_i64_6 : i64
-    llvm.store %26, %arg1 : i64, !llvm.ptr
+    %24 = arith.subi %22, %c3_i64_5 : i64
+    llvm.store %24, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %27, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %25, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_dup2.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,71 +96,68 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %23 = llvm.getelementptr %22[-2] : (!llvm.ptr) -> !llvm.ptr, i256
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %26 = llvm.getelementptr %arg2[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %27 = arith.addi %25, %c1_i64_7 : i64
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    llvm.store %24, %26 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-2] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %22, %23 : i256, !llvm.ptr
+    %24 = llvm.getelementptr %23[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %28 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %29 = arith.addi %28, %c1_i64_9 : i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %26 = arith.addi %25, %c1_i64_7 : i64
+    llvm.store %26, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %30 = arith.cmpi ult, %28, %c2_i64 : i64
-    %31 = arith.cmpi ult, %c1024_i64_8, %29 : i64
-    %32 = arith.xori %30, %31 : i1
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %32, ^bb1(%c92_i8_10 : i8), ^bb11
+    %27 = arith.cmpi ult, %25, %c2_i64 : i64
+    %28 = arith.cmpi ult, %c1024_i64_6, %26 : i64
+    %29 = arith.xori %27, %28 : i1
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %29, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %31 = arith.cmpi uge, %30, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %31, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %35 = arith.subi %33, %c3_i64_11 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %32 = arith.subi %30, %c3_i64_9 : i64
+    llvm.store %32, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %33, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,255 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256_1 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c3735928559_i256 = arith.constant 3735928559 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c3735928559_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3735928559_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c10_i256 = arith.constant 10 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_14 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb16:  // pred: ^bb18
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_16 : i64
-    %35 = arith.cmpi ult, %c1024_i64_15, %34 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_17 : i8), ^bb15
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_13 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_12, %31 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_14 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_19 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_16 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_18 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_15 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb25
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_20 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %44 = arith.subi %43, %c1_i64_21 : i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %44, %arg3 : i64, !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %48 = arith.subi %47, %c1_i64_22 : i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i256
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %52 = arith.subi %51, %c1_i64_23 : i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %55 = arith.cmpi sgt, %54, %c18446744073709551615_i256 : i256
+    %48 = arith.cmpi sgt, %47, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %55, ^bb1(%c84_i8 : i8), ^bb20
+    cf.cond_br %48, ^bb1(%c84_i8 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %56 = arith.trunci %54 : i256 to i64
-    %c0_i64_24 = arith.constant 0 : i64
-    %57 = arith.cmpi slt, %56, %c0_i64_24 : i64
-    %c84_i8_25 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8_25 : i8), ^bb21
+    %49 = arith.trunci %47 : i256 to i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %50 = arith.cmpi slt, %49, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %50, ^bb1(%c84_i8_18 : i8), ^bb21
   ^bb21:  // pred: ^bb20
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %58 = arith.addi %56, %c31_i64 : i64
-    %59 = arith.divui %58, %c32_i64 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %60 = arith.muli %59, %c3_i64_26 : i64
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %62 = arith.cmpi ult, %61, %60 : i64
-    scf.if %62 {
+    %51 = arith.addi %49, %c31_i64 : i64
+    %52 = arith.divui %51, %c32_i64 : i64
+    %c3_i64_19 = arith.constant 3 : i64
+    %53 = arith.muli %52, %c3_i64_19 : i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %107 = arith.subi %61, %60 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb1(%c80_i8_27 : i8), ^bb22
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_20 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i64_28 = arith.constant 0 : i64
-    %63 = arith.cmpi ne, %56, %c0_i64_28 : i64
-    cf.cond_br %63, ^bb29, ^bb23
+    %c0_i64_21 = arith.constant 0 : i64
+    %56 = arith.cmpi ne, %49, %c0_i64_21 : i64
+    cf.cond_br %56, ^bb29, ^bb23
   ^bb23:  // 2 preds: ^bb22, ^bb33
-    %64 = arith.trunci %46 : i256 to i64
+    %57 = arith.trunci %41 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %65 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %42, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_29 = arith.constant 1 : i256
-    %66 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %50, %66 {alignment = 1 : i64} : i256, !llvm.ptr
-    %67 = call @dora_fn_ext_code_copy(%arg0, %65, %66, %56, %64) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %69 = llvm.load %68 : !llvm.ptr -> i64
-    %70 = llvm.load %arg1 : !llvm.ptr -> i64
-    %71 = arith.cmpi ult, %70, %69 : i64
-    scf.if %71 {
+    %58 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %58 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_22 = arith.constant 1 : i256
+    %59 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %44, %59 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = call @dora_fn_ext_code_copy(%arg0, %58, %59, %49, %57) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
+    %61 = llvm.getelementptr %60[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %63 = llvm.load %arg1 : !llvm.ptr -> i64
+    %64 = arith.cmpi ult, %63, %62 : i64
+    scf.if %64 {
     } else {
-      %107 = arith.subi %70, %69 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %63, %62 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %71, ^bb1(%c80_i8_30 : i8), ^bb24
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %64, ^bb1(%c80_i8_23 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_31 = arith.constant 1024 : i64
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_24 = arith.constant 1024 : i64
+    %65 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-4_i64 = arith.constant -4 : i64
-    %73 = arith.addi %72, %c-4_i64 : i64
+    %66 = arith.addi %65, %c-4_i64 : i64
+    llvm.store %66, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %74 = arith.cmpi ult, %72, %c4_i64 : i64
+    %67 = arith.cmpi ult, %65, %c4_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %74, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb19
   ^bb26:  // pred: ^bb15
-    %75 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_32 = arith.constant 0 : i64
+    %68 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_25 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %76 = arith.cmpi uge, %75, %c0_i64_32 : i64
-    %c80_i8_33 = arith.constant 80 : i8
-    cf.cond_br %76, ^bb27, ^bb1(%c80_i8_33 : i8)
+    %69 = arith.cmpi uge, %68, %c0_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %69, ^bb27, ^bb1(%c80_i8_26 : i8)
   ^bb27:  // pred: ^bb26
-    %77 = arith.subi %75, %c0_i64_32 : i64
-    llvm.store %77, %arg1 : i64, !llvm.ptr
+    %70 = arith.subi %68, %c0_i64_25 : i64
+    llvm.store %70, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_34 = arith.constant 0 : i64
+    %c0_i64_27 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_34, %c0_i64_34, %78, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %71 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb29:  // pred: ^bb22
-    %c18446744073709551615_i256_35 = arith.constant 18446744073709551615 : i256
-    %79 = arith.cmpi sgt, %46, %c18446744073709551615_i256_35 : i256
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %79, ^bb1(%c84_i8_36 : i8), ^bb30
+    %c18446744073709551615_i256_28 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %41, %c18446744073709551615_i256_28 : i256
+    %c84_i8_29 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_29 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %80 = arith.trunci %46 : i256 to i64
-    %c0_i64_37 = arith.constant 0 : i64
-    %81 = arith.cmpi slt, %80, %c0_i64_37 : i64
-    %c84_i8_38 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8_38 : i8), ^bb31
+    %73 = arith.trunci %41 : i256 to i64
+    %c0_i64_30 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_30 : i64
+    %c84_i8_31 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_31 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %82 = arith.addi %80, %56 : i64
-    %c0_i64_39 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_39 : i64
-    %c84_i8_40 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_40 : i8), ^bb32
+    %75 = arith.addi %73, %49 : i64
+    %c0_i64_32 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_32 : i64
+    %c84_i8_33 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_33 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_41 = arith.constant 31 : i64
-    %c32_i64_42 = arith.constant 32 : i64
-    %84 = arith.addi %82, %c31_i64_41 : i64
-    %85 = arith.divui %84, %c32_i64_42 : i64
-    %c32_i64_43 = arith.constant 32 : i64
-    %86 = arith.muli %85, %c32_i64_43 : i64
-    %87 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_44 = arith.constant 31 : i64
-    %c32_i64_45 = arith.constant 32 : i64
-    %88 = arith.addi %87, %c31_i64_44 : i64
-    %89 = arith.divui %88, %c32_i64_45 : i64
-    %90 = arith.muli %89, %c32_i64_43 : i64
-    %91 = arith.cmpi ult, %90, %86 : i64
-    cf.cond_br %91, ^bb34, ^bb33
+    %c31_i64_34 = arith.constant 31 : i64
+    %c32_i64_35 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_34 : i64
+    %78 = arith.divui %77, %c32_i64_35 : i64
+    %c32_i64_36 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_36 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_37 = arith.constant 31 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_37 : i64
+    %82 = arith.divui %81, %c32_i64_38 : i64
+    %83 = arith.muli %82, %c32_i64_36 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb23
   ^bb34:  // pred: ^bb32
-    %c3_i64_46 = arith.constant 3 : i64
+    %c3_i64_39 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %92 = arith.muli %89, %89 : i64
-    %93 = arith.divui %92, %c512_i64 : i64
-    %94 = arith.muli %89, %c3_i64_46 : i64
-    %95 = arith.addi %93, %94 : i64
-    %c3_i64_47 = arith.constant 3 : i64
-    %c512_i64_48 = arith.constant 512 : i64
-    %96 = arith.muli %85, %85 : i64
-    %97 = arith.divui %96, %c512_i64_48 : i64
-    %98 = arith.muli %85, %c3_i64_47 : i64
-    %99 = arith.addi %97, %98 : i64
-    %100 = arith.subi %99, %95 : i64
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %102 = arith.cmpi ult, %101, %100 : i64
-    scf.if %102 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_39 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_40 = arith.constant 3 : i64
+    %c512_i64_41 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_41 : i64
+    %91 = arith.muli %78, %c3_i64_40 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %107 = arith.subi %101, %100 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_49 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb1(%c80_i8_49 : i8), ^bb35
+    %c80_i8_42 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_42 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %103 = call @dora_fn_extend_memory(%arg0, %86) : (!llvm.ptr, i64) -> !llvm.ptr
-    %104 = llvm.getelementptr %103[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %105 = llvm.load %104 : !llvm.ptr -> i8
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %106 = arith.cmpi ne, %105, %c0_i8 : i8
-    cf.cond_br %106, ^bb1(%105 : i8), ^bb36
+    %99 = arith.cmpi ne, %98, %c0_i8 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_out_of_bounds.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,255 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c50_i256 = arith.constant 50 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c50_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c50_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c3735928559_i256 = arith.constant 3735928559 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c3735928559_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3735928559_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c10_i256 = arith.constant 10 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb25
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_19 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %44 = arith.subi %43, %c1_i64_20 : i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %44, %arg3 : i64, !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %48 = arith.subi %47, %c1_i64_21 : i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i256
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %52 = arith.subi %51, %c1_i64_22 : i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %55 = arith.cmpi sgt, %54, %c18446744073709551615_i256 : i256
+    %48 = arith.cmpi sgt, %47, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %55, ^bb1(%c84_i8 : i8), ^bb20
+    cf.cond_br %48, ^bb1(%c84_i8 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %56 = arith.trunci %54 : i256 to i64
-    %c0_i64_23 = arith.constant 0 : i64
-    %57 = arith.cmpi slt, %56, %c0_i64_23 : i64
-    %c84_i8_24 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8_24 : i8), ^bb21
+    %49 = arith.trunci %47 : i256 to i64
+    %c0_i64_16 = arith.constant 0 : i64
+    %50 = arith.cmpi slt, %49, %c0_i64_16 : i64
+    %c84_i8_17 = arith.constant 84 : i8
+    cf.cond_br %50, ^bb1(%c84_i8_17 : i8), ^bb21
   ^bb21:  // pred: ^bb20
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %58 = arith.addi %56, %c31_i64 : i64
-    %59 = arith.divui %58, %c32_i64 : i64
-    %c3_i64_25 = arith.constant 3 : i64
-    %60 = arith.muli %59, %c3_i64_25 : i64
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %62 = arith.cmpi ult, %61, %60 : i64
-    scf.if %62 {
+    %51 = arith.addi %49, %c31_i64 : i64
+    %52 = arith.divui %51, %c32_i64 : i64
+    %c3_i64_18 = arith.constant 3 : i64
+    %53 = arith.muli %52, %c3_i64_18 : i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %107 = arith.subi %61, %60 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb1(%c80_i8_26 : i8), ^bb22
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_19 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i64_27 = arith.constant 0 : i64
-    %63 = arith.cmpi ne, %56, %c0_i64_27 : i64
-    cf.cond_br %63, ^bb29, ^bb23
+    %c0_i64_20 = arith.constant 0 : i64
+    %56 = arith.cmpi ne, %49, %c0_i64_20 : i64
+    cf.cond_br %56, ^bb29, ^bb23
   ^bb23:  // 2 preds: ^bb22, ^bb33
-    %64 = arith.trunci %46 : i256 to i64
+    %57 = arith.trunci %41 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %65 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %42, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_28 = arith.constant 1 : i256
-    %66 = llvm.alloca %c1_i256_28 x i256 : (i256) -> !llvm.ptr
-    llvm.store %50, %66 {alignment = 1 : i64} : i256, !llvm.ptr
-    %67 = call @dora_fn_ext_code_copy(%arg0, %65, %66, %56, %64) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %69 = llvm.load %68 : !llvm.ptr -> i64
-    %70 = llvm.load %arg1 : !llvm.ptr -> i64
-    %71 = arith.cmpi ult, %70, %69 : i64
-    scf.if %71 {
+    %58 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %58 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_21 = arith.constant 1 : i256
+    %59 = llvm.alloca %c1_i256_21 x i256 : (i256) -> !llvm.ptr
+    llvm.store %44, %59 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = call @dora_fn_ext_code_copy(%arg0, %58, %59, %49, %57) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
+    %61 = llvm.getelementptr %60[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %63 = llvm.load %arg1 : !llvm.ptr -> i64
+    %64 = arith.cmpi ult, %63, %62 : i64
+    scf.if %64 {
     } else {
-      %107 = arith.subi %70, %69 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %63, %62 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %71, ^bb1(%c80_i8_29 : i8), ^bb24
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %64, ^bb1(%c80_i8_22 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_30 = arith.constant 1024 : i64
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %65 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-4_i64 = arith.constant -4 : i64
-    %73 = arith.addi %72, %c-4_i64 : i64
+    %66 = arith.addi %65, %c-4_i64 : i64
+    llvm.store %66, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %74 = arith.cmpi ult, %72, %c4_i64 : i64
+    %67 = arith.cmpi ult, %65, %c4_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %74, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb19
   ^bb26:  // pred: ^bb15
-    %75 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_31 = arith.constant 0 : i64
+    %68 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_24 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %76 = arith.cmpi uge, %75, %c0_i64_31 : i64
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %76, ^bb27, ^bb1(%c80_i8_32 : i8)
+    %69 = arith.cmpi uge, %68, %c0_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %69, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %77 = arith.subi %75, %c0_i64_31 : i64
-    llvm.store %77, %arg1 : i64, !llvm.ptr
+    %70 = arith.subi %68, %c0_i64_24 : i64
+    llvm.store %70, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_33 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_33, %c0_i64_33, %78, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %71 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb29:  // pred: ^bb22
-    %c18446744073709551615_i256_34 = arith.constant 18446744073709551615 : i256
-    %79 = arith.cmpi sgt, %46, %c18446744073709551615_i256_34 : i256
-    %c84_i8_35 = arith.constant 84 : i8
-    cf.cond_br %79, ^bb1(%c84_i8_35 : i8), ^bb30
+    %c18446744073709551615_i256_27 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %41, %c18446744073709551615_i256_27 : i256
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_28 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %80 = arith.trunci %46 : i256 to i64
-    %c0_i64_36 = arith.constant 0 : i64
-    %81 = arith.cmpi slt, %80, %c0_i64_36 : i64
-    %c84_i8_37 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8_37 : i8), ^bb31
+    %73 = arith.trunci %41 : i256 to i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_29 : i64
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_30 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %82 = arith.addi %80, %56 : i64
-    %c0_i64_38 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_38 : i64
-    %c84_i8_39 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_39 : i8), ^bb32
+    %75 = arith.addi %73, %49 : i64
+    %c0_i64_31 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_31 : i64
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_32 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_40 = arith.constant 31 : i64
-    %c32_i64_41 = arith.constant 32 : i64
-    %84 = arith.addi %82, %c31_i64_40 : i64
-    %85 = arith.divui %84, %c32_i64_41 : i64
-    %c32_i64_42 = arith.constant 32 : i64
-    %86 = arith.muli %85, %c32_i64_42 : i64
-    %87 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_43 = arith.constant 31 : i64
-    %c32_i64_44 = arith.constant 32 : i64
-    %88 = arith.addi %87, %c31_i64_43 : i64
-    %89 = arith.divui %88, %c32_i64_44 : i64
-    %90 = arith.muli %89, %c32_i64_42 : i64
-    %91 = arith.cmpi ult, %90, %86 : i64
-    cf.cond_br %91, ^bb34, ^bb33
+    %c31_i64_33 = arith.constant 31 : i64
+    %c32_i64_34 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_33 : i64
+    %78 = arith.divui %77, %c32_i64_34 : i64
+    %c32_i64_35 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_35 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_36 = arith.constant 31 : i64
+    %c32_i64_37 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_36 : i64
+    %82 = arith.divui %81, %c32_i64_37 : i64
+    %83 = arith.muli %82, %c32_i64_35 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb23
   ^bb34:  // pred: ^bb32
-    %c3_i64_45 = arith.constant 3 : i64
+    %c3_i64_38 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %92 = arith.muli %89, %89 : i64
-    %93 = arith.divui %92, %c512_i64 : i64
-    %94 = arith.muli %89, %c3_i64_45 : i64
-    %95 = arith.addi %93, %94 : i64
-    %c3_i64_46 = arith.constant 3 : i64
-    %c512_i64_47 = arith.constant 512 : i64
-    %96 = arith.muli %85, %85 : i64
-    %97 = arith.divui %96, %c512_i64_47 : i64
-    %98 = arith.muli %85, %c3_i64_46 : i64
-    %99 = arith.addi %97, %98 : i64
-    %100 = arith.subi %99, %95 : i64
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %102 = arith.cmpi ult, %101, %100 : i64
-    scf.if %102 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_38 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_39 = arith.constant 3 : i64
+    %c512_i64_40 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_40 : i64
+    %91 = arith.muli %78, %c3_i64_39 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %107 = arith.subi %101, %100 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb1(%c80_i8_48 : i8), ^bb35
+    %c80_i8_41 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_41 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %103 = call @dora_fn_extend_memory(%arg0, %86) : (!llvm.ptr, i64) -> !llvm.ptr
-    %104 = llvm.getelementptr %103[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %105 = llvm.load %104 : !llvm.ptr -> i8
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %106 = arith.cmpi ne, %105, %c0_i8 : i8
-    cf.cond_br %106, ^bb1(%105 : i8), ^bb36
+    %99 = arith.cmpi ne, %98, %c0_i8 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodecopy_partial.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 20 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb19, ^bb20, ^bb21, ^bb23, ^bb25, ^bb26, ^bb29, ^bb30, ^bb31, ^bb34, ^bb35
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,255 +96,245 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c5_i256 = arith.constant 5 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c5_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c5_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c3735928559_i256 = arith.constant 3735928559 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c3735928559_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3735928559_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %c5_i256_13 = arith.constant 5 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_14 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c5_i256_13, %31 : i256, !llvm.ptr
+    %c5_i256_11 = arith.constant 5 : i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c5_i256_11, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb16:  // pred: ^bb18
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_16 : i64
-    %35 = arith.cmpi ult, %c1024_i64_15, %34 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_17 : i8), ^bb15
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_13 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_12, %31 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_14 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_19 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_16 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_18 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_15 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb25
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_20 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %44 = arith.subi %43, %c1_i64_21 : i64
-    %45 = llvm.getelementptr %arg2[%44] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %44, %arg3 : i64, !llvm.ptr
-    %46 = llvm.load %45 : !llvm.ptr -> i256
-    %47 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %48 = arith.subi %47, %c1_i64_22 : i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    %50 = llvm.load %49 : !llvm.ptr -> i256
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %52 = arith.subi %51, %c1_i64_23 : i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    %54 = llvm.load %53 : !llvm.ptr -> i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %55 = arith.cmpi sgt, %54, %c18446744073709551615_i256 : i256
+    %48 = arith.cmpi sgt, %47, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %55, ^bb1(%c84_i8 : i8), ^bb20
+    cf.cond_br %48, ^bb1(%c84_i8 : i8), ^bb20
   ^bb20:  // pred: ^bb19
-    %56 = arith.trunci %54 : i256 to i64
-    %c0_i64_24 = arith.constant 0 : i64
-    %57 = arith.cmpi slt, %56, %c0_i64_24 : i64
-    %c84_i8_25 = arith.constant 84 : i8
-    cf.cond_br %57, ^bb1(%c84_i8_25 : i8), ^bb21
+    %49 = arith.trunci %47 : i256 to i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %50 = arith.cmpi slt, %49, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %50, ^bb1(%c84_i8_18 : i8), ^bb21
   ^bb21:  // pred: ^bb20
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %58 = arith.addi %56, %c31_i64 : i64
-    %59 = arith.divui %58, %c32_i64 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %60 = arith.muli %59, %c3_i64_26 : i64
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %62 = arith.cmpi ult, %61, %60 : i64
-    scf.if %62 {
+    %51 = arith.addi %49, %c31_i64 : i64
+    %52 = arith.divui %51, %c32_i64 : i64
+    %c3_i64_19 = arith.constant 3 : i64
+    %53 = arith.muli %52, %c3_i64_19 : i64
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    %55 = arith.cmpi ult, %54, %53 : i64
+    scf.if %55 {
     } else {
-      %107 = arith.subi %61, %60 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %54, %53 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb1(%c80_i8_27 : i8), ^bb22
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %55, ^bb1(%c80_i8_20 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %c0_i64_28 = arith.constant 0 : i64
-    %63 = arith.cmpi ne, %56, %c0_i64_28 : i64
-    cf.cond_br %63, ^bb29, ^bb23
+    %c0_i64_21 = arith.constant 0 : i64
+    %56 = arith.cmpi ne, %49, %c0_i64_21 : i64
+    cf.cond_br %56, ^bb29, ^bb23
   ^bb23:  // 2 preds: ^bb22, ^bb33
-    %64 = arith.trunci %46 : i256 to i64
+    %57 = arith.trunci %41 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %65 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %42, %65 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_29 = arith.constant 1 : i256
-    %66 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %50, %66 {alignment = 1 : i64} : i256, !llvm.ptr
-    %67 = call @dora_fn_ext_code_copy(%arg0, %65, %66, %56, %64) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
-    %68 = llvm.getelementptr %67[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %69 = llvm.load %68 : !llvm.ptr -> i64
-    %70 = llvm.load %arg1 : !llvm.ptr -> i64
-    %71 = arith.cmpi ult, %70, %69 : i64
-    scf.if %71 {
+    %58 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %38, %58 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_22 = arith.constant 1 : i256
+    %59 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %44, %59 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = call @dora_fn_ext_code_copy(%arg0, %58, %59, %49, %57) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
+    %61 = llvm.getelementptr %60[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %62 = llvm.load %61 : !llvm.ptr -> i64
+    %63 = llvm.load %arg1 : !llvm.ptr -> i64
+    %64 = arith.cmpi ult, %63, %62 : i64
+    scf.if %64 {
     } else {
-      %107 = arith.subi %70, %69 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %63, %62 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %71, ^bb1(%c80_i8_30 : i8), ^bb24
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %64, ^bb1(%c80_i8_23 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_31 = arith.constant 1024 : i64
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_24 = arith.constant 1024 : i64
+    %65 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-4_i64 = arith.constant -4 : i64
-    %73 = arith.addi %72, %c-4_i64 : i64
+    %66 = arith.addi %65, %c-4_i64 : i64
+    llvm.store %66, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %74 = arith.cmpi ult, %72, %c4_i64 : i64
+    %67 = arith.cmpi ult, %65, %c4_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %74, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %67, ^bb1(%c91_i8 : i8), ^bb19
   ^bb26:  // pred: ^bb15
-    %75 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_32 = arith.constant 0 : i64
+    %68 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_25 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %76 = arith.cmpi uge, %75, %c0_i64_32 : i64
-    %c80_i8_33 = arith.constant 80 : i8
-    cf.cond_br %76, ^bb27, ^bb1(%c80_i8_33 : i8)
+    %69 = arith.cmpi uge, %68, %c0_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %69, ^bb27, ^bb1(%c80_i8_26 : i8)
   ^bb27:  // pred: ^bb26
-    %77 = arith.subi %75, %c0_i64_32 : i64
-    llvm.store %77, %arg1 : i64, !llvm.ptr
+    %70 = arith.subi %68, %c0_i64_25 : i64
+    llvm.store %70, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_34 = arith.constant 0 : i64
+    %c0_i64_27 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_34, %c0_i64_34, %78, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %71 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb29:  // pred: ^bb22
-    %c18446744073709551615_i256_35 = arith.constant 18446744073709551615 : i256
-    %79 = arith.cmpi sgt, %46, %c18446744073709551615_i256_35 : i256
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %79, ^bb1(%c84_i8_36 : i8), ^bb30
+    %c18446744073709551615_i256_28 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %41, %c18446744073709551615_i256_28 : i256
+    %c84_i8_29 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_29 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %80 = arith.trunci %46 : i256 to i64
-    %c0_i64_37 = arith.constant 0 : i64
-    %81 = arith.cmpi slt, %80, %c0_i64_37 : i64
-    %c84_i8_38 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8_38 : i8), ^bb31
+    %73 = arith.trunci %41 : i256 to i64
+    %c0_i64_30 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_30 : i64
+    %c84_i8_31 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_31 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %82 = arith.addi %80, %56 : i64
-    %c0_i64_39 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_39 : i64
-    %c84_i8_40 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_40 : i8), ^bb32
+    %75 = arith.addi %73, %49 : i64
+    %c0_i64_32 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_32 : i64
+    %c84_i8_33 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_33 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c31_i64_41 = arith.constant 31 : i64
-    %c32_i64_42 = arith.constant 32 : i64
-    %84 = arith.addi %82, %c31_i64_41 : i64
-    %85 = arith.divui %84, %c32_i64_42 : i64
-    %c32_i64_43 = arith.constant 32 : i64
-    %86 = arith.muli %85, %c32_i64_43 : i64
-    %87 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_44 = arith.constant 31 : i64
-    %c32_i64_45 = arith.constant 32 : i64
-    %88 = arith.addi %87, %c31_i64_44 : i64
-    %89 = arith.divui %88, %c32_i64_45 : i64
-    %90 = arith.muli %89, %c32_i64_43 : i64
-    %91 = arith.cmpi ult, %90, %86 : i64
-    cf.cond_br %91, ^bb34, ^bb33
+    %c31_i64_34 = arith.constant 31 : i64
+    %c32_i64_35 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64_34 : i64
+    %78 = arith.divui %77, %c32_i64_35 : i64
+    %c32_i64_36 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_36 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_37 = arith.constant 31 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_37 : i64
+    %82 = arith.divui %81, %c32_i64_38 : i64
+    %83 = arith.muli %82, %c32_i64_36 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb34, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb36
     cf.br ^bb23
   ^bb34:  // pred: ^bb32
-    %c3_i64_46 = arith.constant 3 : i64
+    %c3_i64_39 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %92 = arith.muli %89, %89 : i64
-    %93 = arith.divui %92, %c512_i64 : i64
-    %94 = arith.muli %89, %c3_i64_46 : i64
-    %95 = arith.addi %93, %94 : i64
-    %c3_i64_47 = arith.constant 3 : i64
-    %c512_i64_48 = arith.constant 512 : i64
-    %96 = arith.muli %85, %85 : i64
-    %97 = arith.divui %96, %c512_i64_48 : i64
-    %98 = arith.muli %85, %c3_i64_47 : i64
-    %99 = arith.addi %97, %98 : i64
-    %100 = arith.subi %99, %95 : i64
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %102 = arith.cmpi ult, %101, %100 : i64
-    scf.if %102 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_39 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_40 = arith.constant 3 : i64
+    %c512_i64_41 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_41 : i64
+    %91 = arith.muli %78, %c3_i64_40 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %107 = arith.subi %101, %100 : i64
-      llvm.store %107, %arg1 : i64, !llvm.ptr
+      %100 = arith.subi %94, %93 : i64
+      llvm.store %100, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_49 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb1(%c80_i8_49 : i8), ^bb35
+    %c80_i8_42 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_42 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %103 = call @dora_fn_extend_memory(%arg0, %86) : (!llvm.ptr, i64) -> !llvm.ptr
-    %104 = llvm.getelementptr %103[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %105 = llvm.load %104 : !llvm.ptr -> i8
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %106 = arith.cmpi ne, %105, %c0_i8 : i8
-    cf.cond_br %106, ^bb1(%105 : i8), ^bb36
+    %99 = arith.cmpi ne, %98, %c0_i8 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     cf.br ^bb33
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c3735928559_i256 = arith.constant 3735928559 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c3735928559_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,63 +95,60 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    %17 = call @dora_fn_extcodesize(%arg0, %16) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %18 = llvm.getelementptr %17[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %19 = llvm.load %18 : !llvm.ptr -> i64
-    %20 = llvm.getelementptr %17[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %21 = llvm.load %20 : !llvm.ptr -> i64
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    %23 = arith.cmpi ult, %22, %21 : i64
-    scf.if %23 {
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    %16 = call @dora_fn_extcodesize(%arg0, %15) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %17 = llvm.getelementptr %16[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %18 = llvm.load %17 : !llvm.ptr -> i64
+    %19 = llvm.getelementptr %16[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %20 = llvm.load %19 : !llvm.ptr -> i64
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    %22 = arith.cmpi ult, %21, %20 : i64
+    scf.if %22 {
     } else {
-      %35 = arith.subi %22, %21 : i64
-      llvm.store %35, %arg1 : i64, !llvm.ptr
+      %33 = arith.subi %21, %20 : i64
+      llvm.store %33, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %23, ^bb1(%c80_i8_2 : i8), ^bb8
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %22, ^bb1(%c80_i8_1 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %24 = arith.extui %19 : i64 to i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %26 = llvm.getelementptr %arg2[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %27 = arith.addi %25, %c1_i64_3 : i64
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    llvm.store %24, %26 : i256, !llvm.ptr
+    %23 = arith.extui %18 : i64 to i256
+    %24 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %23, %24 : i256, !llvm.ptr
+    %25 = llvm.getelementptr %24[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %25, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %28 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %29 = arith.addi %28, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %30 = arith.cmpi ult, %28, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %26 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %27 = arith.addi %26, %c0_i64_3 : i64
+    llvm.store %27, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %28 = arith.cmpi ult, %26, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %30, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %28, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_7 = arith.constant 0 : i64
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %32 = arith.cmpi uge, %31, %c0_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb11, ^bb1(%c80_i8_8 : i8)
+    %30 = arith.cmpi uge, %29, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %30, ^bb11, ^bb1(%c80_i8_6 : i8)
   ^bb11:  // pred: ^bb10
-    %33 = arith.subi %31, %c0_i64_7 : i64
-    llvm.store %33, %arg1 : i64, !llvm.ptr
+    %31 = arith.subi %29, %c0_i64_5 : i64
+    llvm.store %31, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %34, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %32, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize_nonexistent.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_extcodesize_nonexistent.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,63 +95,60 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    %17 = call @dora_fn_extcodesize(%arg0, %16) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %18 = llvm.getelementptr %17[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %19 = llvm.load %18 : !llvm.ptr -> i64
-    %20 = llvm.getelementptr %17[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %21 = llvm.load %20 : !llvm.ptr -> i64
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    %23 = arith.cmpi ult, %22, %21 : i64
-    scf.if %23 {
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    %16 = call @dora_fn_extcodesize(%arg0, %15) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %17 = llvm.getelementptr %16[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %18 = llvm.load %17 : !llvm.ptr -> i64
+    %19 = llvm.getelementptr %16[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %20 = llvm.load %19 : !llvm.ptr -> i64
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    %22 = arith.cmpi ult, %21, %20 : i64
+    scf.if %22 {
     } else {
-      %35 = arith.subi %22, %21 : i64
-      llvm.store %35, %arg1 : i64, !llvm.ptr
+      %33 = arith.subi %21, %20 : i64
+      llvm.store %33, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %23, ^bb1(%c80_i8_2 : i8), ^bb8
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %22, ^bb1(%c80_i8_1 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %24 = arith.extui %19 : i64 to i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %26 = llvm.getelementptr %arg2[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %27 = arith.addi %25, %c1_i64_3 : i64
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    llvm.store %24, %26 : i256, !llvm.ptr
+    %23 = arith.extui %18 : i64 to i256
+    %24 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %23, %24 : i256, !llvm.ptr
+    %25 = llvm.getelementptr %24[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %25, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %28 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %29 = arith.addi %28, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %30 = arith.cmpi ult, %28, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %26 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %27 = arith.addi %26, %c0_i64_3 : i64
+    llvm.store %27, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %28 = arith.cmpi ult, %26, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %30, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %28, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_7 = arith.constant 0 : i64
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %32 = arith.cmpi uge, %31, %c0_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb11, ^bb1(%c80_i8_8 : i8)
+    %30 = arith.cmpi uge, %29, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %30, ^bb11, ^bb1(%c80_i8_6 : i8)
   ^bb11:  // pred: ^bb10
-    %33 = arith.subi %31, %c0_i64_7 : i64
-    llvm.store %33, %arg1 : i64, !llvm.ptr
+    %31 = arith.subi %29, %c0_i64_5 : i64
+    llvm.store %31, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %34, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %32, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 11 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 11 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = llvm.load %arg1 : !llvm.ptr -> i64
-    %4 = arith.extui %3 : i64 to i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.load %arg1 : !llvm.ptr -> i64
+    %5 = arith.extui %4 : i64 to i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,150 +97,138 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c21000_i256 = arith.constant 21000 : i256
-    %14 = llvm.load %arg3 : !llvm.ptr -> i64
-    %15 = llvm.getelementptr %arg2[%14] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %16 = arith.addi %14, %c1_i64_1 : i64
-    llvm.store %16, %arg3 : i64, !llvm.ptr
-    llvm.store %c21000_i256, %15 : i256, !llvm.ptr
+    %14 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c21000_i256, %14 : i256, !llvm.ptr
+    %15 = llvm.getelementptr %14[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %15, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %17 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.addi %17, %c1_i64_3 : i64
-    %19 = arith.cmpi ult, %c1024_i64_2, %18 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %19, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.addi %16, %c1_i64_2 : i64
+    llvm.store %17, %arg3 : i64, !llvm.ptr
+    %18 = arith.cmpi ult, %c1024_i64_1, %17 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %18, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %20 = llvm.load %arg1 : !llvm.ptr -> i64
+    %19 = llvm.load %arg1 : !llvm.ptr -> i64
     %c3_i64 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %21 = arith.cmpi uge, %20, %c3_i64 : i64
-    %c80_i8_5 = arith.constant 80 : i8
-    cf.cond_br %21, ^bb10, ^bb1(%c80_i8_5 : i8)
+    %20 = arith.cmpi uge, %19, %c3_i64 : i64
+    %c80_i8_4 = arith.constant 80 : i8
+    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
   ^bb10:  // pred: ^bb9
-    %22 = arith.subi %20, %c3_i64 : i64
-    llvm.store %22, %arg1 : i64, !llvm.ptr
+    %21 = arith.subi %19, %c3_i64 : i64
+    llvm.store %21, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %23 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_store_in_gaslimit_ptr(%arg0, %23) : (!llvm.ptr, !llvm.ptr) -> ()
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %26 = llvm.getelementptr %arg2[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_6 = arith.constant 1 : i64
-    %27 = arith.addi %25, %c1_i64_6 : i64
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    llvm.store %24, %26 : i256, !llvm.ptr
+    %22 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_store_in_gaslimit_ptr(%arg0, %22) : (!llvm.ptr, !llvm.ptr) -> ()
+    %23 = llvm.load %22 : !llvm.ptr -> i256
+    %24 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %23, %24 : i256, !llvm.ptr
+    %25 = llvm.getelementptr %24[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %25, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_7 = arith.constant 1024 : i64
-    %28 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %29 = arith.addi %28, %c1_i64_8 : i64
-    %30 = arith.cmpi ult, %c1024_i64_7, %29 : i64
-    %c92_i8_9 = arith.constant 92 : i8
-    cf.cond_br %30, ^bb1(%c92_i8_9 : i8), ^bb11
+    %c1024_i64_5 = arith.constant 1024 : i64
+    %26 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_6 = arith.constant 1 : i64
+    %27 = arith.addi %26, %c1_i64_6 : i64
+    llvm.store %27, %arg3 : i64, !llvm.ptr
+    %28 = arith.cmpi ult, %c1024_i64_5, %27 : i64
+    %c92_i8_7 = arith.constant 92 : i8
+    cf.cond_br %28, ^bb1(%c92_i8_7 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_10 = arith.constant 2 : i64
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_8 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %32 = arith.cmpi uge, %31, %c2_i64_10 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %30 = arith.cmpi uge, %29, %c2_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %30, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %33 = arith.subi %31, %c2_i64_10 : i64
-    llvm.store %33, %arg1 : i64, !llvm.ptr
+    %31 = arith.subi %29, %c2_i64_8 : i64
+    llvm.store %31, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_12 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_12 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
+    %32 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %33 = llvm.getelementptr %32[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %34 = llvm.load %33 : !llvm.ptr -> i256
+    llvm.store %33, %0 : !llvm.ptr, !llvm.ptr
+    %35 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %35[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_13 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = arith.subi %37, %41 : i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %44 = llvm.getelementptr %arg2[%43] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %45 = arith.addi %43, %c1_i64_14 : i64
-    llvm.store %45, %arg3 : i64, !llvm.ptr
-    llvm.store %42, %44 : i256, !llvm.ptr
+    llvm.store %36, %0 : !llvm.ptr, !llvm.ptr
+    %38 = arith.subi %34, %37 : i256
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %38, %39 : i256, !llvm.ptr
+    %40 = llvm.getelementptr %39[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %41 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %47 = arith.addi %46, %c-1_i64 : i64
-    %c2_i64_16 = arith.constant 2 : i64
-    %48 = arith.cmpi ult, %46, %c2_i64_16 : i64
+    %42 = arith.addi %41, %c-1_i64 : i64
+    llvm.store %42, %arg3 : i64, !llvm.ptr
+    %c2_i64_11 = arith.constant 2 : i64
+    %43 = arith.cmpi ult, %41, %c2_i64_11 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %48, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %43, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %49 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %44 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %50 = arith.cmpi uge, %49, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %50, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %45 = arith.cmpi uge, %44, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %45, ^bb18, ^bb1(%c80_i8_13 : i8)
   ^bb18:  // pred: ^bb17
-    %51 = arith.subi %49, %c3_i64_17 : i64
-    llvm.store %51, %arg1 : i64, !llvm.ptr
+    %46 = arith.subi %44, %c3_i64_12 : i64
+    llvm.store %46, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %53 = arith.subi %52, %c1_i64_19 : i64
-    %54 = llvm.getelementptr %arg2[%53] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %53, %arg3 : i64, !llvm.ptr
-    %55 = llvm.load %54 : !llvm.ptr -> i256
-    %56 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %57 = arith.subi %56, %c1_i64_20 : i64
-    %58 = llvm.getelementptr %arg2[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    %59 = llvm.load %58 : !llvm.ptr -> i256
-    %60 = arith.subi %55, %59 : i256
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %62 = llvm.getelementptr %arg2[%61] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %63 = arith.addi %61, %c1_i64_21 : i64
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
+    %47 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %49 = llvm.load %48 : !llvm.ptr -> i256
+    llvm.store %48, %0 : !llvm.ptr, !llvm.ptr
+    %50 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %52 = llvm.load %51 : !llvm.ptr -> i256
+    llvm.store %51, %0 : !llvm.ptr, !llvm.ptr
+    %53 = arith.subi %49, %52 : i256
+    %54 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %53, %54 : i256, !llvm.ptr
+    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %55, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb20:  // pred: ^bb22
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_23 = arith.constant -1 : i64
-    %65 = arith.addi %64, %c-1_i64_23 : i64
-    %c2_i64_24 = arith.constant 2 : i64
-    %66 = arith.cmpi ult, %64, %c2_i64_24 : i64
-    %c91_i8_25 = arith.constant 91 : i8
-    cf.cond_br %66, ^bb1(%c91_i8_25 : i8), ^bb19
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %56 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_15 = arith.constant -1 : i64
+    %57 = arith.addi %56, %c-1_i64_15 : i64
+    llvm.store %57, %arg3 : i64, !llvm.ptr
+    %c2_i64_16 = arith.constant 2 : i64
+    %58 = arith.cmpi ult, %56, %c2_i64_16 : i64
+    %c91_i8_17 = arith.constant 91 : i8
+    cf.cond_br %58, ^bb1(%c91_i8_17 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %67 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_26 = arith.constant 3 : i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %68 = arith.cmpi uge, %67, %c3_i64_26 : i64
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %68, ^bb22, ^bb1(%c80_i8_27 : i8)
+    %60 = arith.cmpi uge, %59, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb22, ^bb1(%c80_i8_19 : i8)
   ^bb22:  // pred: ^bb21
-    %69 = arith.subi %67, %c3_i64_26 : i64
-    llvm.store %69, %arg1 : i64, !llvm.ptr
+    %61 = arith.subi %59, %c3_i64_18 : i64
+    llvm.store %61, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb19
-    %c0_i64_28 = arith.constant 0 : i64
+    %c0_i64_20 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %70 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_28, %c0_i64_28, %70, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_20, %c0_i64_20, %62, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas_gaslimit.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_gas_gaslimit.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 11 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 11 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = llvm.load %arg1 : !llvm.ptr -> i64
-    %4 = arith.extui %3 : i64 to i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.load %arg1 : !llvm.ptr -> i64
+    %5 = arith.extui %4 : i64 to i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,150 +97,138 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c21000_i256 = arith.constant 21000 : i256
-    %14 = llvm.load %arg3 : !llvm.ptr -> i64
-    %15 = llvm.getelementptr %arg2[%14] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %16 = arith.addi %14, %c1_i64_1 : i64
-    llvm.store %16, %arg3 : i64, !llvm.ptr
-    llvm.store %c21000_i256, %15 : i256, !llvm.ptr
+    %14 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c21000_i256, %14 : i256, !llvm.ptr
+    %15 = llvm.getelementptr %14[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %15, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %17 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.addi %17, %c1_i64_3 : i64
-    %19 = arith.cmpi ult, %c1024_i64_2, %18 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %19, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.addi %16, %c1_i64_2 : i64
+    llvm.store %17, %arg3 : i64, !llvm.ptr
+    %18 = arith.cmpi ult, %c1024_i64_1, %17 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %18, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %20 = llvm.load %arg1 : !llvm.ptr -> i64
+    %19 = llvm.load %arg1 : !llvm.ptr -> i64
     %c3_i64 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %21 = arith.cmpi uge, %20, %c3_i64 : i64
-    %c80_i8_5 = arith.constant 80 : i8
-    cf.cond_br %21, ^bb10, ^bb1(%c80_i8_5 : i8)
+    %20 = arith.cmpi uge, %19, %c3_i64 : i64
+    %c80_i8_4 = arith.constant 80 : i8
+    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
   ^bb10:  // pred: ^bb9
-    %22 = arith.subi %20, %c3_i64 : i64
-    llvm.store %22, %arg1 : i64, !llvm.ptr
+    %21 = arith.subi %19, %c3_i64 : i64
+    llvm.store %21, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %23 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_store_in_gaslimit_ptr(%arg0, %23) : (!llvm.ptr, !llvm.ptr) -> ()
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %26 = llvm.getelementptr %arg2[%25] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_6 = arith.constant 1 : i64
-    %27 = arith.addi %25, %c1_i64_6 : i64
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    llvm.store %24, %26 : i256, !llvm.ptr
+    %22 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_store_in_gaslimit_ptr(%arg0, %22) : (!llvm.ptr, !llvm.ptr) -> ()
+    %23 = llvm.load %22 : !llvm.ptr -> i256
+    %24 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %23, %24 : i256, !llvm.ptr
+    %25 = llvm.getelementptr %24[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %25, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_7 = arith.constant 1024 : i64
-    %28 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %29 = arith.addi %28, %c1_i64_8 : i64
-    %30 = arith.cmpi ult, %c1024_i64_7, %29 : i64
-    %c92_i8_9 = arith.constant 92 : i8
-    cf.cond_br %30, ^bb1(%c92_i8_9 : i8), ^bb11
+    %c1024_i64_5 = arith.constant 1024 : i64
+    %26 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_6 = arith.constant 1 : i64
+    %27 = arith.addi %26, %c1_i64_6 : i64
+    llvm.store %27, %arg3 : i64, !llvm.ptr
+    %28 = arith.cmpi ult, %c1024_i64_5, %27 : i64
+    %c92_i8_7 = arith.constant 92 : i8
+    cf.cond_br %28, ^bb1(%c92_i8_7 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_10 = arith.constant 2 : i64
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_8 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %32 = arith.cmpi uge, %31, %c2_i64_10 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %30 = arith.cmpi uge, %29, %c2_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %30, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %33 = arith.subi %31, %c2_i64_10 : i64
-    llvm.store %33, %arg1 : i64, !llvm.ptr
+    %31 = arith.subi %29, %c2_i64_8 : i64
+    llvm.store %31, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_12 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_12 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
+    %32 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %33 = llvm.getelementptr %32[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %34 = llvm.load %33 : !llvm.ptr -> i256
+    llvm.store %33, %0 : !llvm.ptr, !llvm.ptr
+    %35 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %36 = llvm.getelementptr %35[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_13 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = arith.subi %37, %41 : i256
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %44 = llvm.getelementptr %arg2[%43] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %45 = arith.addi %43, %c1_i64_14 : i64
-    llvm.store %45, %arg3 : i64, !llvm.ptr
-    llvm.store %42, %44 : i256, !llvm.ptr
+    llvm.store %36, %0 : !llvm.ptr, !llvm.ptr
+    %38 = arith.subi %34, %37 : i256
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %38, %39 : i256, !llvm.ptr
+    %40 = llvm.getelementptr %39[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %41 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %47 = arith.addi %46, %c-1_i64 : i64
-    %c2_i64_16 = arith.constant 2 : i64
-    %48 = arith.cmpi ult, %46, %c2_i64_16 : i64
+    %42 = arith.addi %41, %c-1_i64 : i64
+    llvm.store %42, %arg3 : i64, !llvm.ptr
+    %c2_i64_11 = arith.constant 2 : i64
+    %43 = arith.cmpi ult, %41, %c2_i64_11 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %48, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %43, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %49 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %44 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %50 = arith.cmpi uge, %49, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %50, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %45 = arith.cmpi uge, %44, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %45, ^bb18, ^bb1(%c80_i8_13 : i8)
   ^bb18:  // pred: ^bb17
-    %51 = arith.subi %49, %c3_i64_17 : i64
-    llvm.store %51, %arg1 : i64, !llvm.ptr
+    %46 = arith.subi %44, %c3_i64_12 : i64
+    llvm.store %46, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %53 = arith.subi %52, %c1_i64_19 : i64
-    %54 = llvm.getelementptr %arg2[%53] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %53, %arg3 : i64, !llvm.ptr
-    %55 = llvm.load %54 : !llvm.ptr -> i256
-    %56 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %57 = arith.subi %56, %c1_i64_20 : i64
-    %58 = llvm.getelementptr %arg2[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    %59 = llvm.load %58 : !llvm.ptr -> i256
-    %60 = arith.subi %55, %59 : i256
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %62 = llvm.getelementptr %arg2[%61] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %63 = arith.addi %61, %c1_i64_21 : i64
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    llvm.store %60, %62 : i256, !llvm.ptr
+    %47 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %48 = llvm.getelementptr %47[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %49 = llvm.load %48 : !llvm.ptr -> i256
+    llvm.store %48, %0 : !llvm.ptr, !llvm.ptr
+    %50 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %51 = llvm.getelementptr %50[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %52 = llvm.load %51 : !llvm.ptr -> i256
+    llvm.store %51, %0 : !llvm.ptr, !llvm.ptr
+    %53 = arith.subi %49, %52 : i256
+    %54 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %53, %54 : i256, !llvm.ptr
+    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %55, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb20:  // pred: ^bb22
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_23 = arith.constant -1 : i64
-    %65 = arith.addi %64, %c-1_i64_23 : i64
-    %c2_i64_24 = arith.constant 2 : i64
-    %66 = arith.cmpi ult, %64, %c2_i64_24 : i64
-    %c91_i8_25 = arith.constant 91 : i8
-    cf.cond_br %66, ^bb1(%c91_i8_25 : i8), ^bb19
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %56 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_15 = arith.constant -1 : i64
+    %57 = arith.addi %56, %c-1_i64_15 : i64
+    llvm.store %57, %arg3 : i64, !llvm.ptr
+    %c2_i64_16 = arith.constant 2 : i64
+    %58 = arith.cmpi ult, %56, %c2_i64_16 : i64
+    %c91_i8_17 = arith.constant 91 : i8
+    cf.cond_br %58, ^bb1(%c91_i8_17 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %67 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_26 = arith.constant 3 : i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %68 = arith.cmpi uge, %67, %c3_i64_26 : i64
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %68, ^bb22, ^bb1(%c80_i8_27 : i8)
+    %60 = arith.cmpi uge, %59, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb22, ^bb1(%c80_i8_19 : i8)
   ^bb22:  // pred: ^bb21
-    %69 = arith.subi %67, %c3_i64_26 : i64
-    llvm.store %69, %arg1 : i64, !llvm.ptr
+    %61 = arith.subi %59, %c3_i64_18 : i64
+    llvm.store %61, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb19
-    %c0_i64_28 = arith.constant 0 : i64
+    %c0_i64_20 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %70 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_28, %c0_i64_28, %70, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_20, %c0_i64_20, %62, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jump_invalid_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jump_invalid_jumpdest.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb12, ^bb15, ^bb19, ^bb22, ^bb23
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 10 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb12, ^bb15, ^bb19, ^bb22, ^bb23
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       1: ^bb19
     ]
   ^bb3:  // pred: ^bb4
     %c4_i256 = arith.constant 4 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c4_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,34 +96,33 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb15
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb14
     %c88_i8 = arith.constant 88 : i8
@@ -129,74 +130,75 @@ module {
   ^bb13:  // no predecessors
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_5 = arith.constant 1024 : i64
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %23 = arith.addi %22, %c0_i64_6 : i64
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %21 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
+    %22 = arith.addi %21, %c0_i64_5 : i64
+    llvm.store %22, %arg3 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb8
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_7 = arith.constant 0 : i64
+    %23 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_6 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %25 = arith.cmpi uge, %24, %c0_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %25, ^bb16, ^bb1(%c80_i8_8 : i8)
+    %24 = arith.cmpi uge, %23, %c0_i64_6 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %24, ^bb16, ^bb1(%c80_i8_7 : i8)
   ^bb16:  // pred: ^bb15
-    %26 = arith.subi %24, %c0_i64_7 : i64
-    llvm.store %26, %arg1 : i64, !llvm.ptr
+    %25 = arith.subi %23, %c0_i64_6 : i64
+    llvm.store %25, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
     cf.br ^bb23
   ^bb18:  // pred: ^bb20
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %27 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_10 = arith.constant 0 : i64
-    %28 = arith.addi %27, %c0_i64_10 : i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %26 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
+    %27 = arith.addi %26, %c0_i64_9 : i64
+    llvm.store %27, %arg3 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb19:  // 2 preds: ^bb2, ^bb13
-    %29 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_11 = arith.constant 1 : i64
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_10 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %30 = arith.cmpi uge, %29, %c1_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %30, ^bb20, ^bb1(%c80_i8_12 : i8)
+    %29 = arith.cmpi uge, %28, %c1_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %29, ^bb20, ^bb1(%c80_i8_11 : i8)
   ^bb20:  // pred: ^bb19
-    %31 = arith.subi %29, %c1_i64_11 : i64
-    llvm.store %31, %arg1 : i64, !llvm.ptr
+    %30 = arith.subi %28, %c1_i64_10 : i64
+    llvm.store %30, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb22
     %c1_i256 = arith.constant 1 : i256
-    %32 = llvm.load %arg3 : !llvm.ptr -> i64
-    %33 = llvm.getelementptr %arg2[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %34 = arith.addi %32, %c1_i64_13 : i64
-    llvm.store %34, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %33 : i256, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %31 : i256, !llvm.ptr
+    %32 = llvm.getelementptr %31[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb22:  // pred: ^bb24
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %36 = arith.addi %35, %c1_i64_15 : i64
-    %37 = arith.cmpi ult, %c1024_i64_14, %36 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %37, ^bb1(%c92_i8_16 : i8), ^bb21
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %34 = arith.addi %33, %c1_i64_13 : i64
+    llvm.store %34, %arg3 : i64, !llvm.ptr
+    %35 = arith.cmpi ult, %c1024_i64_12, %34 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %35, ^bb1(%c92_i8_14 : i8), ^bb21
   ^bb23:  // pred: ^bb17
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb24, ^bb1(%c80_i8_18 : i8)
+    %37 = arith.cmpi uge, %36, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %37, ^bb24, ^bb1(%c80_i8_16 : i8)
   ^bb24:  // pred: ^bb23
-    %40 = arith.subi %38, %c3_i64_17 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %38 = arith.subi %36, %c3_i64_15 : i64
+    llvm.store %38, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb21
-    %c0_i64_19 = arith.constant 0 : i64
+    %c0_i64_17 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_19, %c0_i64_19, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_17, %c0_i64_17, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jumpi_valid_jumpdest.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_jumpi_valid_jumpdest.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb16, ^bb19, ^bb23, ^bb26, ^bb27
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb11
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb16, ^bb19, ^bb23, ^bb26, ^bb27
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb11
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       5: ^bb23
     ]
   ^bb3:  // pred: ^bb4
     %c5_i256 = arith.constant 5 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c5_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,69 +97,65 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi ne, %28, %c0_i256 : i256
-    cf.cond_br %29, ^bb2(%24 : i256), ^bb12
+    %26 = arith.cmpi ne, %25, %c0_i256 : i256
+    cf.cond_br %26, ^bb2(%22 : i256), ^bb12
   ^bb12:  // pred: ^bb11
     cf.br ^bb19
   ^bb13:  // pred: ^bb15
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %27 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %31 = arith.addi %30, %c-2_i64 : i64
+    %28 = arith.addi %27, %c-2_i64 : i64
+    llvm.store %28, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %32 = arith.cmpi ult, %30, %c2_i64 : i64
+    %29 = arith.cmpi ult, %27, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %29, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
     %c10_i64 = arith.constant 10 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c10_i64 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %31 = arith.cmpi uge, %30, %c10_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %31, ^bb15, ^bb1(%c80_i8_7 : i8)
   ^bb15:  // pred: ^bb14
-    %35 = arith.subi %33, %c10_i64 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %32 = arith.subi %30, %c10_i64 : i64
+    llvm.store %32, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb18
     %c88_i8 = arith.constant 88 : i8
@@ -165,74 +163,75 @@ module {
   ^bb17:  // no predecessors
     cf.br ^bb23
   ^bb18:  // pred: ^bb20
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %37 = arith.addi %36, %c0_i64_12 : i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
+    %34 = arith.addi %33, %c0_i64_9 : i64
+    llvm.store %34, %arg3 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb12
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_13 = arith.constant 0 : i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c0_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb20, ^bb1(%c80_i8_14 : i8)
+    %36 = arith.cmpi uge, %35, %c0_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb20, ^bb1(%c80_i8_11 : i8)
   ^bb20:  // pred: ^bb19
-    %40 = arith.subi %38, %c0_i64_13 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %37 = arith.subi %35, %c0_i64_10 : i64
+    llvm.store %37, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb22
     cf.br ^bb27
   ^bb22:  // pred: ^bb24
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %41 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %42 = arith.addi %41, %c0_i64_16 : i64
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %39 = arith.addi %38, %c0_i64_13 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb23:  // 2 preds: ^bb2, ^bb17
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_14 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c1_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb24, ^bb1(%c80_i8_18 : i8)
+    %41 = arith.cmpi uge, %40, %c1_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb24, ^bb1(%c80_i8_15 : i8)
   ^bb24:  // pred: ^bb23
-    %45 = arith.subi %43, %c1_i64_17 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c1_i64_14 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb26
     %c2_i256 = arith.constant 2 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_19 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %47 : i256, !llvm.ptr
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb26:  // pred: ^bb28
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_21 : i64
-    %51 = arith.cmpi ult, %c1024_i64_20, %50 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_22 : i8), ^bb25
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_17 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_16, %46 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_18 : i8), ^bb25
   ^bb27:  // pred: ^bb21
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb28, ^bb1(%c80_i8_24 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb28, ^bb1(%c80_i8_20 : i8)
   ^bb28:  // pred: ^bb27
-    %54 = arith.subi %52, %c3_i64_23 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_19 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb25
-    %c0_i64_25 = arith.constant 0 : i64
+    %c0_i64_21 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_25, %c0_i64_25, %55, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %51 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %51, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mload_misze.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mload_misze.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 29 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb42, ^bb43, ^bb44, ^bb47, ^bb48, ^bb50, ^bb51, ^bb52, ^bb55, ^bb56
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 29 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb42, ^bb43, ^bb44, ^bb47, ^bb48, ^bb50, ^bb51, ^bb52, ^bb55, ^bb56
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
-    %3 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %4 = arith.extui %3 : i64 to i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %5 = arith.extui %4 : i64 to i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3
@@ -95,398 +97,386 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %14 = llvm.load %arg3 : !llvm.ptr -> i64
-    %15 = llvm.getelementptr %arg2[%14] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %16 = arith.addi %14, %c1_i64_1 : i64
-    llvm.store %16, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %15 : i256, !llvm.ptr
+    %14 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %14 : i256, !llvm.ptr
+    %15 = llvm.getelementptr %14[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %15, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %17 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.addi %17, %c1_i64_3 : i64
-    %19 = arith.cmpi ult, %c1024_i64_2, %18 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %19, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.addi %16, %c1_i64_2 : i64
+    llvm.store %17, %arg3 : i64, !llvm.ptr
+    %18 = arith.cmpi ult, %c1024_i64_1, %17 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %18, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %20 = llvm.load %arg1 : !llvm.ptr -> i64
+    %19 = llvm.load %arg1 : !llvm.ptr -> i64
     %c3_i64 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %21 = arith.cmpi uge, %20, %c3_i64 : i64
-    %c80_i8_5 = arith.constant 80 : i8
-    cf.cond_br %21, ^bb10, ^bb1(%c80_i8_5 : i8)
+    %20 = arith.cmpi uge, %19, %c3_i64 : i64
+    %c80_i8_4 = arith.constant 80 : i8
+    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
   ^bb10:  // pred: ^bb9
-    %22 = arith.subi %20, %c3_i64 : i64
-    llvm.store %22, %arg1 : i64, !llvm.ptr
+    %21 = arith.subi %19, %c3_i64 : i64
+    llvm.store %21, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %23 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %24 = arith.subi %23, %c1_i64_6 : i64
-    %25 = llvm.getelementptr %arg2[%24] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    %26 = llvm.load %25 : !llvm.ptr -> i256
+    %22 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %24 = llvm.load %23 : !llvm.ptr -> i256
+    llvm.store %23, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_7 = arith.constant 0 : i64
-    %27 = arith.cmpi ne, %c32_i64, %c0_i64_7 : i64
-    cf.cond_br %27, ^bb42, ^bb12
+    %c0_i64_5 = arith.constant 0 : i64
+    %25 = arith.cmpi ne, %c32_i64, %c0_i64_5 : i64
+    cf.cond_br %25, ^bb42, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb46
-    %28 = arith.trunci %26 : i256 to i64
-    %29 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %30 = llvm.getelementptr %29[%28] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %31 = llvm.load %30 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %32 = llvm.intr.bswap(%31)  : (i256) -> i256
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %34 = llvm.getelementptr %arg2[%33] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %35 = arith.addi %33, %c1_i64_8 : i64
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    llvm.store %32, %34 : i256, !llvm.ptr
+    %26 = arith.trunci %24 : i256 to i64
+    %27 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %28 = llvm.getelementptr %27[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %29 = llvm.load %28 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %30 = llvm.intr.bswap(%29)  : (i256) -> i256
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %30, %31 : i256, !llvm.ptr
+    %32 = llvm.getelementptr %31[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_10 = arith.constant 0 : i64
-    %37 = arith.addi %36, %c0_i64_10 : i64
-    %c1_i64_11 = arith.constant 1 : i64
-    %38 = arith.cmpi ult, %36, %c1_i64_11 : i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_7 = arith.constant 0 : i64
+    %34 = arith.addi %33, %c0_i64_7 : i64
+    llvm.store %34, %arg3 : i64, !llvm.ptr
+    %c1_i64_8 = arith.constant 1 : i64
+    %35 = arith.cmpi ult, %33, %c1_i64_8 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %38, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %40 = arith.cmpi uge, %39, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %40, ^bb15, ^bb1(%c80_i8_13 : i8)
+    %37 = arith.cmpi uge, %36, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %37, ^bb15, ^bb1(%c80_i8_10 : i8)
   ^bb15:  // pred: ^bb14
-    %41 = arith.subi %39, %c3_i64_12 : i64
-    llvm.store %41, %arg1 : i64, !llvm.ptr
+    %38 = arith.subi %36, %c3_i64_9 : i64
+    llvm.store %38, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %43 = arith.subi %42, %c1_i64_14 : i64
-    %44 = llvm.getelementptr %arg2[%43] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %43, %arg3 : i64, !llvm.ptr
-    %45 = llvm.load %44 : !llvm.ptr -> i256
+    %39 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %40 = llvm.getelementptr %39[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %40, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %42 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %47 = arith.addi %46, %c-1_i64 : i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %48 = arith.cmpi ult, %46, %c1_i64_16 : i64
-    %c91_i8_17 = arith.constant 91 : i8
-    cf.cond_br %48, ^bb1(%c91_i8_17 : i8), ^bb16
+    %43 = arith.addi %42, %c-1_i64 : i64
+    llvm.store %43, %arg3 : i64, !llvm.ptr
+    %c1_i64_12 = arith.constant 1 : i64
+    %44 = arith.cmpi ult, %42, %c1_i64_12 : i64
+    %c91_i8_13 = arith.constant 91 : i8
+    cf.cond_br %44, ^bb1(%c91_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %49 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_18 = arith.constant 2 : i64
+    %45 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_14 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %50 = arith.cmpi uge, %49, %c2_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %50, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %46 = arith.cmpi uge, %45, %c2_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %46, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %51 = arith.subi %49, %c2_i64_18 : i64
-    llvm.store %51, %arg1 : i64, !llvm.ptr
+    %47 = arith.subi %45, %c2_i64_14 : i64
+    llvm.store %47, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %52 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %53 = arith.extui %52 : i64 to i256
-    %54 = llvm.load %arg3 : !llvm.ptr -> i64
-    %55 = llvm.getelementptr %arg2[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %56 = arith.addi %54, %c1_i64_20 : i64
-    llvm.store %56, %arg3 : i64, !llvm.ptr
-    llvm.store %53, %55 : i256, !llvm.ptr
+    %48 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %49 = arith.extui %48 : i64 to i256
+    %50 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %49, %50 : i256, !llvm.ptr
+    %51 = llvm.getelementptr %50[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %51, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %58 = arith.addi %57, %c1_i64_22 : i64
-    %59 = arith.cmpi ult, %c1024_i64_21, %58 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %59, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %52 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %53 = arith.addi %52, %c1_i64_17 : i64
+    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %54 = arith.cmpi ult, %c1024_i64_16, %53 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %54, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %60 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_24 = arith.constant 2 : i64
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_19 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %61 = arith.cmpi uge, %60, %c2_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %61, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %56 = arith.cmpi uge, %55, %c2_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %62 = arith.subi %60, %c2_i64_24 : i64
-    llvm.store %62, %arg1 : i64, !llvm.ptr
+    %57 = arith.subi %55, %c2_i64_19 : i64
+    llvm.store %57, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
     %c39_i256 = arith.constant 39 : i256
-    %63 = llvm.load %arg3 : !llvm.ptr -> i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %65 = arith.addi %63, %c1_i64_26 : i64
-    llvm.store %65, %arg3 : i64, !llvm.ptr
-    llvm.store %c39_i256, %64 : i256, !llvm.ptr
+    %58 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c39_i256, %58 : i256, !llvm.ptr
+    %59 = llvm.getelementptr %58[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %59, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb31
   ^bb25:  // pred: ^bb27
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %66 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %67 = arith.addi %66, %c1_i64_28 : i64
-    %68 = arith.cmpi ult, %c1024_i64_27, %67 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %68, ^bb1(%c92_i8_29 : i8), ^bb24
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %60 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %61 = arith.addi %60, %c1_i64_22 : i64
+    llvm.store %61, %arg3 : i64, !llvm.ptr
+    %62 = arith.cmpi ult, %c1024_i64_21, %61 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %62, ^bb1(%c92_i8_23 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %69 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %63 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %70 = arith.cmpi uge, %69, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %70, ^bb27, ^bb1(%c80_i8_31 : i8)
+    %64 = arith.cmpi uge, %63, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %64, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %71 = arith.subi %69, %c3_i64_30 : i64
-    llvm.store %71, %arg1 : i64, !llvm.ptr
+    %65 = arith.subi %63, %c3_i64_24 : i64
+    llvm.store %65, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb30
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %73 = arith.subi %72, %c1_i64_32 : i64
-    %74 = llvm.getelementptr %arg2[%73] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %73, %arg3 : i64, !llvm.ptr
-    %75 = llvm.load %74 : !llvm.ptr -> i256
-    %c32_i64_33 = arith.constant 32 : i64
-    %c0_i64_34 = arith.constant 0 : i64
-    %76 = arith.cmpi ne, %c32_i64_33, %c0_i64_34 : i64
-    cf.cond_br %76, ^bb50, ^bb29
+    %66 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %67 = llvm.getelementptr %66[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %68 = llvm.load %67 : !llvm.ptr -> i256
+    llvm.store %67, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_26 = arith.constant 32 : i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %69 = arith.cmpi ne, %c32_i64_26, %c0_i64_27 : i64
+    cf.cond_br %69, ^bb50, ^bb29
   ^bb29:  // 2 preds: ^bb28, ^bb54
-    %77 = arith.trunci %75 : i256 to i64
-    %78 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %79 = llvm.getelementptr %78[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %80 = llvm.load %79 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %81 = llvm.intr.bswap(%80)  : (i256) -> i256
-    %82 = llvm.load %arg3 : !llvm.ptr -> i64
-    %83 = llvm.getelementptr %arg2[%82] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_35 = arith.constant 1 : i64
-    %84 = arith.addi %82, %c1_i64_35 : i64
-    llvm.store %84, %arg3 : i64, !llvm.ptr
-    llvm.store %81, %83 : i256, !llvm.ptr
+    %70 = arith.trunci %68 : i256 to i64
+    %71 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %72 = llvm.getelementptr %71[%70] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %73 = llvm.load %72 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %74 = llvm.intr.bswap(%73)  : (i256) -> i256
+    %75 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %74, %75 : i256, !llvm.ptr
+    %76 = llvm.getelementptr %75[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %76, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_36 = arith.constant 1024 : i64
-    %85 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_37 = arith.constant 0 : i64
-    %86 = arith.addi %85, %c0_i64_37 : i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %87 = arith.cmpi ult, %85, %c1_i64_38 : i64
-    %c91_i8_39 = arith.constant 91 : i8
-    cf.cond_br %87, ^bb1(%c91_i8_39 : i8), ^bb28
+    %c1024_i64_28 = arith.constant 1024 : i64
+    %77 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_29 = arith.constant 0 : i64
+    %78 = arith.addi %77, %c0_i64_29 : i64
+    llvm.store %78, %arg3 : i64, !llvm.ptr
+    %c1_i64_30 = arith.constant 1 : i64
+    %79 = arith.cmpi ult, %77, %c1_i64_30 : i64
+    %c91_i8_31 = arith.constant 91 : i8
+    cf.cond_br %79, ^bb1(%c91_i8_31 : i8), ^bb28
   ^bb31:  // pred: ^bb24
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_40 = arith.constant 3 : i64
+    %80 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_32 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %89 = arith.cmpi uge, %88, %c3_i64_40 : i64
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %89, ^bb32, ^bb1(%c80_i8_41 : i8)
+    %81 = arith.cmpi uge, %80, %c3_i64_32 : i64
+    %c80_i8_33 = arith.constant 80 : i8
+    cf.cond_br %81, ^bb32, ^bb1(%c80_i8_33 : i8)
   ^bb32:  // pred: ^bb31
-    %90 = arith.subi %88, %c3_i64_40 : i64
-    llvm.store %90, %arg1 : i64, !llvm.ptr
+    %82 = arith.subi %80, %c3_i64_32 : i64
+    llvm.store %82, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
-    %91 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_42 = arith.constant 1 : i64
-    %92 = arith.subi %91, %c1_i64_42 : i64
-    %93 = llvm.getelementptr %arg2[%92] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %92, %arg3 : i64, !llvm.ptr
-    %94 = llvm.load %93 : !llvm.ptr -> i256
+    %83 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %84 = llvm.getelementptr %83[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %85 = llvm.load %84 : !llvm.ptr -> i256
+    llvm.store %84, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb34:  // pred: ^bb36
-    %c1024_i64_43 = arith.constant 1024 : i64
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_44 = arith.constant -1 : i64
-    %96 = arith.addi %95, %c-1_i64_44 : i64
-    %c1_i64_45 = arith.constant 1 : i64
-    %97 = arith.cmpi ult, %95, %c1_i64_45 : i64
-    %c91_i8_46 = arith.constant 91 : i8
-    cf.cond_br %97, ^bb1(%c91_i8_46 : i8), ^bb33
+    %c1024_i64_34 = arith.constant 1024 : i64
+    %86 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_35 = arith.constant -1 : i64
+    %87 = arith.addi %86, %c-1_i64_35 : i64
+    llvm.store %87, %arg3 : i64, !llvm.ptr
+    %c1_i64_36 = arith.constant 1 : i64
+    %88 = arith.cmpi ult, %86, %c1_i64_36 : i64
+    %c91_i8_37 = arith.constant 91 : i8
+    cf.cond_br %88, ^bb1(%c91_i8_37 : i8), ^bb33
   ^bb35:  // pred: ^bb29
-    %98 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_47 = arith.constant 2 : i64
+    %89 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_38 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %99 = arith.cmpi uge, %98, %c2_i64_47 : i64
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %99, ^bb36, ^bb1(%c80_i8_48 : i8)
+    %90 = arith.cmpi uge, %89, %c2_i64_38 : i64
+    %c80_i8_39 = arith.constant 80 : i8
+    cf.cond_br %90, ^bb36, ^bb1(%c80_i8_39 : i8)
   ^bb36:  // pred: ^bb35
-    %100 = arith.subi %98, %c2_i64_47 : i64
-    llvm.store %100, %arg1 : i64, !llvm.ptr
+    %91 = arith.subi %89, %c2_i64_38 : i64
+    llvm.store %91, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb38
-    %101 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %102 = arith.extui %101 : i64 to i256
-    %103 = llvm.load %arg3 : !llvm.ptr -> i64
-    %104 = llvm.getelementptr %arg2[%103] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_49 = arith.constant 1 : i64
-    %105 = arith.addi %103, %c1_i64_49 : i64
-    llvm.store %105, %arg3 : i64, !llvm.ptr
-    llvm.store %102, %104 : i256, !llvm.ptr
+    %92 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %93 = arith.extui %92 : i64 to i256
+    %94 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %93, %94 : i256, !llvm.ptr
+    %95 = llvm.getelementptr %94[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %95, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb41
   ^bb38:  // pred: ^bb40
-    %c1024_i64_50 = arith.constant 1024 : i64
-    %106 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_51 = arith.constant 1 : i64
-    %107 = arith.addi %106, %c1_i64_51 : i64
-    %108 = arith.cmpi ult, %c1024_i64_50, %107 : i64
-    %c92_i8_52 = arith.constant 92 : i8
-    cf.cond_br %108, ^bb1(%c92_i8_52 : i8), ^bb37
+    %c1024_i64_40 = arith.constant 1024 : i64
+    %96 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_41 = arith.constant 1 : i64
+    %97 = arith.addi %96, %c1_i64_41 : i64
+    llvm.store %97, %arg3 : i64, !llvm.ptr
+    %98 = arith.cmpi ult, %c1024_i64_40, %97 : i64
+    %c92_i8_42 = arith.constant 92 : i8
+    cf.cond_br %98, ^bb1(%c92_i8_42 : i8), ^bb37
   ^bb39:  // pred: ^bb33
-    %109 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_53 = arith.constant 2 : i64
+    %99 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_43 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %110 = arith.cmpi uge, %109, %c2_i64_53 : i64
-    %c80_i8_54 = arith.constant 80 : i8
-    cf.cond_br %110, ^bb40, ^bb1(%c80_i8_54 : i8)
+    %100 = arith.cmpi uge, %99, %c2_i64_43 : i64
+    %c80_i8_44 = arith.constant 80 : i8
+    cf.cond_br %100, ^bb40, ^bb1(%c80_i8_44 : i8)
   ^bb40:  // pred: ^bb39
-    %111 = arith.subi %109, %c2_i64_53 : i64
-    llvm.store %111, %arg1 : i64, !llvm.ptr
+    %101 = arith.subi %99, %c2_i64_43 : i64
+    llvm.store %101, %arg1 : i64, !llvm.ptr
     cf.br ^bb38
   ^bb41:  // pred: ^bb37
-    %c0_i64_55 = arith.constant 0 : i64
+    %c0_i64_45 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %112 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_55, %c0_i64_55, %112, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %102 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_45, %c0_i64_45, %102, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb42:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %113 = arith.cmpi sgt, %26, %c18446744073709551615_i256 : i256
+    %103 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %113, ^bb1(%c84_i8 : i8), ^bb43
+    cf.cond_br %103, ^bb1(%c84_i8 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %114 = arith.trunci %26 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %115 = arith.cmpi slt, %114, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %115, ^bb1(%c84_i8_57 : i8), ^bb44
+    %104 = arith.trunci %24 : i256 to i64
+    %c0_i64_46 = arith.constant 0 : i64
+    %105 = arith.cmpi slt, %104, %c0_i64_46 : i64
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %105, ^bb1(%c84_i8_47 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %116 = arith.addi %114, %c32_i64 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %117 = arith.cmpi slt, %116, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %117, ^bb1(%c84_i8_59 : i8), ^bb45
+    %106 = arith.addi %104, %c32_i64 : i64
+    %c0_i64_48 = arith.constant 0 : i64
+    %107 = arith.cmpi slt, %106, %c0_i64_48 : i64
+    %c84_i8_49 = arith.constant 84 : i8
+    cf.cond_br %107, ^bb1(%c84_i8_49 : i8), ^bb45
   ^bb45:  // pred: ^bb44
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_60 = arith.constant 32 : i64
-    %118 = arith.addi %116, %c31_i64 : i64
-    %119 = arith.divui %118, %c32_i64_60 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %120 = arith.muli %119, %c32_i64_61 : i64
-    %121 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_62 = arith.constant 31 : i64
-    %c32_i64_63 = arith.constant 32 : i64
-    %122 = arith.addi %121, %c31_i64_62 : i64
-    %123 = arith.divui %122, %c32_i64_63 : i64
-    %124 = arith.muli %123, %c32_i64_61 : i64
-    %125 = arith.cmpi ult, %124, %120 : i64
-    cf.cond_br %125, ^bb47, ^bb46
+    %c32_i64_50 = arith.constant 32 : i64
+    %108 = arith.addi %106, %c31_i64 : i64
+    %109 = arith.divui %108, %c32_i64_50 : i64
+    %c32_i64_51 = arith.constant 32 : i64
+    %110 = arith.muli %109, %c32_i64_51 : i64
+    %111 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_52 = arith.constant 31 : i64
+    %c32_i64_53 = arith.constant 32 : i64
+    %112 = arith.addi %111, %c31_i64_52 : i64
+    %113 = arith.divui %112, %c32_i64_53 : i64
+    %114 = arith.muli %113, %c32_i64_51 : i64
+    %115 = arith.cmpi ult, %114, %110 : i64
+    cf.cond_br %115, ^bb47, ^bb46
   ^bb46:  // 2 preds: ^bb45, ^bb49
     cf.br ^bb12
   ^bb47:  // pred: ^bb45
-    %c3_i64_64 = arith.constant 3 : i64
+    %c3_i64_54 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %126 = arith.muli %123, %123 : i64
-    %127 = arith.divui %126, %c512_i64 : i64
-    %128 = arith.muli %123, %c3_i64_64 : i64
-    %129 = arith.addi %127, %128 : i64
-    %c3_i64_65 = arith.constant 3 : i64
-    %c512_i64_66 = arith.constant 512 : i64
-    %130 = arith.muli %119, %119 : i64
-    %131 = arith.divui %130, %c512_i64_66 : i64
-    %132 = arith.muli %119, %c3_i64_65 : i64
-    %133 = arith.addi %131, %132 : i64
-    %134 = arith.subi %133, %129 : i64
-    %135 = llvm.load %arg1 : !llvm.ptr -> i64
-    %136 = arith.cmpi ult, %135, %134 : i64
-    scf.if %136 {
+    %116 = arith.muli %113, %113 : i64
+    %117 = arith.divui %116, %c512_i64 : i64
+    %118 = arith.muli %113, %c3_i64_54 : i64
+    %119 = arith.addi %117, %118 : i64
+    %c3_i64_55 = arith.constant 3 : i64
+    %c512_i64_56 = arith.constant 512 : i64
+    %120 = arith.muli %109, %109 : i64
+    %121 = arith.divui %120, %c512_i64_56 : i64
+    %122 = arith.muli %109, %c3_i64_55 : i64
+    %123 = arith.addi %121, %122 : i64
+    %124 = arith.subi %123, %119 : i64
+    %125 = llvm.load %arg1 : !llvm.ptr -> i64
+    %126 = arith.cmpi ult, %125, %124 : i64
+    scf.if %126 {
     } else {
-      %169 = arith.subi %135, %134 : i64
-      llvm.store %169, %arg1 : i64, !llvm.ptr
+      %159 = arith.subi %125, %124 : i64
+      llvm.store %159, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_67 = arith.constant 80 : i8
-    cf.cond_br %136, ^bb1(%c80_i8_67 : i8), ^bb48
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %126, ^bb1(%c80_i8_57 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %137 = call @dora_fn_extend_memory(%arg0, %120) : (!llvm.ptr, i64) -> !llvm.ptr
-    %138 = llvm.getelementptr %137[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %139 = llvm.load %138 : !llvm.ptr -> i8
+    %127 = call @dora_fn_extend_memory(%arg0, %110) : (!llvm.ptr, i64) -> !llvm.ptr
+    %128 = llvm.getelementptr %127[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %129 = llvm.load %128 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %140 = arith.cmpi ne, %139, %c0_i8 : i8
-    cf.cond_br %140, ^bb1(%139 : i8), ^bb49
+    %130 = arith.cmpi ne, %129, %c0_i8 : i8
+    cf.cond_br %130, ^bb1(%129 : i8), ^bb49
   ^bb49:  // pred: ^bb48
     cf.br ^bb46
   ^bb50:  // pred: ^bb28
-    %c18446744073709551615_i256_68 = arith.constant 18446744073709551615 : i256
-    %141 = arith.cmpi sgt, %75, %c18446744073709551615_i256_68 : i256
-    %c84_i8_69 = arith.constant 84 : i8
-    cf.cond_br %141, ^bb1(%c84_i8_69 : i8), ^bb51
+    %c18446744073709551615_i256_58 = arith.constant 18446744073709551615 : i256
+    %131 = arith.cmpi sgt, %68, %c18446744073709551615_i256_58 : i256
+    %c84_i8_59 = arith.constant 84 : i8
+    cf.cond_br %131, ^bb1(%c84_i8_59 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %142 = arith.trunci %75 : i256 to i64
-    %c0_i64_70 = arith.constant 0 : i64
-    %143 = arith.cmpi slt, %142, %c0_i64_70 : i64
-    %c84_i8_71 = arith.constant 84 : i8
-    cf.cond_br %143, ^bb1(%c84_i8_71 : i8), ^bb52
+    %132 = arith.trunci %68 : i256 to i64
+    %c0_i64_60 = arith.constant 0 : i64
+    %133 = arith.cmpi slt, %132, %c0_i64_60 : i64
+    %c84_i8_61 = arith.constant 84 : i8
+    cf.cond_br %133, ^bb1(%c84_i8_61 : i8), ^bb52
   ^bb52:  // pred: ^bb51
-    %144 = arith.addi %142, %c32_i64_33 : i64
-    %c0_i64_72 = arith.constant 0 : i64
-    %145 = arith.cmpi slt, %144, %c0_i64_72 : i64
-    %c84_i8_73 = arith.constant 84 : i8
-    cf.cond_br %145, ^bb1(%c84_i8_73 : i8), ^bb53
+    %134 = arith.addi %132, %c32_i64_26 : i64
+    %c0_i64_62 = arith.constant 0 : i64
+    %135 = arith.cmpi slt, %134, %c0_i64_62 : i64
+    %c84_i8_63 = arith.constant 84 : i8
+    cf.cond_br %135, ^bb1(%c84_i8_63 : i8), ^bb53
   ^bb53:  // pred: ^bb52
-    %c31_i64_74 = arith.constant 31 : i64
-    %c32_i64_75 = arith.constant 32 : i64
-    %146 = arith.addi %144, %c31_i64_74 : i64
-    %147 = arith.divui %146, %c32_i64_75 : i64
-    %c32_i64_76 = arith.constant 32 : i64
-    %148 = arith.muli %147, %c32_i64_76 : i64
-    %149 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_77 = arith.constant 31 : i64
-    %c32_i64_78 = arith.constant 32 : i64
-    %150 = arith.addi %149, %c31_i64_77 : i64
-    %151 = arith.divui %150, %c32_i64_78 : i64
-    %152 = arith.muli %151, %c32_i64_76 : i64
-    %153 = arith.cmpi ult, %152, %148 : i64
-    cf.cond_br %153, ^bb55, ^bb54
+    %c31_i64_64 = arith.constant 31 : i64
+    %c32_i64_65 = arith.constant 32 : i64
+    %136 = arith.addi %134, %c31_i64_64 : i64
+    %137 = arith.divui %136, %c32_i64_65 : i64
+    %c32_i64_66 = arith.constant 32 : i64
+    %138 = arith.muli %137, %c32_i64_66 : i64
+    %139 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_67 = arith.constant 31 : i64
+    %c32_i64_68 = arith.constant 32 : i64
+    %140 = arith.addi %139, %c31_i64_67 : i64
+    %141 = arith.divui %140, %c32_i64_68 : i64
+    %142 = arith.muli %141, %c32_i64_66 : i64
+    %143 = arith.cmpi ult, %142, %138 : i64
+    cf.cond_br %143, ^bb55, ^bb54
   ^bb54:  // 2 preds: ^bb53, ^bb57
     cf.br ^bb29
   ^bb55:  // pred: ^bb53
-    %c3_i64_79 = arith.constant 3 : i64
-    %c512_i64_80 = arith.constant 512 : i64
-    %154 = arith.muli %151, %151 : i64
-    %155 = arith.divui %154, %c512_i64_80 : i64
-    %156 = arith.muli %151, %c3_i64_79 : i64
-    %157 = arith.addi %155, %156 : i64
-    %c3_i64_81 = arith.constant 3 : i64
-    %c512_i64_82 = arith.constant 512 : i64
-    %158 = arith.muli %147, %147 : i64
-    %159 = arith.divui %158, %c512_i64_82 : i64
-    %160 = arith.muli %147, %c3_i64_81 : i64
-    %161 = arith.addi %159, %160 : i64
-    %162 = arith.subi %161, %157 : i64
-    %163 = llvm.load %arg1 : !llvm.ptr -> i64
-    %164 = arith.cmpi ult, %163, %162 : i64
-    scf.if %164 {
+    %c3_i64_69 = arith.constant 3 : i64
+    %c512_i64_70 = arith.constant 512 : i64
+    %144 = arith.muli %141, %141 : i64
+    %145 = arith.divui %144, %c512_i64_70 : i64
+    %146 = arith.muli %141, %c3_i64_69 : i64
+    %147 = arith.addi %145, %146 : i64
+    %c3_i64_71 = arith.constant 3 : i64
+    %c512_i64_72 = arith.constant 512 : i64
+    %148 = arith.muli %137, %137 : i64
+    %149 = arith.divui %148, %c512_i64_72 : i64
+    %150 = arith.muli %137, %c3_i64_71 : i64
+    %151 = arith.addi %149, %150 : i64
+    %152 = arith.subi %151, %147 : i64
+    %153 = llvm.load %arg1 : !llvm.ptr -> i64
+    %154 = arith.cmpi ult, %153, %152 : i64
+    scf.if %154 {
     } else {
-      %169 = arith.subi %163, %162 : i64
-      llvm.store %169, %arg1 : i64, !llvm.ptr
+      %159 = arith.subi %153, %152 : i64
+      llvm.store %159, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_83 = arith.constant 80 : i8
-    cf.cond_br %164, ^bb1(%c80_i8_83 : i8), ^bb56
+    %c80_i8_73 = arith.constant 80 : i8
+    cf.cond_br %154, ^bb1(%c80_i8_73 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %165 = call @dora_fn_extend_memory(%arg0, %148) : (!llvm.ptr, i64) -> !llvm.ptr
-    %166 = llvm.getelementptr %165[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %167 = llvm.load %166 : !llvm.ptr -> i8
-    %c0_i8_84 = arith.constant 0 : i8
-    %168 = arith.cmpi ne, %167, %c0_i8_84 : i8
-    cf.cond_br %168, ^bb1(%167 : i8), ^bb57
+    %155 = call @dora_fn_extend_memory(%arg0, %138) : (!llvm.ptr, i64) -> !llvm.ptr
+    %156 = llvm.getelementptr %155[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %157 = llvm.load %156 : !llvm.ptr -> i8
+    %c0_i8_74 = arith.constant 0 : i8
+    %158 = arith.cmpi ne, %157, %c0_i8_74 : i8
+    cf.cond_br %158, ^bb1(%157 : i8), ^bb57
   ^bb57:  // pred: ^bb56
     cf.br ^bb54
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c255_i256 = arith.constant 255 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c255_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,146 +96,142 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb17, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb17, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb21
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb17:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %41 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %38 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %41, ^bb1(%c84_i8 : i8), ^bb18
+    cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %42 = arith.trunci %24 : i256 to i64
-    %c0_i64_14 = arith.constant 0 : i64
-    %43 = arith.cmpi slt, %42, %c0_i64_14 : i64
-    %c84_i8_15 = arith.constant 84 : i8
-    cf.cond_br %43, ^bb1(%c84_i8_15 : i8), ^bb19
+    %39 = arith.trunci %22 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %40 = arith.cmpi slt, %39, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %40, ^bb1(%c84_i8_12 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %44 = arith.addi %42, %c32_i64 : i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %45 = arith.cmpi slt, %44, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %45, ^bb1(%c84_i8_17 : i8), ^bb20
+    %41 = arith.addi %39, %c32_i64 : i64
+    %c0_i64_13 = arith.constant 0 : i64
+    %42 = arith.cmpi slt, %41, %c0_i64_13 : i64
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %42, ^bb1(%c84_i8_14 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c31_i64 = arith.constant 31 : i64
+    %c32_i64_15 = arith.constant 32 : i64
+    %43 = arith.addi %41, %c31_i64 : i64
+    %44 = arith.divui %43, %c32_i64_15 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %45 = arith.muli %44, %c32_i64_16 : i64
+    %46 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_17 = arith.constant 31 : i64
     %c32_i64_18 = arith.constant 32 : i64
-    %46 = arith.addi %44, %c31_i64 : i64
-    %47 = arith.divui %46, %c32_i64_18 : i64
-    %c32_i64_19 = arith.constant 32 : i64
-    %48 = arith.muli %47, %c32_i64_19 : i64
-    %49 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_20 = arith.constant 31 : i64
-    %c32_i64_21 = arith.constant 32 : i64
-    %50 = arith.addi %49, %c31_i64_20 : i64
-    %51 = arith.divui %50, %c32_i64_21 : i64
-    %52 = arith.muli %51, %c32_i64_19 : i64
-    %53 = arith.cmpi ult, %52, %48 : i64
-    cf.cond_br %53, ^bb22, ^bb21
+    %47 = arith.addi %46, %c31_i64_17 : i64
+    %48 = arith.divui %47, %c32_i64_18 : i64
+    %49 = arith.muli %48, %c32_i64_16 : i64
+    %50 = arith.cmpi ult, %49, %45 : i64
+    cf.cond_br %50, ^bb22, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb24
     cf.br ^bb12
   ^bb22:  // pred: ^bb20
-    %c3_i64_22 = arith.constant 3 : i64
+    %c3_i64_19 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %54 = arith.muli %51, %51 : i64
-    %55 = arith.divui %54, %c512_i64 : i64
-    %56 = arith.muli %51, %c3_i64_22 : i64
-    %57 = arith.addi %55, %56 : i64
-    %c3_i64_23 = arith.constant 3 : i64
-    %c512_i64_24 = arith.constant 512 : i64
-    %58 = arith.muli %47, %47 : i64
-    %59 = arith.divui %58, %c512_i64_24 : i64
-    %60 = arith.muli %47, %c3_i64_23 : i64
-    %61 = arith.addi %59, %60 : i64
-    %62 = arith.subi %61, %57 : i64
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %64 = arith.cmpi ult, %63, %62 : i64
-    scf.if %64 {
+    %51 = arith.muli %48, %48 : i64
+    %52 = arith.divui %51, %c512_i64 : i64
+    %53 = arith.muli %48, %c3_i64_19 : i64
+    %54 = arith.addi %52, %53 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %c512_i64_21 = arith.constant 512 : i64
+    %55 = arith.muli %44, %44 : i64
+    %56 = arith.divui %55, %c512_i64_21 : i64
+    %57 = arith.muli %44, %c3_i64_20 : i64
+    %58 = arith.addi %56, %57 : i64
+    %59 = arith.subi %58, %54 : i64
+    %60 = llvm.load %arg1 : !llvm.ptr -> i64
+    %61 = arith.cmpi ult, %60, %59 : i64
+    scf.if %61 {
     } else {
-      %69 = arith.subi %63, %62 : i64
-      llvm.store %69, %arg1 : i64, !llvm.ptr
+      %66 = arith.subi %60, %59 : i64
+      llvm.store %66, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb1(%c80_i8_25 : i8), ^bb23
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %61, ^bb1(%c80_i8_22 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %65 = call @dora_fn_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
-    %66 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %67 = llvm.load %66 : !llvm.ptr -> i8
+    %62 = call @dora_fn_extend_memory(%arg0, %45) : (!llvm.ptr, i64) -> !llvm.ptr
+    %63 = llvm.getelementptr %62[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %64 = llvm.load %63 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %68 = arith.cmpi ne, %67, %c0_i8 : i8
-    cf.cond_br %68, ^bb1(%67 : i8), ^bb24
+    %65 = arith.cmpi ne, %64, %c0_i8 : i8
+    cf.cond_br %65, ^bb1(%64 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb21
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore8.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore8.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb19, ^bb22, ^bb23
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c65535_i256 = arith.constant 65535 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c65535_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,146 +96,142 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.trunci %28 : i256 to i8
-    %c1_i64_9 = arith.constant 1 : i64
-    %c0_i64_10 = arith.constant 0 : i64
-    %30 = arith.cmpi ne, %c1_i64_9, %c0_i64_10 : i64
-    cf.cond_br %30, ^bb17, ^bb12
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.trunci %25 : i256 to i8
+    %c1_i64_6 = arith.constant 1 : i64
+    %c0_i64_7 = arith.constant 0 : i64
+    %27 = arith.cmpi ne, %c1_i64_6, %c0_i64_7 : i64
+    cf.cond_br %27, ^bb17, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb21
-    %31 = arith.trunci %24 : i256 to i64
-    %32 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    llvm.store %29, %33 {alignment = 1 : i64} : i8, !llvm.ptr
+    %28 = arith.trunci %22 : i256 to i64
+    %29 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[%28] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %26, %30 {alignment = 1 : i64} : i8, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_13 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_10 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_12 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_9 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb17:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %41 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %38 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %41, ^bb1(%c84_i8 : i8), ^bb18
+    cf.cond_br %38, ^bb1(%c84_i8 : i8), ^bb18
   ^bb18:  // pred: ^bb17
-    %42 = arith.trunci %24 : i256 to i64
-    %c0_i64_15 = arith.constant 0 : i64
-    %43 = arith.cmpi slt, %42, %c0_i64_15 : i64
-    %c84_i8_16 = arith.constant 84 : i8
-    cf.cond_br %43, ^bb1(%c84_i8_16 : i8), ^bb19
+    %39 = arith.trunci %22 : i256 to i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %40 = arith.cmpi slt, %39, %c0_i64_12 : i64
+    %c84_i8_13 = arith.constant 84 : i8
+    cf.cond_br %40, ^bb1(%c84_i8_13 : i8), ^bb19
   ^bb19:  // pred: ^bb18
-    %44 = arith.addi %42, %c1_i64_9 : i64
-    %c0_i64_17 = arith.constant 0 : i64
-    %45 = arith.cmpi slt, %44, %c0_i64_17 : i64
-    %c84_i8_18 = arith.constant 84 : i8
-    cf.cond_br %45, ^bb1(%c84_i8_18 : i8), ^bb20
+    %41 = arith.addi %39, %c1_i64_6 : i64
+    %c0_i64_14 = arith.constant 0 : i64
+    %42 = arith.cmpi slt, %41, %c0_i64_14 : i64
+    %c84_i8_15 = arith.constant 84 : i8
+    cf.cond_br %42, ^bb1(%c84_i8_15 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %46 = arith.addi %44, %c31_i64 : i64
-    %47 = arith.divui %46, %c32_i64 : i64
-    %c32_i64_19 = arith.constant 32 : i64
-    %48 = arith.muli %47, %c32_i64_19 : i64
-    %49 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_20 = arith.constant 31 : i64
-    %c32_i64_21 = arith.constant 32 : i64
-    %50 = arith.addi %49, %c31_i64_20 : i64
-    %51 = arith.divui %50, %c32_i64_21 : i64
-    %52 = arith.muli %51, %c32_i64_19 : i64
-    %53 = arith.cmpi ult, %52, %48 : i64
-    cf.cond_br %53, ^bb22, ^bb21
+    %43 = arith.addi %41, %c31_i64 : i64
+    %44 = arith.divui %43, %c32_i64 : i64
+    %c32_i64_16 = arith.constant 32 : i64
+    %45 = arith.muli %44, %c32_i64_16 : i64
+    %46 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_17 = arith.constant 31 : i64
+    %c32_i64_18 = arith.constant 32 : i64
+    %47 = arith.addi %46, %c31_i64_17 : i64
+    %48 = arith.divui %47, %c32_i64_18 : i64
+    %49 = arith.muli %48, %c32_i64_16 : i64
+    %50 = arith.cmpi ult, %49, %45 : i64
+    cf.cond_br %50, ^bb22, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb24
     cf.br ^bb12
   ^bb22:  // pred: ^bb20
-    %c3_i64_22 = arith.constant 3 : i64
+    %c3_i64_19 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %54 = arith.muli %51, %51 : i64
-    %55 = arith.divui %54, %c512_i64 : i64
-    %56 = arith.muli %51, %c3_i64_22 : i64
-    %57 = arith.addi %55, %56 : i64
-    %c3_i64_23 = arith.constant 3 : i64
-    %c512_i64_24 = arith.constant 512 : i64
-    %58 = arith.muli %47, %47 : i64
-    %59 = arith.divui %58, %c512_i64_24 : i64
-    %60 = arith.muli %47, %c3_i64_23 : i64
-    %61 = arith.addi %59, %60 : i64
-    %62 = arith.subi %61, %57 : i64
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %64 = arith.cmpi ult, %63, %62 : i64
-    scf.if %64 {
+    %51 = arith.muli %48, %48 : i64
+    %52 = arith.divui %51, %c512_i64 : i64
+    %53 = arith.muli %48, %c3_i64_19 : i64
+    %54 = arith.addi %52, %53 : i64
+    %c3_i64_20 = arith.constant 3 : i64
+    %c512_i64_21 = arith.constant 512 : i64
+    %55 = arith.muli %44, %44 : i64
+    %56 = arith.divui %55, %c512_i64_21 : i64
+    %57 = arith.muli %44, %c3_i64_20 : i64
+    %58 = arith.addi %56, %57 : i64
+    %59 = arith.subi %58, %54 : i64
+    %60 = llvm.load %arg1 : !llvm.ptr -> i64
+    %61 = arith.cmpi ult, %60, %59 : i64
+    scf.if %61 {
     } else {
-      %69 = arith.subi %63, %62 : i64
-      llvm.store %69, %arg1 : i64, !llvm.ptr
+      %66 = arith.subi %60, %59 : i64
+      llvm.store %66, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb1(%c80_i8_25 : i8), ^bb23
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %61, ^bb1(%c80_i8_22 : i8), ^bb23
   ^bb23:  // pred: ^bb22
-    %65 = call @dora_fn_extend_memory(%arg0, %48) : (!llvm.ptr, i64) -> !llvm.ptr
-    %66 = llvm.getelementptr %65[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %67 = llvm.load %66 : !llvm.ptr -> i8
+    %62 = call @dora_fn_extend_memory(%arg0, %45) : (!llvm.ptr, i64) -> !llvm.ptr
+    %63 = llvm.getelementptr %62[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %64 = llvm.load %63 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %68 = arith.cmpi ne, %67, %c0_i8 : i8
-    cf.cond_br %68, ^bb1(%67 : i8), ^bb24
+    %65 = arith.cmpi ne, %64, %c0_i8 : i8
+    cf.cond_br %65, ^bb1(%64 : i8), ^bb24
   ^bb24:  // pred: ^bb23
     cf.br ^bb21
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 66 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb69, ^bb71, ^bb72, ^bb74, ^bb75, ^bb77, ^bb78, ^bb81, ^bb82, ^bb83, ^bb86, ^bb87, ^bb89, ^bb90, ^bb91, ^bb92, ^bb93, ^bb96, ^bb97, ^bb99, ^bb100, ^bb101, ^bb104, ^bb105, ^bb107, ^bb108, ^bb109, ^bb112, ^bb113
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 66 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb69, ^bb71, ^bb72, ^bb74, ^bb75, ^bb77, ^bb78, ^bb81, ^bb82, ^bb83, ^bb86, ^bb87, ^bb89, ^bb90, ^bb91, ^bb92, ^bb93, ^bb96, ^bb97, ^bb99, ^bb100, ^bb101, ^bb104, ^bb105, ^bb107, ^bb108, ^bb109, ^bb112, ^bb113
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c35176690763027899028215972788860354566387_i256 = arith.constant 35176690763027899028215972788860354566387 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c35176690763027899028215972788860354566387_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,898 +96,861 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb81, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb81, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb85
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c15_i256 = arith.constant 15 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c15_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %c0_i256_25 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_26 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_25, %59 : i256, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb25:  // pred: ^bb27
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_28 : i64
-    %63 = arith.cmpi ult, %c1024_i64_27, %62 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_29 : i8), ^bb24
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_22 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_21, %56 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_23 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_31 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_30 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_24 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb36
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_32 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_33 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_34 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
-    %79 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %80 = arith.cmpi ne, %79, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %80, ^bb1(%c87_i8 : i8), ^bb29
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb30
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %82 = arith.trunci %78 : i256 to i64
-    %c0_i64_35 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_35 : i64
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_36 : i8), ^bb31
+    %73 = arith.trunci %69 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_37 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_37 : i64
-    cf.cond_br %84, ^bb89, ^bb32
+    %c0_i64_28 = arith.constant 0 : i64
+    %75 = arith.cmpi ne, %73, %c0_i64_28 : i64
+    cf.cond_br %75, ^bb89, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb95
     %c32000_i64 = arith.constant 32000 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %c32000_i64 : i64
-    scf.if %86 {
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %c32000_i64 : i64
+    scf.if %77 {
     } else {
-      %362 = arith.subi %85, %c32000_i64 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %76, %c32000_i64 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_38 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c1_i256 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %70, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %89 = arith.trunci %74 : i256 to i64
-    %90 = call @dora_fn_create(%arg0, %82, %89, %87, %88) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %91 = llvm.getelementptr %90[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %92 = llvm.load %91 : !llvm.ptr -> i8
-    %c0_i8_39 = arith.constant 0 : i8
-    %93 = arith.cmpi ne, %92, %c0_i8_39 : i8
-    cf.cond_br %93, ^bb1(%92 : i8), ^bb34
+    %78 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %80 = arith.trunci %66 : i256 to i64
+    %81 = call @dora_fn_create(%arg0, %73, %80, %78, %79) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %82 = llvm.getelementptr %81[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %83 = llvm.load %82 : !llvm.ptr -> i8
+    %c0_i8_30 = arith.constant 0 : i8
+    %84 = arith.cmpi ne, %83, %c0_i8_30 : i8
+    cf.cond_br %84, ^bb1(%83 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %94 = llvm.getelementptr %90[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %85 = llvm.getelementptr %81[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %362 = arith.subi %96, %95 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %87, %86 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_40 : i8), ^bb35
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_31 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = llvm.load %87 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %101 = arith.addi %99, %c1_i64_41 : i64
-    llvm.store %101, %arg3 : i64, !llvm.ptr
-    llvm.store %98, %100 : i256, !llvm.ptr
+    %89 = llvm.load %78 : !llvm.ptr -> i256
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %90 : i256, !llvm.ptr
+    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb41
   ^bb36:  // pred: ^bb38
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_43 = arith.constant -2 : i64
-    %103 = arith.addi %102, %c-2_i64_43 : i64
-    %c3_i64_44 = arith.constant 3 : i64
-    %104 = arith.cmpi ult, %102, %c3_i64_44 : i64
-    %c91_i8_45 = arith.constant 91 : i8
-    cf.cond_br %104, ^bb1(%c91_i8_45 : i8), ^bb28
+    %c1024_i64_32 = arith.constant 1024 : i64
+    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_33 = arith.constant -2 : i64
+    %93 = arith.addi %92, %c-2_i64_33 : i64
+    llvm.store %93, %arg3 : i64, !llvm.ptr
+    %c3_i64_34 = arith.constant 3 : i64
+    %94 = arith.cmpi ult, %92, %c3_i64_34 : i64
+    %c91_i8_35 = arith.constant 91 : i8
+    cf.cond_br %94, ^bb1(%c91_i8_35 : i8), ^bb28
   ^bb37:  // pred: ^bb24
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_36 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %106 = arith.cmpi uge, %105, %c0_i64_46 : i64
-    %c80_i8_47 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb38, ^bb1(%c80_i8_47 : i8)
+    %96 = arith.cmpi uge, %95, %c0_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %96, ^bb38, ^bb1(%c80_i8_37 : i8)
   ^bb38:  // pred: ^bb37
-    %107 = arith.subi %105, %c0_i64_46 : i64
-    llvm.store %107, %arg1 : i64, !llvm.ptr
+    %97 = arith.subi %95, %c0_i64_36 : i64
+    llvm.store %97, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb40
-    %c0_i256_48 = arith.constant 0 : i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %109 = llvm.getelementptr %arg2[%108] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_49 = arith.constant 1 : i64
-    %110 = arith.addi %108, %c1_i64_49 : i64
-    llvm.store %110, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_48, %109 : i256, !llvm.ptr
+    %c0_i256_38 = arith.constant 0 : i256
+    %98 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_38, %98 : i256, !llvm.ptr
+    %99 = llvm.getelementptr %98[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %99, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb45
   ^bb40:  // pred: ^bb42
-    %c1024_i64_50 = arith.constant 1024 : i64
-    %111 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_51 = arith.constant 1 : i64
-    %112 = arith.addi %111, %c1_i64_51 : i64
-    %113 = arith.cmpi ult, %c1024_i64_50, %112 : i64
-    %c92_i8_52 = arith.constant 92 : i8
-    cf.cond_br %113, ^bb1(%c92_i8_52 : i8), ^bb39
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %100 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %101 = arith.addi %100, %c1_i64_40 : i64
+    llvm.store %101, %arg3 : i64, !llvm.ptr
+    %102 = arith.cmpi ult, %c1024_i64_39, %101 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %102, ^bb1(%c92_i8_41 : i8), ^bb39
   ^bb41:  // pred: ^bb35
-    %114 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_53 = arith.constant 3 : i64
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_42 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %115 = arith.cmpi uge, %114, %c3_i64_53 : i64
-    %c80_i8_54 = arith.constant 80 : i8
-    cf.cond_br %115, ^bb42, ^bb1(%c80_i8_54 : i8)
+    %104 = arith.cmpi uge, %103, %c3_i64_42 : i64
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %104, ^bb42, ^bb1(%c80_i8_43 : i8)
   ^bb42:  // pred: ^bb41
-    %116 = arith.subi %114, %c3_i64_53 : i64
-    llvm.store %116, %arg1 : i64, !llvm.ptr
+    %105 = arith.subi %103, %c3_i64_42 : i64
+    llvm.store %105, %arg1 : i64, !llvm.ptr
     cf.br ^bb40
   ^bb43:  // pred: ^bb44
-    %c0_i256_55 = arith.constant 0 : i256
-    %117 = llvm.load %arg3 : !llvm.ptr -> i64
-    %118 = llvm.getelementptr %arg2[%117] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_56 = arith.constant 1 : i64
-    %119 = arith.addi %117, %c1_i64_56 : i64
-    llvm.store %119, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_55, %118 : i256, !llvm.ptr
+    %c0_i256_44 = arith.constant 0 : i256
+    %106 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_44, %106 : i256, !llvm.ptr
+    %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %107, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb49
   ^bb44:  // pred: ^bb46
-    %c1024_i64_57 = arith.constant 1024 : i64
-    %120 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_58 : i64
-    %122 = arith.cmpi ult, %c1024_i64_57, %121 : i64
-    %c92_i8_59 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_59 : i8), ^bb43
+    %c1024_i64_45 = arith.constant 1024 : i64
+    %108 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_46 = arith.constant 1 : i64
+    %109 = arith.addi %108, %c1_i64_46 : i64
+    llvm.store %109, %arg3 : i64, !llvm.ptr
+    %110 = arith.cmpi ult, %c1024_i64_45, %109 : i64
+    %c92_i8_47 = arith.constant 92 : i8
+    cf.cond_br %110, ^bb1(%c92_i8_47 : i8), ^bb43
   ^bb45:  // pred: ^bb39
-    %123 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_60 = arith.constant 3 : i64
+    %111 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_48 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %124 = arith.cmpi uge, %123, %c3_i64_60 : i64
-    %c80_i8_61 = arith.constant 80 : i8
-    cf.cond_br %124, ^bb46, ^bb1(%c80_i8_61 : i8)
+    %112 = arith.cmpi uge, %111, %c3_i64_48 : i64
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %112, ^bb46, ^bb1(%c80_i8_49 : i8)
   ^bb46:  // pred: ^bb45
-    %125 = arith.subi %123, %c3_i64_60 : i64
-    llvm.store %125, %arg1 : i64, !llvm.ptr
+    %113 = arith.subi %111, %c3_i64_48 : i64
+    llvm.store %113, %arg1 : i64, !llvm.ptr
     cf.br ^bb44
   ^bb47:  // pred: ^bb48
-    %c0_i256_62 = arith.constant 0 : i256
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
-    %127 = llvm.getelementptr %arg2[%126] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_63 = arith.constant 1 : i64
-    %128 = arith.addi %126, %c1_i64_63 : i64
-    llvm.store %128, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_62, %127 : i256, !llvm.ptr
+    %c0_i256_50 = arith.constant 0 : i256
+    %114 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_50, %114 : i256, !llvm.ptr
+    %115 = llvm.getelementptr %114[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %115, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb53
   ^bb48:  // pred: ^bb50
-    %c1024_i64_64 = arith.constant 1024 : i64
-    %129 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_65 = arith.constant 1 : i64
-    %130 = arith.addi %129, %c1_i64_65 : i64
-    %131 = arith.cmpi ult, %c1024_i64_64, %130 : i64
-    %c92_i8_66 = arith.constant 92 : i8
-    cf.cond_br %131, ^bb1(%c92_i8_66 : i8), ^bb47
+    %c1024_i64_51 = arith.constant 1024 : i64
+    %116 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_52 = arith.constant 1 : i64
+    %117 = arith.addi %116, %c1_i64_52 : i64
+    llvm.store %117, %arg3 : i64, !llvm.ptr
+    %118 = arith.cmpi ult, %c1024_i64_51, %117 : i64
+    %c92_i8_53 = arith.constant 92 : i8
+    cf.cond_br %118, ^bb1(%c92_i8_53 : i8), ^bb47
   ^bb49:  // pred: ^bb43
-    %132 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_67 = arith.constant 3 : i64
+    %119 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_54 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %133 = arith.cmpi uge, %132, %c3_i64_67 : i64
-    %c80_i8_68 = arith.constant 80 : i8
-    cf.cond_br %133, ^bb50, ^bb1(%c80_i8_68 : i8)
+    %120 = arith.cmpi uge, %119, %c3_i64_54 : i64
+    %c80_i8_55 = arith.constant 80 : i8
+    cf.cond_br %120, ^bb50, ^bb1(%c80_i8_55 : i8)
   ^bb50:  // pred: ^bb49
-    %134 = arith.subi %132, %c3_i64_67 : i64
-    llvm.store %134, %arg1 : i64, !llvm.ptr
+    %121 = arith.subi %119, %c3_i64_54 : i64
+    llvm.store %121, %arg1 : i64, !llvm.ptr
     cf.br ^bb48
   ^bb51:  // pred: ^bb52
-    %c0_i256_69 = arith.constant 0 : i256
-    %135 = llvm.load %arg3 : !llvm.ptr -> i64
-    %136 = llvm.getelementptr %arg2[%135] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_70 = arith.constant 1 : i64
-    %137 = arith.addi %135, %c1_i64_70 : i64
-    llvm.store %137, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_69, %136 : i256, !llvm.ptr
+    %c0_i256_56 = arith.constant 0 : i256
+    %122 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_56, %122 : i256, !llvm.ptr
+    %123 = llvm.getelementptr %122[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %123, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb57
   ^bb52:  // pred: ^bb54
-    %c1024_i64_71 = arith.constant 1024 : i64
-    %138 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_72 : i64
-    %140 = arith.cmpi ult, %c1024_i64_71, %139 : i64
-    %c92_i8_73 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_73 : i8), ^bb51
+    %c1024_i64_57 = arith.constant 1024 : i64
+    %124 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_58 = arith.constant 1 : i64
+    %125 = arith.addi %124, %c1_i64_58 : i64
+    llvm.store %125, %arg3 : i64, !llvm.ptr
+    %126 = arith.cmpi ult, %c1024_i64_57, %125 : i64
+    %c92_i8_59 = arith.constant 92 : i8
+    cf.cond_br %126, ^bb1(%c92_i8_59 : i8), ^bb51
   ^bb53:  // pred: ^bb47
-    %141 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_74 = arith.constant 3 : i64
+    %127 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_60 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %142 = arith.cmpi uge, %141, %c3_i64_74 : i64
-    %c80_i8_75 = arith.constant 80 : i8
-    cf.cond_br %142, ^bb54, ^bb1(%c80_i8_75 : i8)
+    %128 = arith.cmpi uge, %127, %c3_i64_60 : i64
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %128, ^bb54, ^bb1(%c80_i8_61 : i8)
   ^bb54:  // pred: ^bb53
-    %143 = arith.subi %141, %c3_i64_74 : i64
-    llvm.store %143, %arg1 : i64, !llvm.ptr
+    %129 = arith.subi %127, %c3_i64_60 : i64
+    llvm.store %129, %arg1 : i64, !llvm.ptr
     cf.br ^bb52
   ^bb55:  // pred: ^bb56
-    %c0_i256_76 = arith.constant 0 : i256
-    %144 = llvm.load %arg3 : !llvm.ptr -> i64
-    %145 = llvm.getelementptr %arg2[%144] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_77 = arith.constant 1 : i64
-    %146 = arith.addi %144, %c1_i64_77 : i64
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_76, %145 : i256, !llvm.ptr
+    %c0_i256_62 = arith.constant 0 : i256
+    %130 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_62, %130 : i256, !llvm.ptr
+    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %131, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb61
   ^bb56:  // pred: ^bb58
-    %c1024_i64_78 = arith.constant 1024 : i64
-    %147 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %148 = arith.addi %147, %c1_i64_79 : i64
-    %149 = arith.cmpi ult, %c1024_i64_78, %148 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %149, ^bb1(%c92_i8_80 : i8), ^bb55
+    %c1024_i64_63 = arith.constant 1024 : i64
+    %132 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_64 = arith.constant 1 : i64
+    %133 = arith.addi %132, %c1_i64_64 : i64
+    llvm.store %133, %arg3 : i64, !llvm.ptr
+    %134 = arith.cmpi ult, %c1024_i64_63, %133 : i64
+    %c92_i8_65 = arith.constant 92 : i8
+    cf.cond_br %134, ^bb1(%c92_i8_65 : i8), ^bb55
   ^bb57:  // pred: ^bb51
-    %150 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_81 = arith.constant 3 : i64
+    %135 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_66 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %151 = arith.cmpi uge, %150, %c3_i64_81 : i64
-    %c80_i8_82 = arith.constant 80 : i8
-    cf.cond_br %151, ^bb58, ^bb1(%c80_i8_82 : i8)
+    %136 = arith.cmpi uge, %135, %c3_i64_66 : i64
+    %c80_i8_67 = arith.constant 80 : i8
+    cf.cond_br %136, ^bb58, ^bb1(%c80_i8_67 : i8)
   ^bb58:  // pred: ^bb57
-    %152 = arith.subi %150, %c3_i64_81 : i64
-    llvm.store %152, %arg1 : i64, !llvm.ptr
+    %137 = arith.subi %135, %c3_i64_66 : i64
+    llvm.store %137, %arg1 : i64, !llvm.ptr
     cf.br ^bb56
   ^bb59:  // pred: ^bb60
-    %153 = llvm.load %arg3 : !llvm.ptr -> i64
-    %154 = llvm.getelementptr %arg2[%153] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %155 = llvm.getelementptr %154[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.load %arg3 : !llvm.ptr -> i64
-    %158 = llvm.getelementptr %arg2[%157] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_83 = arith.constant 1 : i64
-    %159 = arith.addi %157, %c1_i64_83 : i64
-    llvm.store %159, %arg3 : i64, !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
+    %138 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %139 = llvm.getelementptr %138[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %140 = llvm.load %139 : !llvm.ptr -> i256
+    %141 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %140, %141 : i256, !llvm.ptr
+    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %142, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb65
   ^bb60:  // pred: ^bb62
-    %c1024_i64_84 = arith.constant 1024 : i64
-    %160 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_85 : i64
+    %c1024_i64_68 = arith.constant 1024 : i64
+    %143 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_69 = arith.constant 1 : i64
+    %144 = arith.addi %143, %c1_i64_69 : i64
+    llvm.store %144, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %162 = arith.cmpi ult, %160, %c6_i64 : i64
-    %163 = arith.cmpi ult, %c1024_i64_84, %161 : i64
-    %164 = arith.xori %162, %163 : i1
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %164, ^bb1(%c92_i8_86 : i8), ^bb59
+    %145 = arith.cmpi ult, %143, %c6_i64 : i64
+    %146 = arith.cmpi ult, %c1024_i64_68, %144 : i64
+    %147 = arith.xori %145, %146 : i1
+    %c92_i8_70 = arith.constant 92 : i8
+    cf.cond_br %147, ^bb1(%c92_i8_70 : i8), ^bb59
   ^bb61:  // pred: ^bb55
-    %165 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_87 = arith.constant 3 : i64
+    %148 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_71 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %166 = arith.cmpi uge, %165, %c3_i64_87 : i64
-    %c80_i8_88 = arith.constant 80 : i8
-    cf.cond_br %166, ^bb62, ^bb1(%c80_i8_88 : i8)
+    %149 = arith.cmpi uge, %148, %c3_i64_71 : i64
+    %c80_i8_72 = arith.constant 80 : i8
+    cf.cond_br %149, ^bb62, ^bb1(%c80_i8_72 : i8)
   ^bb62:  // pred: ^bb61
-    %167 = arith.subi %165, %c3_i64_87 : i64
-    llvm.store %167, %arg1 : i64, !llvm.ptr
+    %150 = arith.subi %148, %c3_i64_71 : i64
+    llvm.store %150, %arg1 : i64, !llvm.ptr
     cf.br ^bb60
   ^bb63:  // pred: ^bb64
     %c65535_i256 = arith.constant 65535 : i256
-    %168 = llvm.load %arg3 : !llvm.ptr -> i64
-    %169 = llvm.getelementptr %arg2[%168] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_89 = arith.constant 1 : i64
-    %170 = arith.addi %168, %c1_i64_89 : i64
-    llvm.store %170, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256, %169 : i256, !llvm.ptr
+    %151 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %151 : i256, !llvm.ptr
+    %152 = llvm.getelementptr %151[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %152, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb78
   ^bb64:  // pred: ^bb66
-    %c1024_i64_90 = arith.constant 1024 : i64
-    %171 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_91 = arith.constant 1 : i64
-    %172 = arith.addi %171, %c1_i64_91 : i64
-    %173 = arith.cmpi ult, %c1024_i64_90, %172 : i64
-    %c92_i8_92 = arith.constant 92 : i8
-    cf.cond_br %173, ^bb1(%c92_i8_92 : i8), ^bb63
+    %c1024_i64_73 = arith.constant 1024 : i64
+    %153 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_74 = arith.constant 1 : i64
+    %154 = arith.addi %153, %c1_i64_74 : i64
+    llvm.store %154, %arg3 : i64, !llvm.ptr
+    %155 = arith.cmpi ult, %c1024_i64_73, %154 : i64
+    %c92_i8_75 = arith.constant 92 : i8
+    cf.cond_br %155, ^bb1(%c92_i8_75 : i8), ^bb63
   ^bb65:  // pred: ^bb59
-    %174 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_93 = arith.constant 3 : i64
+    %156 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_76 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %175 = arith.cmpi uge, %174, %c3_i64_93 : i64
-    %c80_i8_94 = arith.constant 80 : i8
-    cf.cond_br %175, ^bb66, ^bb1(%c80_i8_94 : i8)
+    %157 = arith.cmpi uge, %156, %c3_i64_76 : i64
+    %c80_i8_77 = arith.constant 80 : i8
+    cf.cond_br %157, ^bb66, ^bb1(%c80_i8_77 : i8)
   ^bb66:  // pred: ^bb65
-    %176 = arith.subi %174, %c3_i64_93 : i64
-    llvm.store %176, %arg1 : i64, !llvm.ptr
+    %158 = arith.subi %156, %c3_i64_76 : i64
+    llvm.store %158, %arg1 : i64, !llvm.ptr
     cf.br ^bb64
   ^bb67:  // pred: ^bb77
-    %177 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_95 = arith.constant 1 : i64
-    %178 = arith.subi %177, %c1_i64_95 : i64
-    %179 = llvm.getelementptr %arg2[%178] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %178, %arg3 : i64, !llvm.ptr
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    %181 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %182 = arith.subi %181, %c1_i64_96 : i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %182, %arg3 : i64, !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_97 = arith.constant 1 : i64
-    %186 = arith.subi %185, %c1_i64_97 : i64
-    %187 = llvm.getelementptr %arg2[%186] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %186, %arg3 : i64, !llvm.ptr
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    %189 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_98 = arith.constant 1 : i64
-    %190 = arith.subi %189, %c1_i64_98 : i64
-    %191 = llvm.getelementptr %arg2[%190] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %190, %arg3 : i64, !llvm.ptr
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    %193 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_99 = arith.constant 1 : i64
-    %194 = arith.subi %193, %c1_i64_99 : i64
-    %195 = llvm.getelementptr %arg2[%194] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %194, %arg3 : i64, !llvm.ptr
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    %197 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_100 = arith.constant 1 : i64
-    %198 = arith.subi %197, %c1_i64_100 : i64
-    %199 = llvm.getelementptr %arg2[%198] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %198, %arg3 : i64, !llvm.ptr
-    %200 = llvm.load %199 : !llvm.ptr -> i256
-    %201 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_101 = arith.constant 1 : i64
-    %202 = arith.subi %201, %c1_i64_101 : i64
-    %203 = llvm.getelementptr %arg2[%202] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %202, %arg3 : i64, !llvm.ptr
-    %204 = llvm.load %203 : !llvm.ptr -> i256
-    %205 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
-    %c0_i8_102 = arith.constant 0 : i8
-    %206 = arith.cmpi ne, %205, %c0_i8_102 : i8
-    %c0_i256_103 = arith.constant 0 : i256
-    %207 = arith.cmpi ne, %188, %c0_i256_103 : i256
-    %208 = arith.andi %206, %207 : i1
+    %159 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %160 = llvm.getelementptr %159[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %161 = llvm.load %160 : !llvm.ptr -> i256
+    llvm.store %160, %0 : !llvm.ptr, !llvm.ptr
+    %162 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %163 = llvm.getelementptr %162[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %164 = llvm.load %163 : !llvm.ptr -> i256
+    llvm.store %163, %0 : !llvm.ptr, !llvm.ptr
+    %165 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %166 = llvm.getelementptr %165[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %167 = llvm.load %166 : !llvm.ptr -> i256
+    llvm.store %166, %0 : !llvm.ptr, !llvm.ptr
+    %168 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %170 = llvm.load %169 : !llvm.ptr -> i256
+    llvm.store %169, %0 : !llvm.ptr, !llvm.ptr
+    %171 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %0 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %176 = llvm.load %175 : !llvm.ptr -> i256
+    llvm.store %175, %0 : !llvm.ptr, !llvm.ptr
+    %177 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %178 = llvm.getelementptr %177[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %179 = llvm.load %178 : !llvm.ptr -> i256
+    llvm.store %178, %0 : !llvm.ptr, !llvm.ptr
+    %180 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %c0_i8_78 = arith.constant 0 : i8
+    %181 = arith.cmpi ne, %180, %c0_i8_78 : i8
+    %c0_i256_79 = arith.constant 0 : i256
+    %182 = arith.cmpi ne, %167, %c0_i256_79 : i256
+    %183 = arith.andi %181, %182 : i1
     %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %208, ^bb1(%c86_i8 : i8), ^bb68
+    cf.cond_br %183, ^bb1(%c86_i8 : i8), ^bb68
   ^bb68:  // pred: ^bb67
-    %c18446744073709551615_i256_104 = arith.constant 18446744073709551615 : i256
-    %209 = arith.cmpi sgt, %196, %c18446744073709551615_i256_104 : i256
-    %c84_i8_105 = arith.constant 84 : i8
-    cf.cond_br %209, ^bb1(%c84_i8_105 : i8), ^bb69
+    %c18446744073709551615_i256_80 = arith.constant 18446744073709551615 : i256
+    %184 = arith.cmpi sgt, %173, %c18446744073709551615_i256_80 : i256
+    %c84_i8_81 = arith.constant 84 : i8
+    cf.cond_br %184, ^bb1(%c84_i8_81 : i8), ^bb69
   ^bb69:  // pred: ^bb68
-    %210 = arith.trunci %196 : i256 to i64
-    %c0_i64_106 = arith.constant 0 : i64
-    %211 = arith.cmpi slt, %210, %c0_i64_106 : i64
-    %c84_i8_107 = arith.constant 84 : i8
-    cf.cond_br %211, ^bb1(%c84_i8_107 : i8), ^bb70
+    %185 = arith.trunci %173 : i256 to i64
+    %c0_i64_82 = arith.constant 0 : i64
+    %186 = arith.cmpi slt, %185, %c0_i64_82 : i64
+    %c84_i8_83 = arith.constant 84 : i8
+    cf.cond_br %186, ^bb1(%c84_i8_83 : i8), ^bb70
   ^bb70:  // pred: ^bb69
-    %c0_i64_108 = arith.constant 0 : i64
-    %212 = arith.cmpi ne, %210, %c0_i64_108 : i64
-    cf.cond_br %212, ^bb99, ^bb71
+    %c0_i64_84 = arith.constant 0 : i64
+    %187 = arith.cmpi ne, %185, %c0_i64_84 : i64
+    cf.cond_br %187, ^bb99, ^bb71
   ^bb71:  // 2 preds: ^bb70, ^bb103
-    %c18446744073709551615_i256_109 = arith.constant 18446744073709551615 : i256
-    %213 = arith.cmpi sgt, %204, %c18446744073709551615_i256_109 : i256
-    %c84_i8_110 = arith.constant 84 : i8
-    cf.cond_br %213, ^bb1(%c84_i8_110 : i8), ^bb72
+    %c18446744073709551615_i256_85 = arith.constant 18446744073709551615 : i256
+    %188 = arith.cmpi sgt, %179, %c18446744073709551615_i256_85 : i256
+    %c84_i8_86 = arith.constant 84 : i8
+    cf.cond_br %188, ^bb1(%c84_i8_86 : i8), ^bb72
   ^bb72:  // pred: ^bb71
-    %214 = arith.trunci %204 : i256 to i64
-    %c0_i64_111 = arith.constant 0 : i64
-    %215 = arith.cmpi slt, %214, %c0_i64_111 : i64
-    %c84_i8_112 = arith.constant 84 : i8
-    cf.cond_br %215, ^bb1(%c84_i8_112 : i8), ^bb73
+    %189 = arith.trunci %179 : i256 to i64
+    %c0_i64_87 = arith.constant 0 : i64
+    %190 = arith.cmpi slt, %189, %c0_i64_87 : i64
+    %c84_i8_88 = arith.constant 84 : i8
+    cf.cond_br %190, ^bb1(%c84_i8_88 : i8), ^bb73
   ^bb73:  // pred: ^bb72
-    %c0_i64_113 = arith.constant 0 : i64
-    %216 = arith.cmpi ne, %214, %c0_i64_113 : i64
-    cf.cond_br %216, ^bb107, ^bb74
+    %c0_i64_89 = arith.constant 0 : i64
+    %191 = arith.cmpi ne, %189, %c0_i64_89 : i64
+    cf.cond_br %191, ^bb107, ^bb74
   ^bb74:  // 2 preds: ^bb73, ^bb111
-    %217 = arith.trunci %192 : i256 to i64
-    %218 = arith.trunci %200 : i256 to i64
-    %219 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_114 = arith.constant 1 : i256
-    %220 = llvm.alloca %c1_i256_114 x i256 : (i256) -> !llvm.ptr
-    llvm.store %188, %220 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_115 = arith.constant 1 : i256
-    %221 = llvm.alloca %c1_i256_115 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %221 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_116 = arith.constant 1 : i256
-    %222 = llvm.alloca %c1_i256_116 x i256 : (i256) -> !llvm.ptr
-    llvm.store %184, %222 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i8_117 = arith.constant 0 : i8
-    %223 = call @dora_fn_call(%arg0, %221, %222, %220, %217, %210, %218, %214, %219, %c0_i8_117) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %224 = llvm.getelementptr %223[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %225 = llvm.load %224 : !llvm.ptr -> i8
-    %226 = llvm.getelementptr %223[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %227 = llvm.load %226 : !llvm.ptr -> i8
-    %c0_i8_118 = arith.constant 0 : i8
-    %228 = arith.cmpi ne, %227, %c0_i8_118 : i8
-    cf.cond_br %228, ^bb1(%227 : i8), ^bb75
+    %192 = arith.trunci %170 : i256 to i64
+    %193 = arith.trunci %176 : i256 to i64
+    %194 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_90 = arith.constant 1 : i256
+    %195 = llvm.alloca %c1_i256_90 x i256 : (i256) -> !llvm.ptr
+    llvm.store %167, %195 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_91 = arith.constant 1 : i256
+    %196 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
+    llvm.store %161, %196 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_92 = arith.constant 1 : i256
+    %197 = llvm.alloca %c1_i256_92 x i256 : (i256) -> !llvm.ptr
+    llvm.store %164, %197 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i8_93 = arith.constant 0 : i8
+    %198 = call @dora_fn_call(%arg0, %196, %197, %195, %192, %185, %193, %189, %194, %c0_i8_93) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %199 = llvm.getelementptr %198[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %200 = llvm.load %199 : !llvm.ptr -> i8
+    %201 = llvm.getelementptr %198[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %202 = llvm.load %201 : !llvm.ptr -> i8
+    %c0_i8_94 = arith.constant 0 : i8
+    %203 = arith.cmpi ne, %202, %c0_i8_94 : i8
+    cf.cond_br %203, ^bb1(%202 : i8), ^bb75
   ^bb75:  // pred: ^bb74
-    %229 = llvm.getelementptr %223[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %230 = llvm.load %229 : !llvm.ptr -> i64
-    %231 = llvm.load %arg1 : !llvm.ptr -> i64
-    %232 = arith.cmpi ult, %231, %230 : i64
-    scf.if %232 {
+    %204 = llvm.getelementptr %198[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %205 = llvm.load %204 : !llvm.ptr -> i64
+    %206 = llvm.load %arg1 : !llvm.ptr -> i64
+    %207 = arith.cmpi ult, %206, %205 : i64
+    scf.if %207 {
     } else {
-      %362 = arith.subi %231, %230 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %206, %205 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_119 = arith.constant 80 : i8
-    cf.cond_br %232, ^bb1(%c80_i8_119 : i8), ^bb76
+    %c80_i8_95 = arith.constant 80 : i8
+    cf.cond_br %207, ^bb1(%c80_i8_95 : i8), ^bb76
   ^bb76:  // pred: ^bb75
-    %233 = arith.extui %225 : i8 to i256
-    %234 = llvm.load %arg3 : !llvm.ptr -> i64
-    %235 = llvm.getelementptr %arg2[%234] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_120 = arith.constant 1 : i64
-    %236 = arith.addi %234, %c1_i64_120 : i64
-    llvm.store %236, %arg3 : i64, !llvm.ptr
-    llvm.store %233, %235 : i256, !llvm.ptr
+    %208 = arith.extui %200 : i8 to i256
+    %209 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %208, %209 : i256, !llvm.ptr
+    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %210, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb80
   ^bb77:  // pred: ^bb79
-    %c1024_i64_121 = arith.constant 1024 : i64
-    %237 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_96 = arith.constant 1024 : i64
+    %211 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %238 = arith.addi %237, %c-6_i64 : i64
+    %212 = arith.addi %211, %c-6_i64 : i64
+    llvm.store %212, %arg3 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %239 = arith.cmpi ult, %237, %c7_i64 : i64
-    %c91_i8_122 = arith.constant 91 : i8
-    cf.cond_br %239, ^bb1(%c91_i8_122 : i8), ^bb67
+    %213 = arith.cmpi ult, %211, %c7_i64 : i64
+    %c91_i8_97 = arith.constant 91 : i8
+    cf.cond_br %213, ^bb1(%c91_i8_97 : i8), ^bb67
   ^bb78:  // pred: ^bb63
-    %240 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_123 = arith.constant 0 : i64
+    %214 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_98 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %241 = arith.cmpi uge, %240, %c0_i64_123 : i64
-    %c80_i8_124 = arith.constant 80 : i8
-    cf.cond_br %241, ^bb79, ^bb1(%c80_i8_124 : i8)
+    %215 = arith.cmpi uge, %214, %c0_i64_98 : i64
+    %c80_i8_99 = arith.constant 80 : i8
+    cf.cond_br %215, ^bb79, ^bb1(%c80_i8_99 : i8)
   ^bb79:  // pred: ^bb78
-    %242 = arith.subi %240, %c0_i64_123 : i64
-    llvm.store %242, %arg1 : i64, !llvm.ptr
+    %216 = arith.subi %214, %c0_i64_98 : i64
+    llvm.store %216, %arg1 : i64, !llvm.ptr
     cf.br ^bb77
   ^bb80:  // pred: ^bb76
-    %c0_i64_125 = arith.constant 0 : i64
+    %c0_i64_100 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %243 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_125, %c0_i64_125, %243, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %217 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_100, %c0_i64_100, %217, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb81:  // pred: ^bb11
-    %c18446744073709551615_i256_126 = arith.constant 18446744073709551615 : i256
-    %244 = arith.cmpi sgt, %24, %c18446744073709551615_i256_126 : i256
-    %c84_i8_127 = arith.constant 84 : i8
-    cf.cond_br %244, ^bb1(%c84_i8_127 : i8), ^bb82
+    %c18446744073709551615_i256_101 = arith.constant 18446744073709551615 : i256
+    %218 = arith.cmpi sgt, %22, %c18446744073709551615_i256_101 : i256
+    %c84_i8_102 = arith.constant 84 : i8
+    cf.cond_br %218, ^bb1(%c84_i8_102 : i8), ^bb82
   ^bb82:  // pred: ^bb81
-    %245 = arith.trunci %24 : i256 to i64
-    %c0_i64_128 = arith.constant 0 : i64
-    %246 = arith.cmpi slt, %245, %c0_i64_128 : i64
-    %c84_i8_129 = arith.constant 84 : i8
-    cf.cond_br %246, ^bb1(%c84_i8_129 : i8), ^bb83
+    %219 = arith.trunci %22 : i256 to i64
+    %c0_i64_103 = arith.constant 0 : i64
+    %220 = arith.cmpi slt, %219, %c0_i64_103 : i64
+    %c84_i8_104 = arith.constant 84 : i8
+    cf.cond_br %220, ^bb1(%c84_i8_104 : i8), ^bb83
   ^bb83:  // pred: ^bb82
-    %247 = arith.addi %245, %c32_i64 : i64
-    %c0_i64_130 = arith.constant 0 : i64
-    %248 = arith.cmpi slt, %247, %c0_i64_130 : i64
-    %c84_i8_131 = arith.constant 84 : i8
-    cf.cond_br %248, ^bb1(%c84_i8_131 : i8), ^bb84
+    %221 = arith.addi %219, %c32_i64 : i64
+    %c0_i64_105 = arith.constant 0 : i64
+    %222 = arith.cmpi slt, %221, %c0_i64_105 : i64
+    %c84_i8_106 = arith.constant 84 : i8
+    cf.cond_br %222, ^bb1(%c84_i8_106 : i8), ^bb84
   ^bb84:  // pred: ^bb83
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_132 = arith.constant 32 : i64
-    %249 = arith.addi %247, %c31_i64 : i64
-    %250 = arith.divui %249, %c32_i64_132 : i64
-    %c32_i64_133 = arith.constant 32 : i64
-    %251 = arith.muli %250, %c32_i64_133 : i64
-    %252 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_134 = arith.constant 31 : i64
-    %c32_i64_135 = arith.constant 32 : i64
-    %253 = arith.addi %252, %c31_i64_134 : i64
-    %254 = arith.divui %253, %c32_i64_135 : i64
-    %255 = arith.muli %254, %c32_i64_133 : i64
-    %256 = arith.cmpi ult, %255, %251 : i64
-    cf.cond_br %256, ^bb86, ^bb85
+    %c32_i64_107 = arith.constant 32 : i64
+    %223 = arith.addi %221, %c31_i64 : i64
+    %224 = arith.divui %223, %c32_i64_107 : i64
+    %c32_i64_108 = arith.constant 32 : i64
+    %225 = arith.muli %224, %c32_i64_108 : i64
+    %226 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_109 = arith.constant 31 : i64
+    %c32_i64_110 = arith.constant 32 : i64
+    %227 = arith.addi %226, %c31_i64_109 : i64
+    %228 = arith.divui %227, %c32_i64_110 : i64
+    %229 = arith.muli %228, %c32_i64_108 : i64
+    %230 = arith.cmpi ult, %229, %225 : i64
+    cf.cond_br %230, ^bb86, ^bb85
   ^bb85:  // 2 preds: ^bb84, ^bb88
     cf.br ^bb12
   ^bb86:  // pred: ^bb84
-    %c3_i64_136 = arith.constant 3 : i64
+    %c3_i64_111 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %257 = arith.muli %254, %254 : i64
-    %258 = arith.divui %257, %c512_i64 : i64
-    %259 = arith.muli %254, %c3_i64_136 : i64
-    %260 = arith.addi %258, %259 : i64
-    %c3_i64_137 = arith.constant 3 : i64
-    %c512_i64_138 = arith.constant 512 : i64
-    %261 = arith.muli %250, %250 : i64
-    %262 = arith.divui %261, %c512_i64_138 : i64
-    %263 = arith.muli %250, %c3_i64_137 : i64
-    %264 = arith.addi %262, %263 : i64
-    %265 = arith.subi %264, %260 : i64
-    %266 = llvm.load %arg1 : !llvm.ptr -> i64
-    %267 = arith.cmpi ult, %266, %265 : i64
-    scf.if %267 {
+    %231 = arith.muli %228, %228 : i64
+    %232 = arith.divui %231, %c512_i64 : i64
+    %233 = arith.muli %228, %c3_i64_111 : i64
+    %234 = arith.addi %232, %233 : i64
+    %c3_i64_112 = arith.constant 3 : i64
+    %c512_i64_113 = arith.constant 512 : i64
+    %235 = arith.muli %224, %224 : i64
+    %236 = arith.divui %235, %c512_i64_113 : i64
+    %237 = arith.muli %224, %c3_i64_112 : i64
+    %238 = arith.addi %236, %237 : i64
+    %239 = arith.subi %238, %234 : i64
+    %240 = llvm.load %arg1 : !llvm.ptr -> i64
+    %241 = arith.cmpi ult, %240, %239 : i64
+    scf.if %241 {
     } else {
-      %362 = arith.subi %266, %265 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %240, %239 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_139 = arith.constant 80 : i8
-    cf.cond_br %267, ^bb1(%c80_i8_139 : i8), ^bb87
+    %c80_i8_114 = arith.constant 80 : i8
+    cf.cond_br %241, ^bb1(%c80_i8_114 : i8), ^bb87
   ^bb87:  // pred: ^bb86
-    %268 = call @dora_fn_extend_memory(%arg0, %251) : (!llvm.ptr, i64) -> !llvm.ptr
-    %269 = llvm.getelementptr %268[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %270 = llvm.load %269 : !llvm.ptr -> i8
-    %c0_i8_140 = arith.constant 0 : i8
-    %271 = arith.cmpi ne, %270, %c0_i8_140 : i8
-    cf.cond_br %271, ^bb1(%270 : i8), ^bb88
+    %242 = call @dora_fn_extend_memory(%arg0, %225) : (!llvm.ptr, i64) -> !llvm.ptr
+    %243 = llvm.getelementptr %242[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %244 = llvm.load %243 : !llvm.ptr -> i8
+    %c0_i8_115 = arith.constant 0 : i8
+    %245 = arith.cmpi ne, %244, %c0_i8_115 : i8
+    cf.cond_br %245, ^bb1(%244 : i8), ^bb88
   ^bb88:  // pred: ^bb87
     cf.br ^bb85
   ^bb89:  // pred: ^bb31
     %c49152_i64 = arith.constant 49152 : i64
-    %272 = arith.cmpi ugt, %82, %c49152_i64 : i64
+    %246 = arith.cmpi ugt, %73, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %272, ^bb1(%c100_i8 : i8), ^bb90
+    cf.cond_br %246, ^bb1(%c100_i8 : i8), ^bb90
   ^bb90:  // pred: ^bb89
-    %c31_i64_141 = arith.constant 31 : i64
-    %c32_i64_142 = arith.constant 32 : i64
-    %273 = arith.addi %82, %c31_i64_141 : i64
-    %274 = arith.divui %273, %c32_i64_142 : i64
-    %c2_i64_143 = arith.constant 2 : i64
-    %275 = arith.muli %274, %c2_i64_143 : i64
-    %276 = llvm.load %arg1 : !llvm.ptr -> i64
-    %277 = arith.cmpi ult, %276, %275 : i64
-    scf.if %277 {
+    %c31_i64_116 = arith.constant 31 : i64
+    %c32_i64_117 = arith.constant 32 : i64
+    %247 = arith.addi %73, %c31_i64_116 : i64
+    %248 = arith.divui %247, %c32_i64_117 : i64
+    %c2_i64_118 = arith.constant 2 : i64
+    %249 = arith.muli %248, %c2_i64_118 : i64
+    %250 = llvm.load %arg1 : !llvm.ptr -> i64
+    %251 = arith.cmpi ult, %250, %249 : i64
+    scf.if %251 {
     } else {
-      %362 = arith.subi %276, %275 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %250, %249 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_144 = arith.constant 80 : i8
-    cf.cond_br %277, ^bb1(%c80_i8_144 : i8), ^bb91
+    %c80_i8_119 = arith.constant 80 : i8
+    cf.cond_br %251, ^bb1(%c80_i8_119 : i8), ^bb91
   ^bb91:  // pred: ^bb90
-    %c18446744073709551615_i256_145 = arith.constant 18446744073709551615 : i256
-    %278 = arith.cmpi sgt, %74, %c18446744073709551615_i256_145 : i256
-    %c84_i8_146 = arith.constant 84 : i8
-    cf.cond_br %278, ^bb1(%c84_i8_146 : i8), ^bb92
+    %c18446744073709551615_i256_120 = arith.constant 18446744073709551615 : i256
+    %252 = arith.cmpi sgt, %66, %c18446744073709551615_i256_120 : i256
+    %c84_i8_121 = arith.constant 84 : i8
+    cf.cond_br %252, ^bb1(%c84_i8_121 : i8), ^bb92
   ^bb92:  // pred: ^bb91
-    %279 = arith.trunci %74 : i256 to i64
-    %c0_i64_147 = arith.constant 0 : i64
-    %280 = arith.cmpi slt, %279, %c0_i64_147 : i64
-    %c84_i8_148 = arith.constant 84 : i8
-    cf.cond_br %280, ^bb1(%c84_i8_148 : i8), ^bb93
+    %253 = arith.trunci %66 : i256 to i64
+    %c0_i64_122 = arith.constant 0 : i64
+    %254 = arith.cmpi slt, %253, %c0_i64_122 : i64
+    %c84_i8_123 = arith.constant 84 : i8
+    cf.cond_br %254, ^bb1(%c84_i8_123 : i8), ^bb93
   ^bb93:  // pred: ^bb92
-    %281 = arith.addi %279, %82 : i64
-    %c0_i64_149 = arith.constant 0 : i64
-    %282 = arith.cmpi slt, %281, %c0_i64_149 : i64
-    %c84_i8_150 = arith.constant 84 : i8
-    cf.cond_br %282, ^bb1(%c84_i8_150 : i8), ^bb94
+    %255 = arith.addi %253, %73 : i64
+    %c0_i64_124 = arith.constant 0 : i64
+    %256 = arith.cmpi slt, %255, %c0_i64_124 : i64
+    %c84_i8_125 = arith.constant 84 : i8
+    cf.cond_br %256, ^bb1(%c84_i8_125 : i8), ^bb94
   ^bb94:  // pred: ^bb93
-    %c31_i64_151 = arith.constant 31 : i64
-    %c32_i64_152 = arith.constant 32 : i64
-    %283 = arith.addi %281, %c31_i64_151 : i64
-    %284 = arith.divui %283, %c32_i64_152 : i64
-    %c32_i64_153 = arith.constant 32 : i64
-    %285 = arith.muli %284, %c32_i64_153 : i64
-    %286 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_154 = arith.constant 31 : i64
-    %c32_i64_155 = arith.constant 32 : i64
-    %287 = arith.addi %286, %c31_i64_154 : i64
-    %288 = arith.divui %287, %c32_i64_155 : i64
-    %289 = arith.muli %288, %c32_i64_153 : i64
-    %290 = arith.cmpi ult, %289, %285 : i64
-    cf.cond_br %290, ^bb96, ^bb95
+    %c31_i64_126 = arith.constant 31 : i64
+    %c32_i64_127 = arith.constant 32 : i64
+    %257 = arith.addi %255, %c31_i64_126 : i64
+    %258 = arith.divui %257, %c32_i64_127 : i64
+    %c32_i64_128 = arith.constant 32 : i64
+    %259 = arith.muli %258, %c32_i64_128 : i64
+    %260 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_129 = arith.constant 31 : i64
+    %c32_i64_130 = arith.constant 32 : i64
+    %261 = arith.addi %260, %c31_i64_129 : i64
+    %262 = arith.divui %261, %c32_i64_130 : i64
+    %263 = arith.muli %262, %c32_i64_128 : i64
+    %264 = arith.cmpi ult, %263, %259 : i64
+    cf.cond_br %264, ^bb96, ^bb95
   ^bb95:  // 2 preds: ^bb94, ^bb98
     cf.br ^bb32
   ^bb96:  // pred: ^bb94
-    %c3_i64_156 = arith.constant 3 : i64
-    %c512_i64_157 = arith.constant 512 : i64
-    %291 = arith.muli %288, %288 : i64
-    %292 = arith.divui %291, %c512_i64_157 : i64
-    %293 = arith.muli %288, %c3_i64_156 : i64
-    %294 = arith.addi %292, %293 : i64
-    %c3_i64_158 = arith.constant 3 : i64
-    %c512_i64_159 = arith.constant 512 : i64
-    %295 = arith.muli %284, %284 : i64
-    %296 = arith.divui %295, %c512_i64_159 : i64
-    %297 = arith.muli %284, %c3_i64_158 : i64
-    %298 = arith.addi %296, %297 : i64
-    %299 = arith.subi %298, %294 : i64
-    %300 = llvm.load %arg1 : !llvm.ptr -> i64
-    %301 = arith.cmpi ult, %300, %299 : i64
-    scf.if %301 {
+    %c3_i64_131 = arith.constant 3 : i64
+    %c512_i64_132 = arith.constant 512 : i64
+    %265 = arith.muli %262, %262 : i64
+    %266 = arith.divui %265, %c512_i64_132 : i64
+    %267 = arith.muli %262, %c3_i64_131 : i64
+    %268 = arith.addi %266, %267 : i64
+    %c3_i64_133 = arith.constant 3 : i64
+    %c512_i64_134 = arith.constant 512 : i64
+    %269 = arith.muli %258, %258 : i64
+    %270 = arith.divui %269, %c512_i64_134 : i64
+    %271 = arith.muli %258, %c3_i64_133 : i64
+    %272 = arith.addi %270, %271 : i64
+    %273 = arith.subi %272, %268 : i64
+    %274 = llvm.load %arg1 : !llvm.ptr -> i64
+    %275 = arith.cmpi ult, %274, %273 : i64
+    scf.if %275 {
     } else {
-      %362 = arith.subi %300, %299 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %274, %273 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_160 = arith.constant 80 : i8
-    cf.cond_br %301, ^bb1(%c80_i8_160 : i8), ^bb97
+    %c80_i8_135 = arith.constant 80 : i8
+    cf.cond_br %275, ^bb1(%c80_i8_135 : i8), ^bb97
   ^bb97:  // pred: ^bb96
-    %302 = call @dora_fn_extend_memory(%arg0, %285) : (!llvm.ptr, i64) -> !llvm.ptr
-    %303 = llvm.getelementptr %302[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %304 = llvm.load %303 : !llvm.ptr -> i8
-    %c0_i8_161 = arith.constant 0 : i8
-    %305 = arith.cmpi ne, %304, %c0_i8_161 : i8
-    cf.cond_br %305, ^bb1(%304 : i8), ^bb98
+    %276 = call @dora_fn_extend_memory(%arg0, %259) : (!llvm.ptr, i64) -> !llvm.ptr
+    %277 = llvm.getelementptr %276[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %278 = llvm.load %277 : !llvm.ptr -> i8
+    %c0_i8_136 = arith.constant 0 : i8
+    %279 = arith.cmpi ne, %278, %c0_i8_136 : i8
+    cf.cond_br %279, ^bb1(%278 : i8), ^bb98
   ^bb98:  // pred: ^bb97
     cf.br ^bb95
   ^bb99:  // pred: ^bb70
-    %c18446744073709551615_i256_162 = arith.constant 18446744073709551615 : i256
-    %306 = arith.cmpi sgt, %192, %c18446744073709551615_i256_162 : i256
-    %c84_i8_163 = arith.constant 84 : i8
-    cf.cond_br %306, ^bb1(%c84_i8_163 : i8), ^bb100
+    %c18446744073709551615_i256_137 = arith.constant 18446744073709551615 : i256
+    %280 = arith.cmpi sgt, %170, %c18446744073709551615_i256_137 : i256
+    %c84_i8_138 = arith.constant 84 : i8
+    cf.cond_br %280, ^bb1(%c84_i8_138 : i8), ^bb100
   ^bb100:  // pred: ^bb99
-    %307 = arith.trunci %192 : i256 to i64
-    %c0_i64_164 = arith.constant 0 : i64
-    %308 = arith.cmpi slt, %307, %c0_i64_164 : i64
-    %c84_i8_165 = arith.constant 84 : i8
-    cf.cond_br %308, ^bb1(%c84_i8_165 : i8), ^bb101
+    %281 = arith.trunci %170 : i256 to i64
+    %c0_i64_139 = arith.constant 0 : i64
+    %282 = arith.cmpi slt, %281, %c0_i64_139 : i64
+    %c84_i8_140 = arith.constant 84 : i8
+    cf.cond_br %282, ^bb1(%c84_i8_140 : i8), ^bb101
   ^bb101:  // pred: ^bb100
-    %309 = arith.addi %307, %210 : i64
-    %c0_i64_166 = arith.constant 0 : i64
-    %310 = arith.cmpi slt, %309, %c0_i64_166 : i64
-    %c84_i8_167 = arith.constant 84 : i8
-    cf.cond_br %310, ^bb1(%c84_i8_167 : i8), ^bb102
+    %283 = arith.addi %281, %185 : i64
+    %c0_i64_141 = arith.constant 0 : i64
+    %284 = arith.cmpi slt, %283, %c0_i64_141 : i64
+    %c84_i8_142 = arith.constant 84 : i8
+    cf.cond_br %284, ^bb1(%c84_i8_142 : i8), ^bb102
   ^bb102:  // pred: ^bb101
-    %c31_i64_168 = arith.constant 31 : i64
-    %c32_i64_169 = arith.constant 32 : i64
-    %311 = arith.addi %309, %c31_i64_168 : i64
-    %312 = arith.divui %311, %c32_i64_169 : i64
-    %c32_i64_170 = arith.constant 32 : i64
-    %313 = arith.muli %312, %c32_i64_170 : i64
-    %314 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_171 = arith.constant 31 : i64
-    %c32_i64_172 = arith.constant 32 : i64
-    %315 = arith.addi %314, %c31_i64_171 : i64
-    %316 = arith.divui %315, %c32_i64_172 : i64
-    %317 = arith.muli %316, %c32_i64_170 : i64
-    %318 = arith.cmpi ult, %317, %313 : i64
-    cf.cond_br %318, ^bb104, ^bb103
+    %c31_i64_143 = arith.constant 31 : i64
+    %c32_i64_144 = arith.constant 32 : i64
+    %285 = arith.addi %283, %c31_i64_143 : i64
+    %286 = arith.divui %285, %c32_i64_144 : i64
+    %c32_i64_145 = arith.constant 32 : i64
+    %287 = arith.muli %286, %c32_i64_145 : i64
+    %288 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_146 = arith.constant 31 : i64
+    %c32_i64_147 = arith.constant 32 : i64
+    %289 = arith.addi %288, %c31_i64_146 : i64
+    %290 = arith.divui %289, %c32_i64_147 : i64
+    %291 = arith.muli %290, %c32_i64_145 : i64
+    %292 = arith.cmpi ult, %291, %287 : i64
+    cf.cond_br %292, ^bb104, ^bb103
   ^bb103:  // 2 preds: ^bb102, ^bb106
     cf.br ^bb71
   ^bb104:  // pred: ^bb102
-    %c3_i64_173 = arith.constant 3 : i64
-    %c512_i64_174 = arith.constant 512 : i64
-    %319 = arith.muli %316, %316 : i64
-    %320 = arith.divui %319, %c512_i64_174 : i64
-    %321 = arith.muli %316, %c3_i64_173 : i64
-    %322 = arith.addi %320, %321 : i64
-    %c3_i64_175 = arith.constant 3 : i64
-    %c512_i64_176 = arith.constant 512 : i64
-    %323 = arith.muli %312, %312 : i64
-    %324 = arith.divui %323, %c512_i64_176 : i64
-    %325 = arith.muli %312, %c3_i64_175 : i64
-    %326 = arith.addi %324, %325 : i64
-    %327 = arith.subi %326, %322 : i64
-    %328 = llvm.load %arg1 : !llvm.ptr -> i64
-    %329 = arith.cmpi ult, %328, %327 : i64
-    scf.if %329 {
+    %c3_i64_148 = arith.constant 3 : i64
+    %c512_i64_149 = arith.constant 512 : i64
+    %293 = arith.muli %290, %290 : i64
+    %294 = arith.divui %293, %c512_i64_149 : i64
+    %295 = arith.muli %290, %c3_i64_148 : i64
+    %296 = arith.addi %294, %295 : i64
+    %c3_i64_150 = arith.constant 3 : i64
+    %c512_i64_151 = arith.constant 512 : i64
+    %297 = arith.muli %286, %286 : i64
+    %298 = arith.divui %297, %c512_i64_151 : i64
+    %299 = arith.muli %286, %c3_i64_150 : i64
+    %300 = arith.addi %298, %299 : i64
+    %301 = arith.subi %300, %296 : i64
+    %302 = llvm.load %arg1 : !llvm.ptr -> i64
+    %303 = arith.cmpi ult, %302, %301 : i64
+    scf.if %303 {
     } else {
-      %362 = arith.subi %328, %327 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %302, %301 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_177 = arith.constant 80 : i8
-    cf.cond_br %329, ^bb1(%c80_i8_177 : i8), ^bb105
+    %c80_i8_152 = arith.constant 80 : i8
+    cf.cond_br %303, ^bb1(%c80_i8_152 : i8), ^bb105
   ^bb105:  // pred: ^bb104
-    %330 = call @dora_fn_extend_memory(%arg0, %313) : (!llvm.ptr, i64) -> !llvm.ptr
-    %331 = llvm.getelementptr %330[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %332 = llvm.load %331 : !llvm.ptr -> i8
-    %c0_i8_178 = arith.constant 0 : i8
-    %333 = arith.cmpi ne, %332, %c0_i8_178 : i8
-    cf.cond_br %333, ^bb1(%332 : i8), ^bb106
+    %304 = call @dora_fn_extend_memory(%arg0, %287) : (!llvm.ptr, i64) -> !llvm.ptr
+    %305 = llvm.getelementptr %304[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %306 = llvm.load %305 : !llvm.ptr -> i8
+    %c0_i8_153 = arith.constant 0 : i8
+    %307 = arith.cmpi ne, %306, %c0_i8_153 : i8
+    cf.cond_br %307, ^bb1(%306 : i8), ^bb106
   ^bb106:  // pred: ^bb105
     cf.br ^bb103
   ^bb107:  // pred: ^bb73
-    %c18446744073709551615_i256_179 = arith.constant 18446744073709551615 : i256
-    %334 = arith.cmpi sgt, %200, %c18446744073709551615_i256_179 : i256
-    %c84_i8_180 = arith.constant 84 : i8
-    cf.cond_br %334, ^bb1(%c84_i8_180 : i8), ^bb108
+    %c18446744073709551615_i256_154 = arith.constant 18446744073709551615 : i256
+    %308 = arith.cmpi sgt, %176, %c18446744073709551615_i256_154 : i256
+    %c84_i8_155 = arith.constant 84 : i8
+    cf.cond_br %308, ^bb1(%c84_i8_155 : i8), ^bb108
   ^bb108:  // pred: ^bb107
-    %335 = arith.trunci %200 : i256 to i64
-    %c0_i64_181 = arith.constant 0 : i64
-    %336 = arith.cmpi slt, %335, %c0_i64_181 : i64
-    %c84_i8_182 = arith.constant 84 : i8
-    cf.cond_br %336, ^bb1(%c84_i8_182 : i8), ^bb109
+    %309 = arith.trunci %176 : i256 to i64
+    %c0_i64_156 = arith.constant 0 : i64
+    %310 = arith.cmpi slt, %309, %c0_i64_156 : i64
+    %c84_i8_157 = arith.constant 84 : i8
+    cf.cond_br %310, ^bb1(%c84_i8_157 : i8), ^bb109
   ^bb109:  // pred: ^bb108
-    %337 = arith.addi %335, %214 : i64
-    %c0_i64_183 = arith.constant 0 : i64
-    %338 = arith.cmpi slt, %337, %c0_i64_183 : i64
-    %c84_i8_184 = arith.constant 84 : i8
-    cf.cond_br %338, ^bb1(%c84_i8_184 : i8), ^bb110
+    %311 = arith.addi %309, %189 : i64
+    %c0_i64_158 = arith.constant 0 : i64
+    %312 = arith.cmpi slt, %311, %c0_i64_158 : i64
+    %c84_i8_159 = arith.constant 84 : i8
+    cf.cond_br %312, ^bb1(%c84_i8_159 : i8), ^bb110
   ^bb110:  // pred: ^bb109
-    %c31_i64_185 = arith.constant 31 : i64
-    %c32_i64_186 = arith.constant 32 : i64
-    %339 = arith.addi %337, %c31_i64_185 : i64
-    %340 = arith.divui %339, %c32_i64_186 : i64
-    %c32_i64_187 = arith.constant 32 : i64
-    %341 = arith.muli %340, %c32_i64_187 : i64
-    %342 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_188 = arith.constant 31 : i64
-    %c32_i64_189 = arith.constant 32 : i64
-    %343 = arith.addi %342, %c31_i64_188 : i64
-    %344 = arith.divui %343, %c32_i64_189 : i64
-    %345 = arith.muli %344, %c32_i64_187 : i64
-    %346 = arith.cmpi ult, %345, %341 : i64
-    cf.cond_br %346, ^bb112, ^bb111
+    %c31_i64_160 = arith.constant 31 : i64
+    %c32_i64_161 = arith.constant 32 : i64
+    %313 = arith.addi %311, %c31_i64_160 : i64
+    %314 = arith.divui %313, %c32_i64_161 : i64
+    %c32_i64_162 = arith.constant 32 : i64
+    %315 = arith.muli %314, %c32_i64_162 : i64
+    %316 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_163 = arith.constant 31 : i64
+    %c32_i64_164 = arith.constant 32 : i64
+    %317 = arith.addi %316, %c31_i64_163 : i64
+    %318 = arith.divui %317, %c32_i64_164 : i64
+    %319 = arith.muli %318, %c32_i64_162 : i64
+    %320 = arith.cmpi ult, %319, %315 : i64
+    cf.cond_br %320, ^bb112, ^bb111
   ^bb111:  // 2 preds: ^bb110, ^bb114
     cf.br ^bb74
   ^bb112:  // pred: ^bb110
-    %c3_i64_190 = arith.constant 3 : i64
-    %c512_i64_191 = arith.constant 512 : i64
-    %347 = arith.muli %344, %344 : i64
-    %348 = arith.divui %347, %c512_i64_191 : i64
-    %349 = arith.muli %344, %c3_i64_190 : i64
-    %350 = arith.addi %348, %349 : i64
-    %c3_i64_192 = arith.constant 3 : i64
-    %c512_i64_193 = arith.constant 512 : i64
-    %351 = arith.muli %340, %340 : i64
-    %352 = arith.divui %351, %c512_i64_193 : i64
-    %353 = arith.muli %340, %c3_i64_192 : i64
-    %354 = arith.addi %352, %353 : i64
-    %355 = arith.subi %354, %350 : i64
-    %356 = llvm.load %arg1 : !llvm.ptr -> i64
-    %357 = arith.cmpi ult, %356, %355 : i64
-    scf.if %357 {
+    %c3_i64_165 = arith.constant 3 : i64
+    %c512_i64_166 = arith.constant 512 : i64
+    %321 = arith.muli %318, %318 : i64
+    %322 = arith.divui %321, %c512_i64_166 : i64
+    %323 = arith.muli %318, %c3_i64_165 : i64
+    %324 = arith.addi %322, %323 : i64
+    %c3_i64_167 = arith.constant 3 : i64
+    %c512_i64_168 = arith.constant 512 : i64
+    %325 = arith.muli %314, %314 : i64
+    %326 = arith.divui %325, %c512_i64_168 : i64
+    %327 = arith.muli %314, %c3_i64_167 : i64
+    %328 = arith.addi %326, %327 : i64
+    %329 = arith.subi %328, %324 : i64
+    %330 = llvm.load %arg1 : !llvm.ptr -> i64
+    %331 = arith.cmpi ult, %330, %329 : i64
+    scf.if %331 {
     } else {
-      %362 = arith.subi %356, %355 : i64
-      llvm.store %362, %arg1 : i64, !llvm.ptr
+      %336 = arith.subi %330, %329 : i64
+      llvm.store %336, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_194 = arith.constant 80 : i8
-    cf.cond_br %357, ^bb1(%c80_i8_194 : i8), ^bb113
+    %c80_i8_169 = arith.constant 80 : i8
+    cf.cond_br %331, ^bb1(%c80_i8_169 : i8), ^bb113
   ^bb113:  // pred: ^bb112
-    %358 = call @dora_fn_extend_memory(%arg0, %341) : (!llvm.ptr, i64) -> !llvm.ptr
-    %359 = llvm.getelementptr %358[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %360 = llvm.load %359 : !llvm.ptr -> i8
-    %c0_i8_195 = arith.constant 0 : i8
-    %361 = arith.cmpi ne, %360, %c0_i8_195 : i8
-    cf.cond_br %361, ^bb1(%360 : i8), ^bb114
+    %332 = call @dora_fn_extend_memory(%arg0, %315) : (!llvm.ptr, i64) -> !llvm.ptr
+    %333 = llvm.getelementptr %332[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %334 = llvm.load %333 : !llvm.ptr -> i8
+    %c0_i8_170 = arith.constant 0 : i8
+    %335 = arith.cmpi ne, %334, %c0_i8_170 : i8
+    cf.cond_br %335, ^bb1(%334 : i8), ^bb114
   ^bb114:  // pred: ^bb113
     cf.br ^bb111
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 99 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb69, ^bb71, ^bb72, ^bb74, ^bb75, ^bb77, ^bb78, ^bb81, ^bb82, ^bb85, ^bb86, ^bb89, ^bb90, ^bb93, ^bb94, ^bb97, ^bb98, ^bb101, ^bb102, ^bb105, ^bb106, ^bb108, ^bb109, ^bb110, ^bb112, ^bb113, ^bb115, ^bb116, ^bb118, ^bb119, ^bb122, ^bb123, ^bb124, ^bb127, ^bb128, ^bb130, ^bb131, ^bb132, ^bb133, ^bb134, ^bb137, ^bb138, ^bb140, ^bb141, ^bb142, ^bb145, ^bb146, ^bb148, ^bb149, ^bb150, ^bb153, ^bb154, ^bb156, ^bb157, ^bb158, ^bb161, ^bb162, ^bb164, ^bb165, ^bb166, ^bb169, ^bb170
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 99 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb69, ^bb71, ^bb72, ^bb74, ^bb75, ^bb77, ^bb78, ^bb81, ^bb82, ^bb85, ^bb86, ^bb89, ^bb90, ^bb93, ^bb94, ^bb97, ^bb98, ^bb101, ^bb102, ^bb105, ^bb106, ^bb108, ^bb109, ^bb110, ^bb112, ^bb113, ^bb115, ^bb116, ^bb118, ^bb119, ^bb122, ^bb123, ^bb124, ^bb127, ^bb128, ^bb130, ^bb131, ^bb132, ^bb133, ^bb134, ^bb137, ^bb138, ^bb140, ^bb141, ^bb142, ^bb145, ^bb146, ^bb148, ^bb149, ^bb150, ^bb153, ^bb154, ^bb156, ^bb157, ^bb158, ^bb161, ^bb162, ^bb164, ^bb165, ^bb166, ^bb169, ^bb170
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c35176690763027899028215972788860354566387_i256 = arith.constant 35176690763027899028215972788860354566387 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c35176690763027899028215972788860354566387_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,1376 +96,1316 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb122, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb122, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb126
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c15_i256 = arith.constant 15 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c15_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %c0_i256_25 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_26 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_25, %59 : i256, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb25:  // pred: ^bb27
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_28 : i64
-    %63 = arith.cmpi ult, %c1024_i64_27, %62 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_29 : i8), ^bb24
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_22 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_21, %56 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_23 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_31 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_30 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_24 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb36
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_32 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_33 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_34 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
-    %79 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %80 = arith.cmpi ne, %79, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %80, ^bb1(%c87_i8 : i8), ^bb29
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb30
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %82 = arith.trunci %78 : i256 to i64
-    %c0_i64_35 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_35 : i64
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_36 : i8), ^bb31
+    %73 = arith.trunci %69 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_37 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_37 : i64
-    cf.cond_br %84, ^bb130, ^bb32
+    %c0_i64_28 = arith.constant 0 : i64
+    %75 = arith.cmpi ne, %73, %c0_i64_28 : i64
+    cf.cond_br %75, ^bb130, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb136
     %c32000_i64 = arith.constant 32000 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %c32000_i64 : i64
-    scf.if %86 {
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %c32000_i64 : i64
+    scf.if %77 {
     } else {
-      %553 = arith.subi %85, %c32000_i64 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %76, %c32000_i64 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_38 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c1_i256 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %70, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %89 = arith.trunci %74 : i256 to i64
-    %90 = call @dora_fn_create(%arg0, %82, %89, %87, %88) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %91 = llvm.getelementptr %90[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %92 = llvm.load %91 : !llvm.ptr -> i8
-    %c0_i8_39 = arith.constant 0 : i8
-    %93 = arith.cmpi ne, %92, %c0_i8_39 : i8
-    cf.cond_br %93, ^bb1(%92 : i8), ^bb34
+    %78 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %80 = arith.trunci %66 : i256 to i64
+    %81 = call @dora_fn_create(%arg0, %73, %80, %78, %79) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %82 = llvm.getelementptr %81[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %83 = llvm.load %82 : !llvm.ptr -> i8
+    %c0_i8_30 = arith.constant 0 : i8
+    %84 = arith.cmpi ne, %83, %c0_i8_30 : i8
+    cf.cond_br %84, ^bb1(%83 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %94 = llvm.getelementptr %90[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %85 = llvm.getelementptr %81[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %553 = arith.subi %96, %95 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %87, %86 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_40 : i8), ^bb35
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_31 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = llvm.load %87 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %101 = arith.addi %99, %c1_i64_41 : i64
-    llvm.store %101, %arg3 : i64, !llvm.ptr
-    llvm.store %98, %100 : i256, !llvm.ptr
+    %89 = llvm.load %78 : !llvm.ptr -> i256
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %90 : i256, !llvm.ptr
+    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb41
   ^bb36:  // pred: ^bb38
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_43 = arith.constant -2 : i64
-    %103 = arith.addi %102, %c-2_i64_43 : i64
-    %c3_i64_44 = arith.constant 3 : i64
-    %104 = arith.cmpi ult, %102, %c3_i64_44 : i64
-    %c91_i8_45 = arith.constant 91 : i8
-    cf.cond_br %104, ^bb1(%c91_i8_45 : i8), ^bb28
+    %c1024_i64_32 = arith.constant 1024 : i64
+    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_33 = arith.constant -2 : i64
+    %93 = arith.addi %92, %c-2_i64_33 : i64
+    llvm.store %93, %arg3 : i64, !llvm.ptr
+    %c3_i64_34 = arith.constant 3 : i64
+    %94 = arith.cmpi ult, %92, %c3_i64_34 : i64
+    %c91_i8_35 = arith.constant 91 : i8
+    cf.cond_br %94, ^bb1(%c91_i8_35 : i8), ^bb28
   ^bb37:  // pred: ^bb24
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_36 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %106 = arith.cmpi uge, %105, %c0_i64_46 : i64
-    %c80_i8_47 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb38, ^bb1(%c80_i8_47 : i8)
+    %96 = arith.cmpi uge, %95, %c0_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %96, ^bb38, ^bb1(%c80_i8_37 : i8)
   ^bb38:  // pred: ^bb37
-    %107 = arith.subi %105, %c0_i64_46 : i64
-    llvm.store %107, %arg1 : i64, !llvm.ptr
+    %97 = arith.subi %95, %c0_i64_36 : i64
+    llvm.store %97, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb40
-    %c0_i256_48 = arith.constant 0 : i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %109 = llvm.getelementptr %arg2[%108] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_49 = arith.constant 1 : i64
-    %110 = arith.addi %108, %c1_i64_49 : i64
-    llvm.store %110, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_48, %109 : i256, !llvm.ptr
+    %c0_i256_38 = arith.constant 0 : i256
+    %98 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_38, %98 : i256, !llvm.ptr
+    %99 = llvm.getelementptr %98[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %99, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb45
   ^bb40:  // pred: ^bb42
-    %c1024_i64_50 = arith.constant 1024 : i64
-    %111 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_51 = arith.constant 1 : i64
-    %112 = arith.addi %111, %c1_i64_51 : i64
-    %113 = arith.cmpi ult, %c1024_i64_50, %112 : i64
-    %c92_i8_52 = arith.constant 92 : i8
-    cf.cond_br %113, ^bb1(%c92_i8_52 : i8), ^bb39
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %100 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %101 = arith.addi %100, %c1_i64_40 : i64
+    llvm.store %101, %arg3 : i64, !llvm.ptr
+    %102 = arith.cmpi ult, %c1024_i64_39, %101 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %102, ^bb1(%c92_i8_41 : i8), ^bb39
   ^bb41:  // pred: ^bb35
-    %114 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_53 = arith.constant 3 : i64
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_42 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %115 = arith.cmpi uge, %114, %c3_i64_53 : i64
-    %c80_i8_54 = arith.constant 80 : i8
-    cf.cond_br %115, ^bb42, ^bb1(%c80_i8_54 : i8)
+    %104 = arith.cmpi uge, %103, %c3_i64_42 : i64
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %104, ^bb42, ^bb1(%c80_i8_43 : i8)
   ^bb42:  // pred: ^bb41
-    %116 = arith.subi %114, %c3_i64_53 : i64
-    llvm.store %116, %arg1 : i64, !llvm.ptr
+    %105 = arith.subi %103, %c3_i64_42 : i64
+    llvm.store %105, %arg1 : i64, !llvm.ptr
     cf.br ^bb40
   ^bb43:  // pred: ^bb44
-    %c0_i256_55 = arith.constant 0 : i256
-    %117 = llvm.load %arg3 : !llvm.ptr -> i64
-    %118 = llvm.getelementptr %arg2[%117] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_56 = arith.constant 1 : i64
-    %119 = arith.addi %117, %c1_i64_56 : i64
-    llvm.store %119, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_55, %118 : i256, !llvm.ptr
+    %c0_i256_44 = arith.constant 0 : i256
+    %106 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_44, %106 : i256, !llvm.ptr
+    %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %107, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb49
   ^bb44:  // pred: ^bb46
-    %c1024_i64_57 = arith.constant 1024 : i64
-    %120 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_58 : i64
-    %122 = arith.cmpi ult, %c1024_i64_57, %121 : i64
-    %c92_i8_59 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_59 : i8), ^bb43
+    %c1024_i64_45 = arith.constant 1024 : i64
+    %108 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_46 = arith.constant 1 : i64
+    %109 = arith.addi %108, %c1_i64_46 : i64
+    llvm.store %109, %arg3 : i64, !llvm.ptr
+    %110 = arith.cmpi ult, %c1024_i64_45, %109 : i64
+    %c92_i8_47 = arith.constant 92 : i8
+    cf.cond_br %110, ^bb1(%c92_i8_47 : i8), ^bb43
   ^bb45:  // pred: ^bb39
-    %123 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_60 = arith.constant 3 : i64
+    %111 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_48 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %124 = arith.cmpi uge, %123, %c3_i64_60 : i64
-    %c80_i8_61 = arith.constant 80 : i8
-    cf.cond_br %124, ^bb46, ^bb1(%c80_i8_61 : i8)
+    %112 = arith.cmpi uge, %111, %c3_i64_48 : i64
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %112, ^bb46, ^bb1(%c80_i8_49 : i8)
   ^bb46:  // pred: ^bb45
-    %125 = arith.subi %123, %c3_i64_60 : i64
-    llvm.store %125, %arg1 : i64, !llvm.ptr
+    %113 = arith.subi %111, %c3_i64_48 : i64
+    llvm.store %113, %arg1 : i64, !llvm.ptr
     cf.br ^bb44
   ^bb47:  // pred: ^bb48
-    %c0_i256_62 = arith.constant 0 : i256
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
-    %127 = llvm.getelementptr %arg2[%126] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_63 = arith.constant 1 : i64
-    %128 = arith.addi %126, %c1_i64_63 : i64
-    llvm.store %128, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_62, %127 : i256, !llvm.ptr
+    %c0_i256_50 = arith.constant 0 : i256
+    %114 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_50, %114 : i256, !llvm.ptr
+    %115 = llvm.getelementptr %114[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %115, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb53
   ^bb48:  // pred: ^bb50
-    %c1024_i64_64 = arith.constant 1024 : i64
-    %129 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_65 = arith.constant 1 : i64
-    %130 = arith.addi %129, %c1_i64_65 : i64
-    %131 = arith.cmpi ult, %c1024_i64_64, %130 : i64
-    %c92_i8_66 = arith.constant 92 : i8
-    cf.cond_br %131, ^bb1(%c92_i8_66 : i8), ^bb47
+    %c1024_i64_51 = arith.constant 1024 : i64
+    %116 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_52 = arith.constant 1 : i64
+    %117 = arith.addi %116, %c1_i64_52 : i64
+    llvm.store %117, %arg3 : i64, !llvm.ptr
+    %118 = arith.cmpi ult, %c1024_i64_51, %117 : i64
+    %c92_i8_53 = arith.constant 92 : i8
+    cf.cond_br %118, ^bb1(%c92_i8_53 : i8), ^bb47
   ^bb49:  // pred: ^bb43
-    %132 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_67 = arith.constant 3 : i64
+    %119 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_54 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %133 = arith.cmpi uge, %132, %c3_i64_67 : i64
-    %c80_i8_68 = arith.constant 80 : i8
-    cf.cond_br %133, ^bb50, ^bb1(%c80_i8_68 : i8)
+    %120 = arith.cmpi uge, %119, %c3_i64_54 : i64
+    %c80_i8_55 = arith.constant 80 : i8
+    cf.cond_br %120, ^bb50, ^bb1(%c80_i8_55 : i8)
   ^bb50:  // pred: ^bb49
-    %134 = arith.subi %132, %c3_i64_67 : i64
-    llvm.store %134, %arg1 : i64, !llvm.ptr
+    %121 = arith.subi %119, %c3_i64_54 : i64
+    llvm.store %121, %arg1 : i64, !llvm.ptr
     cf.br ^bb48
   ^bb51:  // pred: ^bb52
-    %c0_i256_69 = arith.constant 0 : i256
-    %135 = llvm.load %arg3 : !llvm.ptr -> i64
-    %136 = llvm.getelementptr %arg2[%135] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_70 = arith.constant 1 : i64
-    %137 = arith.addi %135, %c1_i64_70 : i64
-    llvm.store %137, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_69, %136 : i256, !llvm.ptr
+    %c0_i256_56 = arith.constant 0 : i256
+    %122 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_56, %122 : i256, !llvm.ptr
+    %123 = llvm.getelementptr %122[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %123, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb57
   ^bb52:  // pred: ^bb54
-    %c1024_i64_71 = arith.constant 1024 : i64
-    %138 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_72 : i64
-    %140 = arith.cmpi ult, %c1024_i64_71, %139 : i64
-    %c92_i8_73 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_73 : i8), ^bb51
+    %c1024_i64_57 = arith.constant 1024 : i64
+    %124 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_58 = arith.constant 1 : i64
+    %125 = arith.addi %124, %c1_i64_58 : i64
+    llvm.store %125, %arg3 : i64, !llvm.ptr
+    %126 = arith.cmpi ult, %c1024_i64_57, %125 : i64
+    %c92_i8_59 = arith.constant 92 : i8
+    cf.cond_br %126, ^bb1(%c92_i8_59 : i8), ^bb51
   ^bb53:  // pred: ^bb47
-    %141 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_74 = arith.constant 3 : i64
+    %127 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_60 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %142 = arith.cmpi uge, %141, %c3_i64_74 : i64
-    %c80_i8_75 = arith.constant 80 : i8
-    cf.cond_br %142, ^bb54, ^bb1(%c80_i8_75 : i8)
+    %128 = arith.cmpi uge, %127, %c3_i64_60 : i64
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %128, ^bb54, ^bb1(%c80_i8_61 : i8)
   ^bb54:  // pred: ^bb53
-    %143 = arith.subi %141, %c3_i64_74 : i64
-    llvm.store %143, %arg1 : i64, !llvm.ptr
+    %129 = arith.subi %127, %c3_i64_60 : i64
+    llvm.store %129, %arg1 : i64, !llvm.ptr
     cf.br ^bb52
   ^bb55:  // pred: ^bb56
-    %c0_i256_76 = arith.constant 0 : i256
-    %144 = llvm.load %arg3 : !llvm.ptr -> i64
-    %145 = llvm.getelementptr %arg2[%144] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_77 = arith.constant 1 : i64
-    %146 = arith.addi %144, %c1_i64_77 : i64
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_76, %145 : i256, !llvm.ptr
+    %c0_i256_62 = arith.constant 0 : i256
+    %130 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_62, %130 : i256, !llvm.ptr
+    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %131, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb61
   ^bb56:  // pred: ^bb58
-    %c1024_i64_78 = arith.constant 1024 : i64
-    %147 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %148 = arith.addi %147, %c1_i64_79 : i64
-    %149 = arith.cmpi ult, %c1024_i64_78, %148 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %149, ^bb1(%c92_i8_80 : i8), ^bb55
+    %c1024_i64_63 = arith.constant 1024 : i64
+    %132 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_64 = arith.constant 1 : i64
+    %133 = arith.addi %132, %c1_i64_64 : i64
+    llvm.store %133, %arg3 : i64, !llvm.ptr
+    %134 = arith.cmpi ult, %c1024_i64_63, %133 : i64
+    %c92_i8_65 = arith.constant 92 : i8
+    cf.cond_br %134, ^bb1(%c92_i8_65 : i8), ^bb55
   ^bb57:  // pred: ^bb51
-    %150 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_81 = arith.constant 3 : i64
+    %135 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_66 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %151 = arith.cmpi uge, %150, %c3_i64_81 : i64
-    %c80_i8_82 = arith.constant 80 : i8
-    cf.cond_br %151, ^bb58, ^bb1(%c80_i8_82 : i8)
+    %136 = arith.cmpi uge, %135, %c3_i64_66 : i64
+    %c80_i8_67 = arith.constant 80 : i8
+    cf.cond_br %136, ^bb58, ^bb1(%c80_i8_67 : i8)
   ^bb58:  // pred: ^bb57
-    %152 = arith.subi %150, %c3_i64_81 : i64
-    llvm.store %152, %arg1 : i64, !llvm.ptr
+    %137 = arith.subi %135, %c3_i64_66 : i64
+    llvm.store %137, %arg1 : i64, !llvm.ptr
     cf.br ^bb56
   ^bb59:  // pred: ^bb60
-    %153 = llvm.load %arg3 : !llvm.ptr -> i64
-    %154 = llvm.getelementptr %arg2[%153] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %155 = llvm.getelementptr %154[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.load %arg3 : !llvm.ptr -> i64
-    %158 = llvm.getelementptr %arg2[%157] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_83 = arith.constant 1 : i64
-    %159 = arith.addi %157, %c1_i64_83 : i64
-    llvm.store %159, %arg3 : i64, !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
+    %138 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %139 = llvm.getelementptr %138[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %140 = llvm.load %139 : !llvm.ptr -> i256
+    %141 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %140, %141 : i256, !llvm.ptr
+    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %142, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb65
   ^bb60:  // pred: ^bb62
-    %c1024_i64_84 = arith.constant 1024 : i64
-    %160 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_85 : i64
+    %c1024_i64_68 = arith.constant 1024 : i64
+    %143 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_69 = arith.constant 1 : i64
+    %144 = arith.addi %143, %c1_i64_69 : i64
+    llvm.store %144, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %162 = arith.cmpi ult, %160, %c6_i64 : i64
-    %163 = arith.cmpi ult, %c1024_i64_84, %161 : i64
-    %164 = arith.xori %162, %163 : i1
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %164, ^bb1(%c92_i8_86 : i8), ^bb59
+    %145 = arith.cmpi ult, %143, %c6_i64 : i64
+    %146 = arith.cmpi ult, %c1024_i64_68, %144 : i64
+    %147 = arith.xori %145, %146 : i1
+    %c92_i8_70 = arith.constant 92 : i8
+    cf.cond_br %147, ^bb1(%c92_i8_70 : i8), ^bb59
   ^bb61:  // pred: ^bb55
-    %165 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_87 = arith.constant 3 : i64
+    %148 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_71 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %166 = arith.cmpi uge, %165, %c3_i64_87 : i64
-    %c80_i8_88 = arith.constant 80 : i8
-    cf.cond_br %166, ^bb62, ^bb1(%c80_i8_88 : i8)
+    %149 = arith.cmpi uge, %148, %c3_i64_71 : i64
+    %c80_i8_72 = arith.constant 80 : i8
+    cf.cond_br %149, ^bb62, ^bb1(%c80_i8_72 : i8)
   ^bb62:  // pred: ^bb61
-    %167 = arith.subi %165, %c3_i64_87 : i64
-    llvm.store %167, %arg1 : i64, !llvm.ptr
+    %150 = arith.subi %148, %c3_i64_71 : i64
+    llvm.store %150, %arg1 : i64, !llvm.ptr
     cf.br ^bb60
   ^bb63:  // pred: ^bb64
     %c65535_i256 = arith.constant 65535 : i256
-    %168 = llvm.load %arg3 : !llvm.ptr -> i64
-    %169 = llvm.getelementptr %arg2[%168] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_89 = arith.constant 1 : i64
-    %170 = arith.addi %168, %c1_i64_89 : i64
-    llvm.store %170, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256, %169 : i256, !llvm.ptr
+    %151 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %151 : i256, !llvm.ptr
+    %152 = llvm.getelementptr %151[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %152, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb78
   ^bb64:  // pred: ^bb66
-    %c1024_i64_90 = arith.constant 1024 : i64
-    %171 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_91 = arith.constant 1 : i64
-    %172 = arith.addi %171, %c1_i64_91 : i64
-    %173 = arith.cmpi ult, %c1024_i64_90, %172 : i64
-    %c92_i8_92 = arith.constant 92 : i8
-    cf.cond_br %173, ^bb1(%c92_i8_92 : i8), ^bb63
+    %c1024_i64_73 = arith.constant 1024 : i64
+    %153 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_74 = arith.constant 1 : i64
+    %154 = arith.addi %153, %c1_i64_74 : i64
+    llvm.store %154, %arg3 : i64, !llvm.ptr
+    %155 = arith.cmpi ult, %c1024_i64_73, %154 : i64
+    %c92_i8_75 = arith.constant 92 : i8
+    cf.cond_br %155, ^bb1(%c92_i8_75 : i8), ^bb63
   ^bb65:  // pred: ^bb59
-    %174 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_93 = arith.constant 3 : i64
+    %156 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_76 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %175 = arith.cmpi uge, %174, %c3_i64_93 : i64
-    %c80_i8_94 = arith.constant 80 : i8
-    cf.cond_br %175, ^bb66, ^bb1(%c80_i8_94 : i8)
+    %157 = arith.cmpi uge, %156, %c3_i64_76 : i64
+    %c80_i8_77 = arith.constant 80 : i8
+    cf.cond_br %157, ^bb66, ^bb1(%c80_i8_77 : i8)
   ^bb66:  // pred: ^bb65
-    %176 = arith.subi %174, %c3_i64_93 : i64
-    llvm.store %176, %arg1 : i64, !llvm.ptr
+    %158 = arith.subi %156, %c3_i64_76 : i64
+    llvm.store %158, %arg1 : i64, !llvm.ptr
     cf.br ^bb64
   ^bb67:  // pred: ^bb77
-    %177 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_95 = arith.constant 1 : i64
-    %178 = arith.subi %177, %c1_i64_95 : i64
-    %179 = llvm.getelementptr %arg2[%178] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %178, %arg3 : i64, !llvm.ptr
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    %181 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %182 = arith.subi %181, %c1_i64_96 : i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %182, %arg3 : i64, !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_97 = arith.constant 1 : i64
-    %186 = arith.subi %185, %c1_i64_97 : i64
-    %187 = llvm.getelementptr %arg2[%186] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %186, %arg3 : i64, !llvm.ptr
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    %189 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_98 = arith.constant 1 : i64
-    %190 = arith.subi %189, %c1_i64_98 : i64
-    %191 = llvm.getelementptr %arg2[%190] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %190, %arg3 : i64, !llvm.ptr
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    %193 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_99 = arith.constant 1 : i64
-    %194 = arith.subi %193, %c1_i64_99 : i64
-    %195 = llvm.getelementptr %arg2[%194] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %194, %arg3 : i64, !llvm.ptr
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    %197 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_100 = arith.constant 1 : i64
-    %198 = arith.subi %197, %c1_i64_100 : i64
-    %199 = llvm.getelementptr %arg2[%198] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %198, %arg3 : i64, !llvm.ptr
-    %200 = llvm.load %199 : !llvm.ptr -> i256
-    %201 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_101 = arith.constant 1 : i64
-    %202 = arith.subi %201, %c1_i64_101 : i64
-    %203 = llvm.getelementptr %arg2[%202] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %202, %arg3 : i64, !llvm.ptr
-    %204 = llvm.load %203 : !llvm.ptr -> i256
-    %205 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
-    %c0_i8_102 = arith.constant 0 : i8
-    %206 = arith.cmpi ne, %205, %c0_i8_102 : i8
-    %c0_i256_103 = arith.constant 0 : i256
-    %207 = arith.cmpi ne, %188, %c0_i256_103 : i256
-    %208 = arith.andi %206, %207 : i1
+    %159 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %160 = llvm.getelementptr %159[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %161 = llvm.load %160 : !llvm.ptr -> i256
+    llvm.store %160, %0 : !llvm.ptr, !llvm.ptr
+    %162 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %163 = llvm.getelementptr %162[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %164 = llvm.load %163 : !llvm.ptr -> i256
+    llvm.store %163, %0 : !llvm.ptr, !llvm.ptr
+    %165 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %166 = llvm.getelementptr %165[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %167 = llvm.load %166 : !llvm.ptr -> i256
+    llvm.store %166, %0 : !llvm.ptr, !llvm.ptr
+    %168 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %170 = llvm.load %169 : !llvm.ptr -> i256
+    llvm.store %169, %0 : !llvm.ptr, !llvm.ptr
+    %171 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %0 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %176 = llvm.load %175 : !llvm.ptr -> i256
+    llvm.store %175, %0 : !llvm.ptr, !llvm.ptr
+    %177 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %178 = llvm.getelementptr %177[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %179 = llvm.load %178 : !llvm.ptr -> i256
+    llvm.store %178, %0 : !llvm.ptr, !llvm.ptr
+    %180 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %c0_i8_78 = arith.constant 0 : i8
+    %181 = arith.cmpi ne, %180, %c0_i8_78 : i8
+    %c0_i256_79 = arith.constant 0 : i256
+    %182 = arith.cmpi ne, %167, %c0_i256_79 : i256
+    %183 = arith.andi %181, %182 : i1
     %c86_i8 = arith.constant 86 : i8
-    cf.cond_br %208, ^bb1(%c86_i8 : i8), ^bb68
+    cf.cond_br %183, ^bb1(%c86_i8 : i8), ^bb68
   ^bb68:  // pred: ^bb67
-    %c18446744073709551615_i256_104 = arith.constant 18446744073709551615 : i256
-    %209 = arith.cmpi sgt, %196, %c18446744073709551615_i256_104 : i256
-    %c84_i8_105 = arith.constant 84 : i8
-    cf.cond_br %209, ^bb1(%c84_i8_105 : i8), ^bb69
+    %c18446744073709551615_i256_80 = arith.constant 18446744073709551615 : i256
+    %184 = arith.cmpi sgt, %173, %c18446744073709551615_i256_80 : i256
+    %c84_i8_81 = arith.constant 84 : i8
+    cf.cond_br %184, ^bb1(%c84_i8_81 : i8), ^bb69
   ^bb69:  // pred: ^bb68
-    %210 = arith.trunci %196 : i256 to i64
-    %c0_i64_106 = arith.constant 0 : i64
-    %211 = arith.cmpi slt, %210, %c0_i64_106 : i64
-    %c84_i8_107 = arith.constant 84 : i8
-    cf.cond_br %211, ^bb1(%c84_i8_107 : i8), ^bb70
+    %185 = arith.trunci %173 : i256 to i64
+    %c0_i64_82 = arith.constant 0 : i64
+    %186 = arith.cmpi slt, %185, %c0_i64_82 : i64
+    %c84_i8_83 = arith.constant 84 : i8
+    cf.cond_br %186, ^bb1(%c84_i8_83 : i8), ^bb70
   ^bb70:  // pred: ^bb69
-    %c0_i64_108 = arith.constant 0 : i64
-    %212 = arith.cmpi ne, %210, %c0_i64_108 : i64
-    cf.cond_br %212, ^bb140, ^bb71
+    %c0_i64_84 = arith.constant 0 : i64
+    %187 = arith.cmpi ne, %185, %c0_i64_84 : i64
+    cf.cond_br %187, ^bb140, ^bb71
   ^bb71:  // 2 preds: ^bb70, ^bb144
-    %c18446744073709551615_i256_109 = arith.constant 18446744073709551615 : i256
-    %213 = arith.cmpi sgt, %204, %c18446744073709551615_i256_109 : i256
-    %c84_i8_110 = arith.constant 84 : i8
-    cf.cond_br %213, ^bb1(%c84_i8_110 : i8), ^bb72
+    %c18446744073709551615_i256_85 = arith.constant 18446744073709551615 : i256
+    %188 = arith.cmpi sgt, %179, %c18446744073709551615_i256_85 : i256
+    %c84_i8_86 = arith.constant 84 : i8
+    cf.cond_br %188, ^bb1(%c84_i8_86 : i8), ^bb72
   ^bb72:  // pred: ^bb71
-    %214 = arith.trunci %204 : i256 to i64
-    %c0_i64_111 = arith.constant 0 : i64
-    %215 = arith.cmpi slt, %214, %c0_i64_111 : i64
-    %c84_i8_112 = arith.constant 84 : i8
-    cf.cond_br %215, ^bb1(%c84_i8_112 : i8), ^bb73
+    %189 = arith.trunci %179 : i256 to i64
+    %c0_i64_87 = arith.constant 0 : i64
+    %190 = arith.cmpi slt, %189, %c0_i64_87 : i64
+    %c84_i8_88 = arith.constant 84 : i8
+    cf.cond_br %190, ^bb1(%c84_i8_88 : i8), ^bb73
   ^bb73:  // pred: ^bb72
-    %c0_i64_113 = arith.constant 0 : i64
-    %216 = arith.cmpi ne, %214, %c0_i64_113 : i64
-    cf.cond_br %216, ^bb148, ^bb74
+    %c0_i64_89 = arith.constant 0 : i64
+    %191 = arith.cmpi ne, %189, %c0_i64_89 : i64
+    cf.cond_br %191, ^bb148, ^bb74
   ^bb74:  // 2 preds: ^bb73, ^bb152
-    %217 = arith.trunci %192 : i256 to i64
-    %218 = arith.trunci %200 : i256 to i64
-    %219 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_114 = arith.constant 1 : i256
-    %220 = llvm.alloca %c1_i256_114 x i256 : (i256) -> !llvm.ptr
-    llvm.store %188, %220 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_115 = arith.constant 1 : i256
-    %221 = llvm.alloca %c1_i256_115 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %221 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_116 = arith.constant 1 : i256
-    %222 = llvm.alloca %c1_i256_116 x i256 : (i256) -> !llvm.ptr
-    llvm.store %184, %222 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i8_117 = arith.constant 0 : i8
-    %223 = call @dora_fn_call(%arg0, %221, %222, %220, %217, %210, %218, %214, %219, %c0_i8_117) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %224 = llvm.getelementptr %223[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %225 = llvm.load %224 : !llvm.ptr -> i8
-    %226 = llvm.getelementptr %223[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %227 = llvm.load %226 : !llvm.ptr -> i8
-    %c0_i8_118 = arith.constant 0 : i8
-    %228 = arith.cmpi ne, %227, %c0_i8_118 : i8
-    cf.cond_br %228, ^bb1(%227 : i8), ^bb75
+    %192 = arith.trunci %170 : i256 to i64
+    %193 = arith.trunci %176 : i256 to i64
+    %194 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_90 = arith.constant 1 : i256
+    %195 = llvm.alloca %c1_i256_90 x i256 : (i256) -> !llvm.ptr
+    llvm.store %167, %195 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_91 = arith.constant 1 : i256
+    %196 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
+    llvm.store %161, %196 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_92 = arith.constant 1 : i256
+    %197 = llvm.alloca %c1_i256_92 x i256 : (i256) -> !llvm.ptr
+    llvm.store %164, %197 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i8_93 = arith.constant 0 : i8
+    %198 = call @dora_fn_call(%arg0, %196, %197, %195, %192, %185, %193, %189, %194, %c0_i8_93) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %199 = llvm.getelementptr %198[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %200 = llvm.load %199 : !llvm.ptr -> i8
+    %201 = llvm.getelementptr %198[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %202 = llvm.load %201 : !llvm.ptr -> i8
+    %c0_i8_94 = arith.constant 0 : i8
+    %203 = arith.cmpi ne, %202, %c0_i8_94 : i8
+    cf.cond_br %203, ^bb1(%202 : i8), ^bb75
   ^bb75:  // pred: ^bb74
-    %229 = llvm.getelementptr %223[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %230 = llvm.load %229 : !llvm.ptr -> i64
-    %231 = llvm.load %arg1 : !llvm.ptr -> i64
-    %232 = arith.cmpi ult, %231, %230 : i64
-    scf.if %232 {
+    %204 = llvm.getelementptr %198[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %205 = llvm.load %204 : !llvm.ptr -> i64
+    %206 = llvm.load %arg1 : !llvm.ptr -> i64
+    %207 = arith.cmpi ult, %206, %205 : i64
+    scf.if %207 {
     } else {
-      %553 = arith.subi %231, %230 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %206, %205 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_119 = arith.constant 80 : i8
-    cf.cond_br %232, ^bb1(%c80_i8_119 : i8), ^bb76
+    %c80_i8_95 = arith.constant 80 : i8
+    cf.cond_br %207, ^bb1(%c80_i8_95 : i8), ^bb76
   ^bb76:  // pred: ^bb75
-    %233 = arith.extui %225 : i8 to i256
-    %234 = llvm.load %arg3 : !llvm.ptr -> i64
-    %235 = llvm.getelementptr %arg2[%234] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_120 = arith.constant 1 : i64
-    %236 = arith.addi %234, %c1_i64_120 : i64
-    llvm.store %236, %arg3 : i64, !llvm.ptr
-    llvm.store %233, %235 : i256, !llvm.ptr
+    %208 = arith.extui %200 : i8 to i256
+    %209 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %208, %209 : i256, !llvm.ptr
+    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %210, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb82
   ^bb77:  // pred: ^bb79
-    %c1024_i64_121 = arith.constant 1024 : i64
-    %237 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_96 = arith.constant 1024 : i64
+    %211 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %238 = arith.addi %237, %c-6_i64 : i64
+    %212 = arith.addi %211, %c-6_i64 : i64
+    llvm.store %212, %arg3 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %239 = arith.cmpi ult, %237, %c7_i64 : i64
-    %c91_i8_122 = arith.constant 91 : i8
-    cf.cond_br %239, ^bb1(%c91_i8_122 : i8), ^bb67
+    %213 = arith.cmpi ult, %211, %c7_i64 : i64
+    %c91_i8_97 = arith.constant 91 : i8
+    cf.cond_br %213, ^bb1(%c91_i8_97 : i8), ^bb67
   ^bb78:  // pred: ^bb63
-    %240 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_123 = arith.constant 0 : i64
+    %214 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_98 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %241 = arith.cmpi uge, %240, %c0_i64_123 : i64
-    %c80_i8_124 = arith.constant 80 : i8
-    cf.cond_br %241, ^bb79, ^bb1(%c80_i8_124 : i8)
+    %215 = arith.cmpi uge, %214, %c0_i64_98 : i64
+    %c80_i8_99 = arith.constant 80 : i8
+    cf.cond_br %215, ^bb79, ^bb1(%c80_i8_99 : i8)
   ^bb79:  // pred: ^bb78
-    %242 = arith.subi %240, %c0_i64_123 : i64
-    llvm.store %242, %arg1 : i64, !llvm.ptr
+    %216 = arith.subi %214, %c0_i64_98 : i64
+    llvm.store %216, %arg1 : i64, !llvm.ptr
     cf.br ^bb77
   ^bb80:  // pred: ^bb81
-    %c0_i256_125 = arith.constant 0 : i256
-    %243 = llvm.load %arg3 : !llvm.ptr -> i64
-    %244 = llvm.getelementptr %arg2[%243] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_126 = arith.constant 1 : i64
-    %245 = arith.addi %243, %c1_i64_126 : i64
-    llvm.store %245, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_125, %244 : i256, !llvm.ptr
+    %c0_i256_100 = arith.constant 0 : i256
+    %217 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_100, %217 : i256, !llvm.ptr
+    %218 = llvm.getelementptr %217[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %218, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb86
   ^bb81:  // pred: ^bb83
-    %c1024_i64_127 = arith.constant 1024 : i64
-    %246 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_128 = arith.constant 1 : i64
-    %247 = arith.addi %246, %c1_i64_128 : i64
-    %248 = arith.cmpi ult, %c1024_i64_127, %247 : i64
-    %c92_i8_129 = arith.constant 92 : i8
-    cf.cond_br %248, ^bb1(%c92_i8_129 : i8), ^bb80
+    %c1024_i64_101 = arith.constant 1024 : i64
+    %219 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_102 = arith.constant 1 : i64
+    %220 = arith.addi %219, %c1_i64_102 : i64
+    llvm.store %220, %arg3 : i64, !llvm.ptr
+    %221 = arith.cmpi ult, %c1024_i64_101, %220 : i64
+    %c92_i8_103 = arith.constant 92 : i8
+    cf.cond_br %221, ^bb1(%c92_i8_103 : i8), ^bb80
   ^bb82:  // pred: ^bb76
-    %249 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_130 = arith.constant 3 : i64
+    %222 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_104 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %250 = arith.cmpi uge, %249, %c3_i64_130 : i64
-    %c80_i8_131 = arith.constant 80 : i8
-    cf.cond_br %250, ^bb83, ^bb1(%c80_i8_131 : i8)
+    %223 = arith.cmpi uge, %222, %c3_i64_104 : i64
+    %c80_i8_105 = arith.constant 80 : i8
+    cf.cond_br %223, ^bb83, ^bb1(%c80_i8_105 : i8)
   ^bb83:  // pred: ^bb82
-    %251 = arith.subi %249, %c3_i64_130 : i64
-    llvm.store %251, %arg1 : i64, !llvm.ptr
+    %224 = arith.subi %222, %c3_i64_104 : i64
+    llvm.store %224, %arg1 : i64, !llvm.ptr
     cf.br ^bb81
   ^bb84:  // pred: ^bb85
-    %c0_i256_132 = arith.constant 0 : i256
-    %252 = llvm.load %arg3 : !llvm.ptr -> i64
-    %253 = llvm.getelementptr %arg2[%252] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_133 = arith.constant 1 : i64
-    %254 = arith.addi %252, %c1_i64_133 : i64
-    llvm.store %254, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_132, %253 : i256, !llvm.ptr
+    %c0_i256_106 = arith.constant 0 : i256
+    %225 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_106, %225 : i256, !llvm.ptr
+    %226 = llvm.getelementptr %225[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %226, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb90
   ^bb85:  // pred: ^bb87
-    %c1024_i64_134 = arith.constant 1024 : i64
-    %255 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_135 = arith.constant 1 : i64
-    %256 = arith.addi %255, %c1_i64_135 : i64
-    %257 = arith.cmpi ult, %c1024_i64_134, %256 : i64
-    %c92_i8_136 = arith.constant 92 : i8
-    cf.cond_br %257, ^bb1(%c92_i8_136 : i8), ^bb84
+    %c1024_i64_107 = arith.constant 1024 : i64
+    %227 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_108 = arith.constant 1 : i64
+    %228 = arith.addi %227, %c1_i64_108 : i64
+    llvm.store %228, %arg3 : i64, !llvm.ptr
+    %229 = arith.cmpi ult, %c1024_i64_107, %228 : i64
+    %c92_i8_109 = arith.constant 92 : i8
+    cf.cond_br %229, ^bb1(%c92_i8_109 : i8), ^bb84
   ^bb86:  // pred: ^bb80
-    %258 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_137 = arith.constant 3 : i64
+    %230 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_110 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %259 = arith.cmpi uge, %258, %c3_i64_137 : i64
-    %c80_i8_138 = arith.constant 80 : i8
-    cf.cond_br %259, ^bb87, ^bb1(%c80_i8_138 : i8)
+    %231 = arith.cmpi uge, %230, %c3_i64_110 : i64
+    %c80_i8_111 = arith.constant 80 : i8
+    cf.cond_br %231, ^bb87, ^bb1(%c80_i8_111 : i8)
   ^bb87:  // pred: ^bb86
-    %260 = arith.subi %258, %c3_i64_137 : i64
-    llvm.store %260, %arg1 : i64, !llvm.ptr
+    %232 = arith.subi %230, %c3_i64_110 : i64
+    llvm.store %232, %arg1 : i64, !llvm.ptr
     cf.br ^bb85
   ^bb88:  // pred: ^bb89
     %c32_i256 = arith.constant 32 : i256
-    %261 = llvm.load %arg3 : !llvm.ptr -> i64
-    %262 = llvm.getelementptr %arg2[%261] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_139 = arith.constant 1 : i64
-    %263 = arith.addi %261, %c1_i64_139 : i64
-    llvm.store %263, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %262 : i256, !llvm.ptr
+    %233 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %233 : i256, !llvm.ptr
+    %234 = llvm.getelementptr %233[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %234, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb94
   ^bb89:  // pred: ^bb91
-    %c1024_i64_140 = arith.constant 1024 : i64
-    %264 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_141 = arith.constant 1 : i64
-    %265 = arith.addi %264, %c1_i64_141 : i64
-    %266 = arith.cmpi ult, %c1024_i64_140, %265 : i64
-    %c92_i8_142 = arith.constant 92 : i8
-    cf.cond_br %266, ^bb1(%c92_i8_142 : i8), ^bb88
+    %c1024_i64_112 = arith.constant 1024 : i64
+    %235 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_113 = arith.constant 1 : i64
+    %236 = arith.addi %235, %c1_i64_113 : i64
+    llvm.store %236, %arg3 : i64, !llvm.ptr
+    %237 = arith.cmpi ult, %c1024_i64_112, %236 : i64
+    %c92_i8_114 = arith.constant 92 : i8
+    cf.cond_br %237, ^bb1(%c92_i8_114 : i8), ^bb88
   ^bb90:  // pred: ^bb84
-    %267 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_143 = arith.constant 3 : i64
+    %238 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_115 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %268 = arith.cmpi uge, %267, %c3_i64_143 : i64
-    %c80_i8_144 = arith.constant 80 : i8
-    cf.cond_br %268, ^bb91, ^bb1(%c80_i8_144 : i8)
+    %239 = arith.cmpi uge, %238, %c3_i64_115 : i64
+    %c80_i8_116 = arith.constant 80 : i8
+    cf.cond_br %239, ^bb91, ^bb1(%c80_i8_116 : i8)
   ^bb91:  // pred: ^bb90
-    %269 = arith.subi %267, %c3_i64_143 : i64
-    llvm.store %269, %arg1 : i64, !llvm.ptr
+    %240 = arith.subi %238, %c3_i64_115 : i64
+    llvm.store %240, %arg1 : i64, !llvm.ptr
     cf.br ^bb89
   ^bb92:  // pred: ^bb93
-    %c0_i256_145 = arith.constant 0 : i256
-    %270 = llvm.load %arg3 : !llvm.ptr -> i64
-    %271 = llvm.getelementptr %arg2[%270] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_146 = arith.constant 1 : i64
-    %272 = arith.addi %270, %c1_i64_146 : i64
-    llvm.store %272, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_145, %271 : i256, !llvm.ptr
+    %c0_i256_117 = arith.constant 0 : i256
+    %241 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_117, %241 : i256, !llvm.ptr
+    %242 = llvm.getelementptr %241[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %242, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb98
   ^bb93:  // pred: ^bb95
-    %c1024_i64_147 = arith.constant 1024 : i64
-    %273 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_148 = arith.constant 1 : i64
-    %274 = arith.addi %273, %c1_i64_148 : i64
-    %275 = arith.cmpi ult, %c1024_i64_147, %274 : i64
-    %c92_i8_149 = arith.constant 92 : i8
-    cf.cond_br %275, ^bb1(%c92_i8_149 : i8), ^bb92
+    %c1024_i64_118 = arith.constant 1024 : i64
+    %243 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_119 = arith.constant 1 : i64
+    %244 = arith.addi %243, %c1_i64_119 : i64
+    llvm.store %244, %arg3 : i64, !llvm.ptr
+    %245 = arith.cmpi ult, %c1024_i64_118, %244 : i64
+    %c92_i8_120 = arith.constant 92 : i8
+    cf.cond_br %245, ^bb1(%c92_i8_120 : i8), ^bb92
   ^bb94:  // pred: ^bb88
-    %276 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_150 = arith.constant 3 : i64
+    %246 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_121 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %277 = arith.cmpi uge, %276, %c3_i64_150 : i64
-    %c80_i8_151 = arith.constant 80 : i8
-    cf.cond_br %277, ^bb95, ^bb1(%c80_i8_151 : i8)
+    %247 = arith.cmpi uge, %246, %c3_i64_121 : i64
+    %c80_i8_122 = arith.constant 80 : i8
+    cf.cond_br %247, ^bb95, ^bb1(%c80_i8_122 : i8)
   ^bb95:  // pred: ^bb94
-    %278 = arith.subi %276, %c3_i64_150 : i64
-    llvm.store %278, %arg1 : i64, !llvm.ptr
+    %248 = arith.subi %246, %c3_i64_121 : i64
+    llvm.store %248, %arg1 : i64, !llvm.ptr
     cf.br ^bb93
   ^bb96:  // pred: ^bb97
-    %c0_i256_152 = arith.constant 0 : i256
-    %279 = llvm.load %arg3 : !llvm.ptr -> i64
-    %280 = llvm.getelementptr %arg2[%279] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_153 = arith.constant 1 : i64
-    %281 = arith.addi %279, %c1_i64_153 : i64
-    llvm.store %281, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_152, %280 : i256, !llvm.ptr
+    %c0_i256_123 = arith.constant 0 : i256
+    %249 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_123, %249 : i256, !llvm.ptr
+    %250 = llvm.getelementptr %249[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %250, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb102
   ^bb97:  // pred: ^bb99
-    %c1024_i64_154 = arith.constant 1024 : i64
-    %282 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_155 = arith.constant 1 : i64
-    %283 = arith.addi %282, %c1_i64_155 : i64
-    %284 = arith.cmpi ult, %c1024_i64_154, %283 : i64
-    %c92_i8_156 = arith.constant 92 : i8
-    cf.cond_br %284, ^bb1(%c92_i8_156 : i8), ^bb96
+    %c1024_i64_124 = arith.constant 1024 : i64
+    %251 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_125 = arith.constant 1 : i64
+    %252 = arith.addi %251, %c1_i64_125 : i64
+    llvm.store %252, %arg3 : i64, !llvm.ptr
+    %253 = arith.cmpi ult, %c1024_i64_124, %252 : i64
+    %c92_i8_126 = arith.constant 92 : i8
+    cf.cond_br %253, ^bb1(%c92_i8_126 : i8), ^bb96
   ^bb98:  // pred: ^bb92
-    %285 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_157 = arith.constant 3 : i64
+    %254 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_127 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %286 = arith.cmpi uge, %285, %c3_i64_157 : i64
-    %c80_i8_158 = arith.constant 80 : i8
-    cf.cond_br %286, ^bb99, ^bb1(%c80_i8_158 : i8)
+    %255 = arith.cmpi uge, %254, %c3_i64_127 : i64
+    %c80_i8_128 = arith.constant 80 : i8
+    cf.cond_br %255, ^bb99, ^bb1(%c80_i8_128 : i8)
   ^bb99:  // pred: ^bb98
-    %287 = arith.subi %285, %c3_i64_157 : i64
-    llvm.store %287, %arg1 : i64, !llvm.ptr
+    %256 = arith.subi %254, %c3_i64_127 : i64
+    llvm.store %256, %arg1 : i64, !llvm.ptr
     cf.br ^bb97
   ^bb100:  // pred: ^bb101
-    %288 = llvm.load %arg3 : !llvm.ptr -> i64
-    %289 = llvm.getelementptr %arg2[%288] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %290 = llvm.getelementptr %289[-7] : (!llvm.ptr) -> !llvm.ptr, i256
-    %291 = llvm.load %290 : !llvm.ptr -> i256
-    %292 = llvm.load %arg3 : !llvm.ptr -> i64
-    %293 = llvm.getelementptr %arg2[%292] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_159 = arith.constant 1 : i64
-    %294 = arith.addi %292, %c1_i64_159 : i64
-    llvm.store %294, %arg3 : i64, !llvm.ptr
-    llvm.store %291, %293 : i256, !llvm.ptr
+    %257 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %258 = llvm.getelementptr %257[-7] : (!llvm.ptr) -> !llvm.ptr, i256
+    %259 = llvm.load %258 : !llvm.ptr -> i256
+    %260 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %259, %260 : i256, !llvm.ptr
+    %261 = llvm.getelementptr %260[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %261, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb106
   ^bb101:  // pred: ^bb103
-    %c1024_i64_160 = arith.constant 1024 : i64
-    %295 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_161 = arith.constant 1 : i64
-    %296 = arith.addi %295, %c1_i64_161 : i64
-    %c7_i64_162 = arith.constant 7 : i64
-    %297 = arith.cmpi ult, %295, %c7_i64_162 : i64
-    %298 = arith.cmpi ult, %c1024_i64_160, %296 : i64
-    %299 = arith.xori %297, %298 : i1
-    %c92_i8_163 = arith.constant 92 : i8
-    cf.cond_br %299, ^bb1(%c92_i8_163 : i8), ^bb100
+    %c1024_i64_129 = arith.constant 1024 : i64
+    %262 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_130 = arith.constant 1 : i64
+    %263 = arith.addi %262, %c1_i64_130 : i64
+    llvm.store %263, %arg3 : i64, !llvm.ptr
+    %c7_i64_131 = arith.constant 7 : i64
+    %264 = arith.cmpi ult, %262, %c7_i64_131 : i64
+    %265 = arith.cmpi ult, %c1024_i64_129, %263 : i64
+    %266 = arith.xori %264, %265 : i1
+    %c92_i8_132 = arith.constant 92 : i8
+    cf.cond_br %266, ^bb1(%c92_i8_132 : i8), ^bb100
   ^bb102:  // pred: ^bb96
-    %300 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_164 = arith.constant 3 : i64
+    %267 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_133 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %301 = arith.cmpi uge, %300, %c3_i64_164 : i64
-    %c80_i8_165 = arith.constant 80 : i8
-    cf.cond_br %301, ^bb103, ^bb1(%c80_i8_165 : i8)
+    %268 = arith.cmpi uge, %267, %c3_i64_133 : i64
+    %c80_i8_134 = arith.constant 80 : i8
+    cf.cond_br %268, ^bb103, ^bb1(%c80_i8_134 : i8)
   ^bb103:  // pred: ^bb102
-    %302 = arith.subi %300, %c3_i64_164 : i64
-    llvm.store %302, %arg1 : i64, !llvm.ptr
+    %269 = arith.subi %267, %c3_i64_133 : i64
+    llvm.store %269, %arg1 : i64, !llvm.ptr
     cf.br ^bb101
   ^bb104:  // pred: ^bb105
-    %c65535_i256_166 = arith.constant 65535 : i256
-    %303 = llvm.load %arg3 : !llvm.ptr -> i64
-    %304 = llvm.getelementptr %arg2[%303] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_167 = arith.constant 1 : i64
-    %305 = arith.addi %303, %c1_i64_167 : i64
-    llvm.store %305, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256_166, %304 : i256, !llvm.ptr
+    %c65535_i256_135 = arith.constant 65535 : i256
+    %270 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_135, %270 : i256, !llvm.ptr
+    %271 = llvm.getelementptr %270[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %271, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb119
   ^bb105:  // pred: ^bb107
-    %c1024_i64_168 = arith.constant 1024 : i64
-    %306 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_169 = arith.constant 1 : i64
-    %307 = arith.addi %306, %c1_i64_169 : i64
-    %308 = arith.cmpi ult, %c1024_i64_168, %307 : i64
-    %c92_i8_170 = arith.constant 92 : i8
-    cf.cond_br %308, ^bb1(%c92_i8_170 : i8), ^bb104
+    %c1024_i64_136 = arith.constant 1024 : i64
+    %272 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_137 = arith.constant 1 : i64
+    %273 = arith.addi %272, %c1_i64_137 : i64
+    llvm.store %273, %arg3 : i64, !llvm.ptr
+    %274 = arith.cmpi ult, %c1024_i64_136, %273 : i64
+    %c92_i8_138 = arith.constant 92 : i8
+    cf.cond_br %274, ^bb1(%c92_i8_138 : i8), ^bb104
   ^bb106:  // pred: ^bb100
-    %309 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_171 = arith.constant 3 : i64
+    %275 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_139 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %310 = arith.cmpi uge, %309, %c3_i64_171 : i64
-    %c80_i8_172 = arith.constant 80 : i8
-    cf.cond_br %310, ^bb107, ^bb1(%c80_i8_172 : i8)
+    %276 = arith.cmpi uge, %275, %c3_i64_139 : i64
+    %c80_i8_140 = arith.constant 80 : i8
+    cf.cond_br %276, ^bb107, ^bb1(%c80_i8_140 : i8)
   ^bb107:  // pred: ^bb106
-    %311 = arith.subi %309, %c3_i64_171 : i64
-    llvm.store %311, %arg1 : i64, !llvm.ptr
+    %277 = arith.subi %275, %c3_i64_139 : i64
+    llvm.store %277, %arg1 : i64, !llvm.ptr
     cf.br ^bb105
   ^bb108:  // pred: ^bb118
-    %312 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_173 = arith.constant 1 : i64
-    %313 = arith.subi %312, %c1_i64_173 : i64
-    %314 = llvm.getelementptr %arg2[%313] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %313, %arg3 : i64, !llvm.ptr
-    %315 = llvm.load %314 : !llvm.ptr -> i256
-    %316 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_174 = arith.constant 1 : i64
-    %317 = arith.subi %316, %c1_i64_174 : i64
-    %318 = llvm.getelementptr %arg2[%317] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %317, %arg3 : i64, !llvm.ptr
-    %319 = llvm.load %318 : !llvm.ptr -> i256
-    %320 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_175 = arith.constant 1 : i64
-    %321 = arith.subi %320, %c1_i64_175 : i64
-    %322 = llvm.getelementptr %arg2[%321] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %321, %arg3 : i64, !llvm.ptr
-    %323 = llvm.load %322 : !llvm.ptr -> i256
-    %324 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_176 = arith.constant 1 : i64
-    %325 = arith.subi %324, %c1_i64_176 : i64
-    %326 = llvm.getelementptr %arg2[%325] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %325, %arg3 : i64, !llvm.ptr
-    %327 = llvm.load %326 : !llvm.ptr -> i256
-    %328 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_177 = arith.constant 1 : i64
-    %329 = arith.subi %328, %c1_i64_177 : i64
-    %330 = llvm.getelementptr %arg2[%329] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %329, %arg3 : i64, !llvm.ptr
-    %331 = llvm.load %330 : !llvm.ptr -> i256
-    %332 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_178 = arith.constant 1 : i64
-    %333 = arith.subi %332, %c1_i64_178 : i64
-    %334 = llvm.getelementptr %arg2[%333] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %333, %arg3 : i64, !llvm.ptr
-    %335 = llvm.load %334 : !llvm.ptr -> i256
-    %336 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_179 = arith.constant 1 : i64
-    %337 = arith.subi %336, %c1_i64_179 : i64
-    %338 = llvm.getelementptr %arg2[%337] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %337, %arg3 : i64, !llvm.ptr
-    %339 = llvm.load %338 : !llvm.ptr -> i256
-    %340 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
-    %c0_i8_180 = arith.constant 0 : i8
-    %341 = arith.cmpi ne, %340, %c0_i8_180 : i8
-    %c0_i256_181 = arith.constant 0 : i256
-    %342 = arith.cmpi ne, %323, %c0_i256_181 : i256
-    %343 = arith.andi %341, %342 : i1
-    %c86_i8_182 = arith.constant 86 : i8
-    cf.cond_br %343, ^bb1(%c86_i8_182 : i8), ^bb109
+    %278 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %279 = llvm.getelementptr %278[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %280 = llvm.load %279 : !llvm.ptr -> i256
+    llvm.store %279, %0 : !llvm.ptr, !llvm.ptr
+    %281 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %282 = llvm.getelementptr %281[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %283 = llvm.load %282 : !llvm.ptr -> i256
+    llvm.store %282, %0 : !llvm.ptr, !llvm.ptr
+    %284 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %285 = llvm.getelementptr %284[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %286 = llvm.load %285 : !llvm.ptr -> i256
+    llvm.store %285, %0 : !llvm.ptr, !llvm.ptr
+    %287 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %288 = llvm.getelementptr %287[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %289 = llvm.load %288 : !llvm.ptr -> i256
+    llvm.store %288, %0 : !llvm.ptr, !llvm.ptr
+    %290 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %291 = llvm.getelementptr %290[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %292 = llvm.load %291 : !llvm.ptr -> i256
+    llvm.store %291, %0 : !llvm.ptr, !llvm.ptr
+    %293 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %294 = llvm.getelementptr %293[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %295 = llvm.load %294 : !llvm.ptr -> i256
+    llvm.store %294, %0 : !llvm.ptr, !llvm.ptr
+    %296 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %297 = llvm.getelementptr %296[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %298 = llvm.load %297 : !llvm.ptr -> i256
+    llvm.store %297, %0 : !llvm.ptr, !llvm.ptr
+    %299 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %c0_i8_141 = arith.constant 0 : i8
+    %300 = arith.cmpi ne, %299, %c0_i8_141 : i8
+    %c0_i256_142 = arith.constant 0 : i256
+    %301 = arith.cmpi ne, %286, %c0_i256_142 : i256
+    %302 = arith.andi %300, %301 : i1
+    %c86_i8_143 = arith.constant 86 : i8
+    cf.cond_br %302, ^bb1(%c86_i8_143 : i8), ^bb109
   ^bb109:  // pred: ^bb108
-    %c18446744073709551615_i256_183 = arith.constant 18446744073709551615 : i256
-    %344 = arith.cmpi sgt, %331, %c18446744073709551615_i256_183 : i256
-    %c84_i8_184 = arith.constant 84 : i8
-    cf.cond_br %344, ^bb1(%c84_i8_184 : i8), ^bb110
+    %c18446744073709551615_i256_144 = arith.constant 18446744073709551615 : i256
+    %303 = arith.cmpi sgt, %292, %c18446744073709551615_i256_144 : i256
+    %c84_i8_145 = arith.constant 84 : i8
+    cf.cond_br %303, ^bb1(%c84_i8_145 : i8), ^bb110
   ^bb110:  // pred: ^bb109
-    %345 = arith.trunci %331 : i256 to i64
-    %c0_i64_185 = arith.constant 0 : i64
-    %346 = arith.cmpi slt, %345, %c0_i64_185 : i64
-    %c84_i8_186 = arith.constant 84 : i8
-    cf.cond_br %346, ^bb1(%c84_i8_186 : i8), ^bb111
+    %304 = arith.trunci %292 : i256 to i64
+    %c0_i64_146 = arith.constant 0 : i64
+    %305 = arith.cmpi slt, %304, %c0_i64_146 : i64
+    %c84_i8_147 = arith.constant 84 : i8
+    cf.cond_br %305, ^bb1(%c84_i8_147 : i8), ^bb111
   ^bb111:  // pred: ^bb110
-    %c0_i64_187 = arith.constant 0 : i64
-    %347 = arith.cmpi ne, %345, %c0_i64_187 : i64
-    cf.cond_br %347, ^bb156, ^bb112
+    %c0_i64_148 = arith.constant 0 : i64
+    %306 = arith.cmpi ne, %304, %c0_i64_148 : i64
+    cf.cond_br %306, ^bb156, ^bb112
   ^bb112:  // 2 preds: ^bb111, ^bb160
-    %c18446744073709551615_i256_188 = arith.constant 18446744073709551615 : i256
-    %348 = arith.cmpi sgt, %339, %c18446744073709551615_i256_188 : i256
-    %c84_i8_189 = arith.constant 84 : i8
-    cf.cond_br %348, ^bb1(%c84_i8_189 : i8), ^bb113
+    %c18446744073709551615_i256_149 = arith.constant 18446744073709551615 : i256
+    %307 = arith.cmpi sgt, %298, %c18446744073709551615_i256_149 : i256
+    %c84_i8_150 = arith.constant 84 : i8
+    cf.cond_br %307, ^bb1(%c84_i8_150 : i8), ^bb113
   ^bb113:  // pred: ^bb112
-    %349 = arith.trunci %339 : i256 to i64
-    %c0_i64_190 = arith.constant 0 : i64
-    %350 = arith.cmpi slt, %349, %c0_i64_190 : i64
-    %c84_i8_191 = arith.constant 84 : i8
-    cf.cond_br %350, ^bb1(%c84_i8_191 : i8), ^bb114
+    %308 = arith.trunci %298 : i256 to i64
+    %c0_i64_151 = arith.constant 0 : i64
+    %309 = arith.cmpi slt, %308, %c0_i64_151 : i64
+    %c84_i8_152 = arith.constant 84 : i8
+    cf.cond_br %309, ^bb1(%c84_i8_152 : i8), ^bb114
   ^bb114:  // pred: ^bb113
-    %c0_i64_192 = arith.constant 0 : i64
-    %351 = arith.cmpi ne, %349, %c0_i64_192 : i64
-    cf.cond_br %351, ^bb164, ^bb115
+    %c0_i64_153 = arith.constant 0 : i64
+    %310 = arith.cmpi ne, %308, %c0_i64_153 : i64
+    cf.cond_br %310, ^bb164, ^bb115
   ^bb115:  // 2 preds: ^bb114, ^bb168
-    %352 = arith.trunci %327 : i256 to i64
-    %353 = arith.trunci %335 : i256 to i64
-    %354 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_193 = arith.constant 1 : i256
-    %355 = llvm.alloca %c1_i256_193 x i256 : (i256) -> !llvm.ptr
-    llvm.store %323, %355 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_194 = arith.constant 1 : i256
-    %356 = llvm.alloca %c1_i256_194 x i256 : (i256) -> !llvm.ptr
-    llvm.store %315, %356 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_195 = arith.constant 1 : i256
-    %357 = llvm.alloca %c1_i256_195 x i256 : (i256) -> !llvm.ptr
-    llvm.store %319, %357 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i8_196 = arith.constant 0 : i8
-    %358 = call @dora_fn_call(%arg0, %356, %357, %355, %352, %345, %353, %349, %354, %c0_i8_196) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %359 = llvm.getelementptr %358[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %360 = llvm.load %359 : !llvm.ptr -> i8
-    %361 = llvm.getelementptr %358[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %362 = llvm.load %361 : !llvm.ptr -> i8
-    %c0_i8_197 = arith.constant 0 : i8
-    %363 = arith.cmpi ne, %362, %c0_i8_197 : i8
-    cf.cond_br %363, ^bb1(%362 : i8), ^bb116
+    %311 = arith.trunci %289 : i256 to i64
+    %312 = arith.trunci %295 : i256 to i64
+    %313 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_154 = arith.constant 1 : i256
+    %314 = llvm.alloca %c1_i256_154 x i256 : (i256) -> !llvm.ptr
+    llvm.store %286, %314 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_155 = arith.constant 1 : i256
+    %315 = llvm.alloca %c1_i256_155 x i256 : (i256) -> !llvm.ptr
+    llvm.store %280, %315 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_156 = arith.constant 1 : i256
+    %316 = llvm.alloca %c1_i256_156 x i256 : (i256) -> !llvm.ptr
+    llvm.store %283, %316 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i8_157 = arith.constant 0 : i8
+    %317 = call @dora_fn_call(%arg0, %315, %316, %314, %311, %304, %312, %308, %313, %c0_i8_157) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %318 = llvm.getelementptr %317[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %319 = llvm.load %318 : !llvm.ptr -> i8
+    %320 = llvm.getelementptr %317[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %321 = llvm.load %320 : !llvm.ptr -> i8
+    %c0_i8_158 = arith.constant 0 : i8
+    %322 = arith.cmpi ne, %321, %c0_i8_158 : i8
+    cf.cond_br %322, ^bb1(%321 : i8), ^bb116
   ^bb116:  // pred: ^bb115
-    %364 = llvm.getelementptr %358[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %365 = llvm.load %364 : !llvm.ptr -> i64
-    %366 = llvm.load %arg1 : !llvm.ptr -> i64
-    %367 = arith.cmpi ult, %366, %365 : i64
-    scf.if %367 {
+    %323 = llvm.getelementptr %317[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %324 = llvm.load %323 : !llvm.ptr -> i64
+    %325 = llvm.load %arg1 : !llvm.ptr -> i64
+    %326 = arith.cmpi ult, %325, %324 : i64
+    scf.if %326 {
     } else {
-      %553 = arith.subi %366, %365 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %325, %324 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_198 = arith.constant 80 : i8
-    cf.cond_br %367, ^bb1(%c80_i8_198 : i8), ^bb117
+    %c80_i8_159 = arith.constant 80 : i8
+    cf.cond_br %326, ^bb1(%c80_i8_159 : i8), ^bb117
   ^bb117:  // pred: ^bb116
-    %368 = arith.extui %360 : i8 to i256
-    %369 = llvm.load %arg3 : !llvm.ptr -> i64
-    %370 = llvm.getelementptr %arg2[%369] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_199 = arith.constant 1 : i64
-    %371 = arith.addi %369, %c1_i64_199 : i64
-    llvm.store %371, %arg3 : i64, !llvm.ptr
-    llvm.store %368, %370 : i256, !llvm.ptr
+    %327 = arith.extui %319 : i8 to i256
+    %328 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %327, %328 : i256, !llvm.ptr
+    %329 = llvm.getelementptr %328[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %329, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb121
   ^bb118:  // pred: ^bb120
-    %c1024_i64_200 = arith.constant 1024 : i64
-    %372 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-6_i64_201 = arith.constant -6 : i64
-    %373 = arith.addi %372, %c-6_i64_201 : i64
-    %c7_i64_202 = arith.constant 7 : i64
-    %374 = arith.cmpi ult, %372, %c7_i64_202 : i64
-    %c91_i8_203 = arith.constant 91 : i8
-    cf.cond_br %374, ^bb1(%c91_i8_203 : i8), ^bb108
+    %c1024_i64_160 = arith.constant 1024 : i64
+    %330 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-6_i64_161 = arith.constant -6 : i64
+    %331 = arith.addi %330, %c-6_i64_161 : i64
+    llvm.store %331, %arg3 : i64, !llvm.ptr
+    %c7_i64_162 = arith.constant 7 : i64
+    %332 = arith.cmpi ult, %330, %c7_i64_162 : i64
+    %c91_i8_163 = arith.constant 91 : i8
+    cf.cond_br %332, ^bb1(%c91_i8_163 : i8), ^bb108
   ^bb119:  // pred: ^bb104
-    %375 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_204 = arith.constant 0 : i64
+    %333 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_164 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %376 = arith.cmpi uge, %375, %c0_i64_204 : i64
-    %c80_i8_205 = arith.constant 80 : i8
-    cf.cond_br %376, ^bb120, ^bb1(%c80_i8_205 : i8)
+    %334 = arith.cmpi uge, %333, %c0_i64_164 : i64
+    %c80_i8_165 = arith.constant 80 : i8
+    cf.cond_br %334, ^bb120, ^bb1(%c80_i8_165 : i8)
   ^bb120:  // pred: ^bb119
-    %377 = arith.subi %375, %c0_i64_204 : i64
-    llvm.store %377, %arg1 : i64, !llvm.ptr
+    %335 = arith.subi %333, %c0_i64_164 : i64
+    llvm.store %335, %arg1 : i64, !llvm.ptr
     cf.br ^bb118
   ^bb121:  // pred: ^bb117
-    %c0_i64_206 = arith.constant 0 : i64
+    %c0_i64_166 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %378 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_206, %c0_i64_206, %378, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %336 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_166, %c0_i64_166, %336, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb122:  // pred: ^bb11
-    %c18446744073709551615_i256_207 = arith.constant 18446744073709551615 : i256
-    %379 = arith.cmpi sgt, %24, %c18446744073709551615_i256_207 : i256
-    %c84_i8_208 = arith.constant 84 : i8
-    cf.cond_br %379, ^bb1(%c84_i8_208 : i8), ^bb123
+    %c18446744073709551615_i256_167 = arith.constant 18446744073709551615 : i256
+    %337 = arith.cmpi sgt, %22, %c18446744073709551615_i256_167 : i256
+    %c84_i8_168 = arith.constant 84 : i8
+    cf.cond_br %337, ^bb1(%c84_i8_168 : i8), ^bb123
   ^bb123:  // pred: ^bb122
-    %380 = arith.trunci %24 : i256 to i64
-    %c0_i64_209 = arith.constant 0 : i64
-    %381 = arith.cmpi slt, %380, %c0_i64_209 : i64
-    %c84_i8_210 = arith.constant 84 : i8
-    cf.cond_br %381, ^bb1(%c84_i8_210 : i8), ^bb124
+    %338 = arith.trunci %22 : i256 to i64
+    %c0_i64_169 = arith.constant 0 : i64
+    %339 = arith.cmpi slt, %338, %c0_i64_169 : i64
+    %c84_i8_170 = arith.constant 84 : i8
+    cf.cond_br %339, ^bb1(%c84_i8_170 : i8), ^bb124
   ^bb124:  // pred: ^bb123
-    %382 = arith.addi %380, %c32_i64 : i64
-    %c0_i64_211 = arith.constant 0 : i64
-    %383 = arith.cmpi slt, %382, %c0_i64_211 : i64
-    %c84_i8_212 = arith.constant 84 : i8
-    cf.cond_br %383, ^bb1(%c84_i8_212 : i8), ^bb125
+    %340 = arith.addi %338, %c32_i64 : i64
+    %c0_i64_171 = arith.constant 0 : i64
+    %341 = arith.cmpi slt, %340, %c0_i64_171 : i64
+    %c84_i8_172 = arith.constant 84 : i8
+    cf.cond_br %341, ^bb1(%c84_i8_172 : i8), ^bb125
   ^bb125:  // pred: ^bb124
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_213 = arith.constant 32 : i64
-    %384 = arith.addi %382, %c31_i64 : i64
-    %385 = arith.divui %384, %c32_i64_213 : i64
-    %c32_i64_214 = arith.constant 32 : i64
-    %386 = arith.muli %385, %c32_i64_214 : i64
-    %387 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_215 = arith.constant 31 : i64
-    %c32_i64_216 = arith.constant 32 : i64
-    %388 = arith.addi %387, %c31_i64_215 : i64
-    %389 = arith.divui %388, %c32_i64_216 : i64
-    %390 = arith.muli %389, %c32_i64_214 : i64
-    %391 = arith.cmpi ult, %390, %386 : i64
-    cf.cond_br %391, ^bb127, ^bb126
+    %c32_i64_173 = arith.constant 32 : i64
+    %342 = arith.addi %340, %c31_i64 : i64
+    %343 = arith.divui %342, %c32_i64_173 : i64
+    %c32_i64_174 = arith.constant 32 : i64
+    %344 = arith.muli %343, %c32_i64_174 : i64
+    %345 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_175 = arith.constant 31 : i64
+    %c32_i64_176 = arith.constant 32 : i64
+    %346 = arith.addi %345, %c31_i64_175 : i64
+    %347 = arith.divui %346, %c32_i64_176 : i64
+    %348 = arith.muli %347, %c32_i64_174 : i64
+    %349 = arith.cmpi ult, %348, %344 : i64
+    cf.cond_br %349, ^bb127, ^bb126
   ^bb126:  // 2 preds: ^bb125, ^bb129
     cf.br ^bb12
   ^bb127:  // pred: ^bb125
-    %c3_i64_217 = arith.constant 3 : i64
+    %c3_i64_177 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %392 = arith.muli %389, %389 : i64
-    %393 = arith.divui %392, %c512_i64 : i64
-    %394 = arith.muli %389, %c3_i64_217 : i64
-    %395 = arith.addi %393, %394 : i64
-    %c3_i64_218 = arith.constant 3 : i64
-    %c512_i64_219 = arith.constant 512 : i64
-    %396 = arith.muli %385, %385 : i64
-    %397 = arith.divui %396, %c512_i64_219 : i64
-    %398 = arith.muli %385, %c3_i64_218 : i64
-    %399 = arith.addi %397, %398 : i64
-    %400 = arith.subi %399, %395 : i64
-    %401 = llvm.load %arg1 : !llvm.ptr -> i64
-    %402 = arith.cmpi ult, %401, %400 : i64
-    scf.if %402 {
+    %350 = arith.muli %347, %347 : i64
+    %351 = arith.divui %350, %c512_i64 : i64
+    %352 = arith.muli %347, %c3_i64_177 : i64
+    %353 = arith.addi %351, %352 : i64
+    %c3_i64_178 = arith.constant 3 : i64
+    %c512_i64_179 = arith.constant 512 : i64
+    %354 = arith.muli %343, %343 : i64
+    %355 = arith.divui %354, %c512_i64_179 : i64
+    %356 = arith.muli %343, %c3_i64_178 : i64
+    %357 = arith.addi %355, %356 : i64
+    %358 = arith.subi %357, %353 : i64
+    %359 = llvm.load %arg1 : !llvm.ptr -> i64
+    %360 = arith.cmpi ult, %359, %358 : i64
+    scf.if %360 {
     } else {
-      %553 = arith.subi %401, %400 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %359, %358 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_220 = arith.constant 80 : i8
-    cf.cond_br %402, ^bb1(%c80_i8_220 : i8), ^bb128
+    %c80_i8_180 = arith.constant 80 : i8
+    cf.cond_br %360, ^bb1(%c80_i8_180 : i8), ^bb128
   ^bb128:  // pred: ^bb127
-    %403 = call @dora_fn_extend_memory(%arg0, %386) : (!llvm.ptr, i64) -> !llvm.ptr
-    %404 = llvm.getelementptr %403[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %405 = llvm.load %404 : !llvm.ptr -> i8
-    %c0_i8_221 = arith.constant 0 : i8
-    %406 = arith.cmpi ne, %405, %c0_i8_221 : i8
-    cf.cond_br %406, ^bb1(%405 : i8), ^bb129
+    %361 = call @dora_fn_extend_memory(%arg0, %344) : (!llvm.ptr, i64) -> !llvm.ptr
+    %362 = llvm.getelementptr %361[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %363 = llvm.load %362 : !llvm.ptr -> i8
+    %c0_i8_181 = arith.constant 0 : i8
+    %364 = arith.cmpi ne, %363, %c0_i8_181 : i8
+    cf.cond_br %364, ^bb1(%363 : i8), ^bb129
   ^bb129:  // pred: ^bb128
     cf.br ^bb126
   ^bb130:  // pred: ^bb31
     %c49152_i64 = arith.constant 49152 : i64
-    %407 = arith.cmpi ugt, %82, %c49152_i64 : i64
+    %365 = arith.cmpi ugt, %73, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %407, ^bb1(%c100_i8 : i8), ^bb131
+    cf.cond_br %365, ^bb1(%c100_i8 : i8), ^bb131
   ^bb131:  // pred: ^bb130
-    %c31_i64_222 = arith.constant 31 : i64
-    %c32_i64_223 = arith.constant 32 : i64
-    %408 = arith.addi %82, %c31_i64_222 : i64
-    %409 = arith.divui %408, %c32_i64_223 : i64
-    %c2_i64_224 = arith.constant 2 : i64
-    %410 = arith.muli %409, %c2_i64_224 : i64
-    %411 = llvm.load %arg1 : !llvm.ptr -> i64
-    %412 = arith.cmpi ult, %411, %410 : i64
-    scf.if %412 {
+    %c31_i64_182 = arith.constant 31 : i64
+    %c32_i64_183 = arith.constant 32 : i64
+    %366 = arith.addi %73, %c31_i64_182 : i64
+    %367 = arith.divui %366, %c32_i64_183 : i64
+    %c2_i64_184 = arith.constant 2 : i64
+    %368 = arith.muli %367, %c2_i64_184 : i64
+    %369 = llvm.load %arg1 : !llvm.ptr -> i64
+    %370 = arith.cmpi ult, %369, %368 : i64
+    scf.if %370 {
     } else {
-      %553 = arith.subi %411, %410 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %369, %368 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_225 = arith.constant 80 : i8
-    cf.cond_br %412, ^bb1(%c80_i8_225 : i8), ^bb132
+    %c80_i8_185 = arith.constant 80 : i8
+    cf.cond_br %370, ^bb1(%c80_i8_185 : i8), ^bb132
   ^bb132:  // pred: ^bb131
-    %c18446744073709551615_i256_226 = arith.constant 18446744073709551615 : i256
-    %413 = arith.cmpi sgt, %74, %c18446744073709551615_i256_226 : i256
-    %c84_i8_227 = arith.constant 84 : i8
-    cf.cond_br %413, ^bb1(%c84_i8_227 : i8), ^bb133
+    %c18446744073709551615_i256_186 = arith.constant 18446744073709551615 : i256
+    %371 = arith.cmpi sgt, %66, %c18446744073709551615_i256_186 : i256
+    %c84_i8_187 = arith.constant 84 : i8
+    cf.cond_br %371, ^bb1(%c84_i8_187 : i8), ^bb133
   ^bb133:  // pred: ^bb132
-    %414 = arith.trunci %74 : i256 to i64
-    %c0_i64_228 = arith.constant 0 : i64
-    %415 = arith.cmpi slt, %414, %c0_i64_228 : i64
-    %c84_i8_229 = arith.constant 84 : i8
-    cf.cond_br %415, ^bb1(%c84_i8_229 : i8), ^bb134
+    %372 = arith.trunci %66 : i256 to i64
+    %c0_i64_188 = arith.constant 0 : i64
+    %373 = arith.cmpi slt, %372, %c0_i64_188 : i64
+    %c84_i8_189 = arith.constant 84 : i8
+    cf.cond_br %373, ^bb1(%c84_i8_189 : i8), ^bb134
   ^bb134:  // pred: ^bb133
-    %416 = arith.addi %414, %82 : i64
-    %c0_i64_230 = arith.constant 0 : i64
-    %417 = arith.cmpi slt, %416, %c0_i64_230 : i64
-    %c84_i8_231 = arith.constant 84 : i8
-    cf.cond_br %417, ^bb1(%c84_i8_231 : i8), ^bb135
+    %374 = arith.addi %372, %73 : i64
+    %c0_i64_190 = arith.constant 0 : i64
+    %375 = arith.cmpi slt, %374, %c0_i64_190 : i64
+    %c84_i8_191 = arith.constant 84 : i8
+    cf.cond_br %375, ^bb1(%c84_i8_191 : i8), ^bb135
   ^bb135:  // pred: ^bb134
-    %c31_i64_232 = arith.constant 31 : i64
-    %c32_i64_233 = arith.constant 32 : i64
-    %418 = arith.addi %416, %c31_i64_232 : i64
-    %419 = arith.divui %418, %c32_i64_233 : i64
-    %c32_i64_234 = arith.constant 32 : i64
-    %420 = arith.muli %419, %c32_i64_234 : i64
-    %421 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_235 = arith.constant 31 : i64
-    %c32_i64_236 = arith.constant 32 : i64
-    %422 = arith.addi %421, %c31_i64_235 : i64
-    %423 = arith.divui %422, %c32_i64_236 : i64
-    %424 = arith.muli %423, %c32_i64_234 : i64
-    %425 = arith.cmpi ult, %424, %420 : i64
-    cf.cond_br %425, ^bb137, ^bb136
+    %c31_i64_192 = arith.constant 31 : i64
+    %c32_i64_193 = arith.constant 32 : i64
+    %376 = arith.addi %374, %c31_i64_192 : i64
+    %377 = arith.divui %376, %c32_i64_193 : i64
+    %c32_i64_194 = arith.constant 32 : i64
+    %378 = arith.muli %377, %c32_i64_194 : i64
+    %379 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_195 = arith.constant 31 : i64
+    %c32_i64_196 = arith.constant 32 : i64
+    %380 = arith.addi %379, %c31_i64_195 : i64
+    %381 = arith.divui %380, %c32_i64_196 : i64
+    %382 = arith.muli %381, %c32_i64_194 : i64
+    %383 = arith.cmpi ult, %382, %378 : i64
+    cf.cond_br %383, ^bb137, ^bb136
   ^bb136:  // 2 preds: ^bb135, ^bb139
     cf.br ^bb32
   ^bb137:  // pred: ^bb135
-    %c3_i64_237 = arith.constant 3 : i64
-    %c512_i64_238 = arith.constant 512 : i64
-    %426 = arith.muli %423, %423 : i64
-    %427 = arith.divui %426, %c512_i64_238 : i64
-    %428 = arith.muli %423, %c3_i64_237 : i64
-    %429 = arith.addi %427, %428 : i64
-    %c3_i64_239 = arith.constant 3 : i64
-    %c512_i64_240 = arith.constant 512 : i64
-    %430 = arith.muli %419, %419 : i64
-    %431 = arith.divui %430, %c512_i64_240 : i64
-    %432 = arith.muli %419, %c3_i64_239 : i64
-    %433 = arith.addi %431, %432 : i64
-    %434 = arith.subi %433, %429 : i64
-    %435 = llvm.load %arg1 : !llvm.ptr -> i64
-    %436 = arith.cmpi ult, %435, %434 : i64
-    scf.if %436 {
+    %c3_i64_197 = arith.constant 3 : i64
+    %c512_i64_198 = arith.constant 512 : i64
+    %384 = arith.muli %381, %381 : i64
+    %385 = arith.divui %384, %c512_i64_198 : i64
+    %386 = arith.muli %381, %c3_i64_197 : i64
+    %387 = arith.addi %385, %386 : i64
+    %c3_i64_199 = arith.constant 3 : i64
+    %c512_i64_200 = arith.constant 512 : i64
+    %388 = arith.muli %377, %377 : i64
+    %389 = arith.divui %388, %c512_i64_200 : i64
+    %390 = arith.muli %377, %c3_i64_199 : i64
+    %391 = arith.addi %389, %390 : i64
+    %392 = arith.subi %391, %387 : i64
+    %393 = llvm.load %arg1 : !llvm.ptr -> i64
+    %394 = arith.cmpi ult, %393, %392 : i64
+    scf.if %394 {
     } else {
-      %553 = arith.subi %435, %434 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %393, %392 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_241 = arith.constant 80 : i8
-    cf.cond_br %436, ^bb1(%c80_i8_241 : i8), ^bb138
+    %c80_i8_201 = arith.constant 80 : i8
+    cf.cond_br %394, ^bb1(%c80_i8_201 : i8), ^bb138
   ^bb138:  // pred: ^bb137
-    %437 = call @dora_fn_extend_memory(%arg0, %420) : (!llvm.ptr, i64) -> !llvm.ptr
-    %438 = llvm.getelementptr %437[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %439 = llvm.load %438 : !llvm.ptr -> i8
-    %c0_i8_242 = arith.constant 0 : i8
-    %440 = arith.cmpi ne, %439, %c0_i8_242 : i8
-    cf.cond_br %440, ^bb1(%439 : i8), ^bb139
+    %395 = call @dora_fn_extend_memory(%arg0, %378) : (!llvm.ptr, i64) -> !llvm.ptr
+    %396 = llvm.getelementptr %395[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %397 = llvm.load %396 : !llvm.ptr -> i8
+    %c0_i8_202 = arith.constant 0 : i8
+    %398 = arith.cmpi ne, %397, %c0_i8_202 : i8
+    cf.cond_br %398, ^bb1(%397 : i8), ^bb139
   ^bb139:  // pred: ^bb138
     cf.br ^bb136
   ^bb140:  // pred: ^bb70
-    %c18446744073709551615_i256_243 = arith.constant 18446744073709551615 : i256
-    %441 = arith.cmpi sgt, %192, %c18446744073709551615_i256_243 : i256
-    %c84_i8_244 = arith.constant 84 : i8
-    cf.cond_br %441, ^bb1(%c84_i8_244 : i8), ^bb141
+    %c18446744073709551615_i256_203 = arith.constant 18446744073709551615 : i256
+    %399 = arith.cmpi sgt, %170, %c18446744073709551615_i256_203 : i256
+    %c84_i8_204 = arith.constant 84 : i8
+    cf.cond_br %399, ^bb1(%c84_i8_204 : i8), ^bb141
   ^bb141:  // pred: ^bb140
-    %442 = arith.trunci %192 : i256 to i64
-    %c0_i64_245 = arith.constant 0 : i64
-    %443 = arith.cmpi slt, %442, %c0_i64_245 : i64
-    %c84_i8_246 = arith.constant 84 : i8
-    cf.cond_br %443, ^bb1(%c84_i8_246 : i8), ^bb142
+    %400 = arith.trunci %170 : i256 to i64
+    %c0_i64_205 = arith.constant 0 : i64
+    %401 = arith.cmpi slt, %400, %c0_i64_205 : i64
+    %c84_i8_206 = arith.constant 84 : i8
+    cf.cond_br %401, ^bb1(%c84_i8_206 : i8), ^bb142
   ^bb142:  // pred: ^bb141
-    %444 = arith.addi %442, %210 : i64
-    %c0_i64_247 = arith.constant 0 : i64
-    %445 = arith.cmpi slt, %444, %c0_i64_247 : i64
-    %c84_i8_248 = arith.constant 84 : i8
-    cf.cond_br %445, ^bb1(%c84_i8_248 : i8), ^bb143
+    %402 = arith.addi %400, %185 : i64
+    %c0_i64_207 = arith.constant 0 : i64
+    %403 = arith.cmpi slt, %402, %c0_i64_207 : i64
+    %c84_i8_208 = arith.constant 84 : i8
+    cf.cond_br %403, ^bb1(%c84_i8_208 : i8), ^bb143
   ^bb143:  // pred: ^bb142
-    %c31_i64_249 = arith.constant 31 : i64
-    %c32_i64_250 = arith.constant 32 : i64
-    %446 = arith.addi %444, %c31_i64_249 : i64
-    %447 = arith.divui %446, %c32_i64_250 : i64
-    %c32_i64_251 = arith.constant 32 : i64
-    %448 = arith.muli %447, %c32_i64_251 : i64
-    %449 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_252 = arith.constant 31 : i64
-    %c32_i64_253 = arith.constant 32 : i64
-    %450 = arith.addi %449, %c31_i64_252 : i64
-    %451 = arith.divui %450, %c32_i64_253 : i64
-    %452 = arith.muli %451, %c32_i64_251 : i64
-    %453 = arith.cmpi ult, %452, %448 : i64
-    cf.cond_br %453, ^bb145, ^bb144
+    %c31_i64_209 = arith.constant 31 : i64
+    %c32_i64_210 = arith.constant 32 : i64
+    %404 = arith.addi %402, %c31_i64_209 : i64
+    %405 = arith.divui %404, %c32_i64_210 : i64
+    %c32_i64_211 = arith.constant 32 : i64
+    %406 = arith.muli %405, %c32_i64_211 : i64
+    %407 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_212 = arith.constant 31 : i64
+    %c32_i64_213 = arith.constant 32 : i64
+    %408 = arith.addi %407, %c31_i64_212 : i64
+    %409 = arith.divui %408, %c32_i64_213 : i64
+    %410 = arith.muli %409, %c32_i64_211 : i64
+    %411 = arith.cmpi ult, %410, %406 : i64
+    cf.cond_br %411, ^bb145, ^bb144
   ^bb144:  // 2 preds: ^bb143, ^bb147
     cf.br ^bb71
   ^bb145:  // pred: ^bb143
-    %c3_i64_254 = arith.constant 3 : i64
-    %c512_i64_255 = arith.constant 512 : i64
-    %454 = arith.muli %451, %451 : i64
-    %455 = arith.divui %454, %c512_i64_255 : i64
-    %456 = arith.muli %451, %c3_i64_254 : i64
-    %457 = arith.addi %455, %456 : i64
-    %c3_i64_256 = arith.constant 3 : i64
-    %c512_i64_257 = arith.constant 512 : i64
-    %458 = arith.muli %447, %447 : i64
-    %459 = arith.divui %458, %c512_i64_257 : i64
-    %460 = arith.muli %447, %c3_i64_256 : i64
-    %461 = arith.addi %459, %460 : i64
-    %462 = arith.subi %461, %457 : i64
-    %463 = llvm.load %arg1 : !llvm.ptr -> i64
-    %464 = arith.cmpi ult, %463, %462 : i64
-    scf.if %464 {
+    %c3_i64_214 = arith.constant 3 : i64
+    %c512_i64_215 = arith.constant 512 : i64
+    %412 = arith.muli %409, %409 : i64
+    %413 = arith.divui %412, %c512_i64_215 : i64
+    %414 = arith.muli %409, %c3_i64_214 : i64
+    %415 = arith.addi %413, %414 : i64
+    %c3_i64_216 = arith.constant 3 : i64
+    %c512_i64_217 = arith.constant 512 : i64
+    %416 = arith.muli %405, %405 : i64
+    %417 = arith.divui %416, %c512_i64_217 : i64
+    %418 = arith.muli %405, %c3_i64_216 : i64
+    %419 = arith.addi %417, %418 : i64
+    %420 = arith.subi %419, %415 : i64
+    %421 = llvm.load %arg1 : !llvm.ptr -> i64
+    %422 = arith.cmpi ult, %421, %420 : i64
+    scf.if %422 {
     } else {
-      %553 = arith.subi %463, %462 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %421, %420 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_258 = arith.constant 80 : i8
-    cf.cond_br %464, ^bb1(%c80_i8_258 : i8), ^bb146
+    %c80_i8_218 = arith.constant 80 : i8
+    cf.cond_br %422, ^bb1(%c80_i8_218 : i8), ^bb146
   ^bb146:  // pred: ^bb145
-    %465 = call @dora_fn_extend_memory(%arg0, %448) : (!llvm.ptr, i64) -> !llvm.ptr
-    %466 = llvm.getelementptr %465[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %467 = llvm.load %466 : !llvm.ptr -> i8
-    %c0_i8_259 = arith.constant 0 : i8
-    %468 = arith.cmpi ne, %467, %c0_i8_259 : i8
-    cf.cond_br %468, ^bb1(%467 : i8), ^bb147
+    %423 = call @dora_fn_extend_memory(%arg0, %406) : (!llvm.ptr, i64) -> !llvm.ptr
+    %424 = llvm.getelementptr %423[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %425 = llvm.load %424 : !llvm.ptr -> i8
+    %c0_i8_219 = arith.constant 0 : i8
+    %426 = arith.cmpi ne, %425, %c0_i8_219 : i8
+    cf.cond_br %426, ^bb1(%425 : i8), ^bb147
   ^bb147:  // pred: ^bb146
     cf.br ^bb144
   ^bb148:  // pred: ^bb73
-    %c18446744073709551615_i256_260 = arith.constant 18446744073709551615 : i256
-    %469 = arith.cmpi sgt, %200, %c18446744073709551615_i256_260 : i256
-    %c84_i8_261 = arith.constant 84 : i8
-    cf.cond_br %469, ^bb1(%c84_i8_261 : i8), ^bb149
+    %c18446744073709551615_i256_220 = arith.constant 18446744073709551615 : i256
+    %427 = arith.cmpi sgt, %176, %c18446744073709551615_i256_220 : i256
+    %c84_i8_221 = arith.constant 84 : i8
+    cf.cond_br %427, ^bb1(%c84_i8_221 : i8), ^bb149
   ^bb149:  // pred: ^bb148
-    %470 = arith.trunci %200 : i256 to i64
-    %c0_i64_262 = arith.constant 0 : i64
-    %471 = arith.cmpi slt, %470, %c0_i64_262 : i64
-    %c84_i8_263 = arith.constant 84 : i8
-    cf.cond_br %471, ^bb1(%c84_i8_263 : i8), ^bb150
+    %428 = arith.trunci %176 : i256 to i64
+    %c0_i64_222 = arith.constant 0 : i64
+    %429 = arith.cmpi slt, %428, %c0_i64_222 : i64
+    %c84_i8_223 = arith.constant 84 : i8
+    cf.cond_br %429, ^bb1(%c84_i8_223 : i8), ^bb150
   ^bb150:  // pred: ^bb149
-    %472 = arith.addi %470, %214 : i64
-    %c0_i64_264 = arith.constant 0 : i64
-    %473 = arith.cmpi slt, %472, %c0_i64_264 : i64
-    %c84_i8_265 = arith.constant 84 : i8
-    cf.cond_br %473, ^bb1(%c84_i8_265 : i8), ^bb151
+    %430 = arith.addi %428, %189 : i64
+    %c0_i64_224 = arith.constant 0 : i64
+    %431 = arith.cmpi slt, %430, %c0_i64_224 : i64
+    %c84_i8_225 = arith.constant 84 : i8
+    cf.cond_br %431, ^bb1(%c84_i8_225 : i8), ^bb151
   ^bb151:  // pred: ^bb150
-    %c31_i64_266 = arith.constant 31 : i64
-    %c32_i64_267 = arith.constant 32 : i64
-    %474 = arith.addi %472, %c31_i64_266 : i64
-    %475 = arith.divui %474, %c32_i64_267 : i64
-    %c32_i64_268 = arith.constant 32 : i64
-    %476 = arith.muli %475, %c32_i64_268 : i64
-    %477 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_269 = arith.constant 31 : i64
-    %c32_i64_270 = arith.constant 32 : i64
-    %478 = arith.addi %477, %c31_i64_269 : i64
-    %479 = arith.divui %478, %c32_i64_270 : i64
-    %480 = arith.muli %479, %c32_i64_268 : i64
-    %481 = arith.cmpi ult, %480, %476 : i64
-    cf.cond_br %481, ^bb153, ^bb152
+    %c31_i64_226 = arith.constant 31 : i64
+    %c32_i64_227 = arith.constant 32 : i64
+    %432 = arith.addi %430, %c31_i64_226 : i64
+    %433 = arith.divui %432, %c32_i64_227 : i64
+    %c32_i64_228 = arith.constant 32 : i64
+    %434 = arith.muli %433, %c32_i64_228 : i64
+    %435 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_229 = arith.constant 31 : i64
+    %c32_i64_230 = arith.constant 32 : i64
+    %436 = arith.addi %435, %c31_i64_229 : i64
+    %437 = arith.divui %436, %c32_i64_230 : i64
+    %438 = arith.muli %437, %c32_i64_228 : i64
+    %439 = arith.cmpi ult, %438, %434 : i64
+    cf.cond_br %439, ^bb153, ^bb152
   ^bb152:  // 2 preds: ^bb151, ^bb155
     cf.br ^bb74
   ^bb153:  // pred: ^bb151
-    %c3_i64_271 = arith.constant 3 : i64
-    %c512_i64_272 = arith.constant 512 : i64
-    %482 = arith.muli %479, %479 : i64
-    %483 = arith.divui %482, %c512_i64_272 : i64
-    %484 = arith.muli %479, %c3_i64_271 : i64
-    %485 = arith.addi %483, %484 : i64
-    %c3_i64_273 = arith.constant 3 : i64
-    %c512_i64_274 = arith.constant 512 : i64
-    %486 = arith.muli %475, %475 : i64
-    %487 = arith.divui %486, %c512_i64_274 : i64
-    %488 = arith.muli %475, %c3_i64_273 : i64
-    %489 = arith.addi %487, %488 : i64
-    %490 = arith.subi %489, %485 : i64
-    %491 = llvm.load %arg1 : !llvm.ptr -> i64
-    %492 = arith.cmpi ult, %491, %490 : i64
-    scf.if %492 {
+    %c3_i64_231 = arith.constant 3 : i64
+    %c512_i64_232 = arith.constant 512 : i64
+    %440 = arith.muli %437, %437 : i64
+    %441 = arith.divui %440, %c512_i64_232 : i64
+    %442 = arith.muli %437, %c3_i64_231 : i64
+    %443 = arith.addi %441, %442 : i64
+    %c3_i64_233 = arith.constant 3 : i64
+    %c512_i64_234 = arith.constant 512 : i64
+    %444 = arith.muli %433, %433 : i64
+    %445 = arith.divui %444, %c512_i64_234 : i64
+    %446 = arith.muli %433, %c3_i64_233 : i64
+    %447 = arith.addi %445, %446 : i64
+    %448 = arith.subi %447, %443 : i64
+    %449 = llvm.load %arg1 : !llvm.ptr -> i64
+    %450 = arith.cmpi ult, %449, %448 : i64
+    scf.if %450 {
     } else {
-      %553 = arith.subi %491, %490 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %449, %448 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_275 = arith.constant 80 : i8
-    cf.cond_br %492, ^bb1(%c80_i8_275 : i8), ^bb154
+    %c80_i8_235 = arith.constant 80 : i8
+    cf.cond_br %450, ^bb1(%c80_i8_235 : i8), ^bb154
   ^bb154:  // pred: ^bb153
-    %493 = call @dora_fn_extend_memory(%arg0, %476) : (!llvm.ptr, i64) -> !llvm.ptr
-    %494 = llvm.getelementptr %493[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %495 = llvm.load %494 : !llvm.ptr -> i8
-    %c0_i8_276 = arith.constant 0 : i8
-    %496 = arith.cmpi ne, %495, %c0_i8_276 : i8
-    cf.cond_br %496, ^bb1(%495 : i8), ^bb155
+    %451 = call @dora_fn_extend_memory(%arg0, %434) : (!llvm.ptr, i64) -> !llvm.ptr
+    %452 = llvm.getelementptr %451[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %453 = llvm.load %452 : !llvm.ptr -> i8
+    %c0_i8_236 = arith.constant 0 : i8
+    %454 = arith.cmpi ne, %453, %c0_i8_236 : i8
+    cf.cond_br %454, ^bb1(%453 : i8), ^bb155
   ^bb155:  // pred: ^bb154
     cf.br ^bb152
   ^bb156:  // pred: ^bb111
-    %c18446744073709551615_i256_277 = arith.constant 18446744073709551615 : i256
-    %497 = arith.cmpi sgt, %327, %c18446744073709551615_i256_277 : i256
-    %c84_i8_278 = arith.constant 84 : i8
-    cf.cond_br %497, ^bb1(%c84_i8_278 : i8), ^bb157
+    %c18446744073709551615_i256_237 = arith.constant 18446744073709551615 : i256
+    %455 = arith.cmpi sgt, %289, %c18446744073709551615_i256_237 : i256
+    %c84_i8_238 = arith.constant 84 : i8
+    cf.cond_br %455, ^bb1(%c84_i8_238 : i8), ^bb157
   ^bb157:  // pred: ^bb156
-    %498 = arith.trunci %327 : i256 to i64
-    %c0_i64_279 = arith.constant 0 : i64
-    %499 = arith.cmpi slt, %498, %c0_i64_279 : i64
-    %c84_i8_280 = arith.constant 84 : i8
-    cf.cond_br %499, ^bb1(%c84_i8_280 : i8), ^bb158
+    %456 = arith.trunci %289 : i256 to i64
+    %c0_i64_239 = arith.constant 0 : i64
+    %457 = arith.cmpi slt, %456, %c0_i64_239 : i64
+    %c84_i8_240 = arith.constant 84 : i8
+    cf.cond_br %457, ^bb1(%c84_i8_240 : i8), ^bb158
   ^bb158:  // pred: ^bb157
-    %500 = arith.addi %498, %345 : i64
-    %c0_i64_281 = arith.constant 0 : i64
-    %501 = arith.cmpi slt, %500, %c0_i64_281 : i64
-    %c84_i8_282 = arith.constant 84 : i8
-    cf.cond_br %501, ^bb1(%c84_i8_282 : i8), ^bb159
+    %458 = arith.addi %456, %304 : i64
+    %c0_i64_241 = arith.constant 0 : i64
+    %459 = arith.cmpi slt, %458, %c0_i64_241 : i64
+    %c84_i8_242 = arith.constant 84 : i8
+    cf.cond_br %459, ^bb1(%c84_i8_242 : i8), ^bb159
   ^bb159:  // pred: ^bb158
-    %c31_i64_283 = arith.constant 31 : i64
-    %c32_i64_284 = arith.constant 32 : i64
-    %502 = arith.addi %500, %c31_i64_283 : i64
-    %503 = arith.divui %502, %c32_i64_284 : i64
-    %c32_i64_285 = arith.constant 32 : i64
-    %504 = arith.muli %503, %c32_i64_285 : i64
-    %505 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_286 = arith.constant 31 : i64
-    %c32_i64_287 = arith.constant 32 : i64
-    %506 = arith.addi %505, %c31_i64_286 : i64
-    %507 = arith.divui %506, %c32_i64_287 : i64
-    %508 = arith.muli %507, %c32_i64_285 : i64
-    %509 = arith.cmpi ult, %508, %504 : i64
-    cf.cond_br %509, ^bb161, ^bb160
+    %c31_i64_243 = arith.constant 31 : i64
+    %c32_i64_244 = arith.constant 32 : i64
+    %460 = arith.addi %458, %c31_i64_243 : i64
+    %461 = arith.divui %460, %c32_i64_244 : i64
+    %c32_i64_245 = arith.constant 32 : i64
+    %462 = arith.muli %461, %c32_i64_245 : i64
+    %463 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_246 = arith.constant 31 : i64
+    %c32_i64_247 = arith.constant 32 : i64
+    %464 = arith.addi %463, %c31_i64_246 : i64
+    %465 = arith.divui %464, %c32_i64_247 : i64
+    %466 = arith.muli %465, %c32_i64_245 : i64
+    %467 = arith.cmpi ult, %466, %462 : i64
+    cf.cond_br %467, ^bb161, ^bb160
   ^bb160:  // 2 preds: ^bb159, ^bb163
     cf.br ^bb112
   ^bb161:  // pred: ^bb159
-    %c3_i64_288 = arith.constant 3 : i64
-    %c512_i64_289 = arith.constant 512 : i64
-    %510 = arith.muli %507, %507 : i64
-    %511 = arith.divui %510, %c512_i64_289 : i64
-    %512 = arith.muli %507, %c3_i64_288 : i64
-    %513 = arith.addi %511, %512 : i64
-    %c3_i64_290 = arith.constant 3 : i64
-    %c512_i64_291 = arith.constant 512 : i64
-    %514 = arith.muli %503, %503 : i64
-    %515 = arith.divui %514, %c512_i64_291 : i64
-    %516 = arith.muli %503, %c3_i64_290 : i64
-    %517 = arith.addi %515, %516 : i64
-    %518 = arith.subi %517, %513 : i64
-    %519 = llvm.load %arg1 : !llvm.ptr -> i64
-    %520 = arith.cmpi ult, %519, %518 : i64
-    scf.if %520 {
+    %c3_i64_248 = arith.constant 3 : i64
+    %c512_i64_249 = arith.constant 512 : i64
+    %468 = arith.muli %465, %465 : i64
+    %469 = arith.divui %468, %c512_i64_249 : i64
+    %470 = arith.muli %465, %c3_i64_248 : i64
+    %471 = arith.addi %469, %470 : i64
+    %c3_i64_250 = arith.constant 3 : i64
+    %c512_i64_251 = arith.constant 512 : i64
+    %472 = arith.muli %461, %461 : i64
+    %473 = arith.divui %472, %c512_i64_251 : i64
+    %474 = arith.muli %461, %c3_i64_250 : i64
+    %475 = arith.addi %473, %474 : i64
+    %476 = arith.subi %475, %471 : i64
+    %477 = llvm.load %arg1 : !llvm.ptr -> i64
+    %478 = arith.cmpi ult, %477, %476 : i64
+    scf.if %478 {
     } else {
-      %553 = arith.subi %519, %518 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %477, %476 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_292 = arith.constant 80 : i8
-    cf.cond_br %520, ^bb1(%c80_i8_292 : i8), ^bb162
+    %c80_i8_252 = arith.constant 80 : i8
+    cf.cond_br %478, ^bb1(%c80_i8_252 : i8), ^bb162
   ^bb162:  // pred: ^bb161
-    %521 = call @dora_fn_extend_memory(%arg0, %504) : (!llvm.ptr, i64) -> !llvm.ptr
-    %522 = llvm.getelementptr %521[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %523 = llvm.load %522 : !llvm.ptr -> i8
-    %c0_i8_293 = arith.constant 0 : i8
-    %524 = arith.cmpi ne, %523, %c0_i8_293 : i8
-    cf.cond_br %524, ^bb1(%523 : i8), ^bb163
+    %479 = call @dora_fn_extend_memory(%arg0, %462) : (!llvm.ptr, i64) -> !llvm.ptr
+    %480 = llvm.getelementptr %479[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %481 = llvm.load %480 : !llvm.ptr -> i8
+    %c0_i8_253 = arith.constant 0 : i8
+    %482 = arith.cmpi ne, %481, %c0_i8_253 : i8
+    cf.cond_br %482, ^bb1(%481 : i8), ^bb163
   ^bb163:  // pred: ^bb162
     cf.br ^bb160
   ^bb164:  // pred: ^bb114
-    %c18446744073709551615_i256_294 = arith.constant 18446744073709551615 : i256
-    %525 = arith.cmpi sgt, %335, %c18446744073709551615_i256_294 : i256
-    %c84_i8_295 = arith.constant 84 : i8
-    cf.cond_br %525, ^bb1(%c84_i8_295 : i8), ^bb165
+    %c18446744073709551615_i256_254 = arith.constant 18446744073709551615 : i256
+    %483 = arith.cmpi sgt, %295, %c18446744073709551615_i256_254 : i256
+    %c84_i8_255 = arith.constant 84 : i8
+    cf.cond_br %483, ^bb1(%c84_i8_255 : i8), ^bb165
   ^bb165:  // pred: ^bb164
-    %526 = arith.trunci %335 : i256 to i64
-    %c0_i64_296 = arith.constant 0 : i64
-    %527 = arith.cmpi slt, %526, %c0_i64_296 : i64
-    %c84_i8_297 = arith.constant 84 : i8
-    cf.cond_br %527, ^bb1(%c84_i8_297 : i8), ^bb166
+    %484 = arith.trunci %295 : i256 to i64
+    %c0_i64_256 = arith.constant 0 : i64
+    %485 = arith.cmpi slt, %484, %c0_i64_256 : i64
+    %c84_i8_257 = arith.constant 84 : i8
+    cf.cond_br %485, ^bb1(%c84_i8_257 : i8), ^bb166
   ^bb166:  // pred: ^bb165
-    %528 = arith.addi %526, %349 : i64
-    %c0_i64_298 = arith.constant 0 : i64
-    %529 = arith.cmpi slt, %528, %c0_i64_298 : i64
-    %c84_i8_299 = arith.constant 84 : i8
-    cf.cond_br %529, ^bb1(%c84_i8_299 : i8), ^bb167
+    %486 = arith.addi %484, %308 : i64
+    %c0_i64_258 = arith.constant 0 : i64
+    %487 = arith.cmpi slt, %486, %c0_i64_258 : i64
+    %c84_i8_259 = arith.constant 84 : i8
+    cf.cond_br %487, ^bb1(%c84_i8_259 : i8), ^bb167
   ^bb167:  // pred: ^bb166
-    %c31_i64_300 = arith.constant 31 : i64
-    %c32_i64_301 = arith.constant 32 : i64
-    %530 = arith.addi %528, %c31_i64_300 : i64
-    %531 = arith.divui %530, %c32_i64_301 : i64
-    %c32_i64_302 = arith.constant 32 : i64
-    %532 = arith.muli %531, %c32_i64_302 : i64
-    %533 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_303 = arith.constant 31 : i64
-    %c32_i64_304 = arith.constant 32 : i64
-    %534 = arith.addi %533, %c31_i64_303 : i64
-    %535 = arith.divui %534, %c32_i64_304 : i64
-    %536 = arith.muli %535, %c32_i64_302 : i64
-    %537 = arith.cmpi ult, %536, %532 : i64
-    cf.cond_br %537, ^bb169, ^bb168
+    %c31_i64_260 = arith.constant 31 : i64
+    %c32_i64_261 = arith.constant 32 : i64
+    %488 = arith.addi %486, %c31_i64_260 : i64
+    %489 = arith.divui %488, %c32_i64_261 : i64
+    %c32_i64_262 = arith.constant 32 : i64
+    %490 = arith.muli %489, %c32_i64_262 : i64
+    %491 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_263 = arith.constant 31 : i64
+    %c32_i64_264 = arith.constant 32 : i64
+    %492 = arith.addi %491, %c31_i64_263 : i64
+    %493 = arith.divui %492, %c32_i64_264 : i64
+    %494 = arith.muli %493, %c32_i64_262 : i64
+    %495 = arith.cmpi ult, %494, %490 : i64
+    cf.cond_br %495, ^bb169, ^bb168
   ^bb168:  // 2 preds: ^bb167, ^bb171
     cf.br ^bb115
   ^bb169:  // pred: ^bb167
-    %c3_i64_305 = arith.constant 3 : i64
-    %c512_i64_306 = arith.constant 512 : i64
-    %538 = arith.muli %535, %535 : i64
-    %539 = arith.divui %538, %c512_i64_306 : i64
-    %540 = arith.muli %535, %c3_i64_305 : i64
-    %541 = arith.addi %539, %540 : i64
-    %c3_i64_307 = arith.constant 3 : i64
-    %c512_i64_308 = arith.constant 512 : i64
-    %542 = arith.muli %531, %531 : i64
-    %543 = arith.divui %542, %c512_i64_308 : i64
-    %544 = arith.muli %531, %c3_i64_307 : i64
-    %545 = arith.addi %543, %544 : i64
-    %546 = arith.subi %545, %541 : i64
-    %547 = llvm.load %arg1 : !llvm.ptr -> i64
-    %548 = arith.cmpi ult, %547, %546 : i64
-    scf.if %548 {
+    %c3_i64_265 = arith.constant 3 : i64
+    %c512_i64_266 = arith.constant 512 : i64
+    %496 = arith.muli %493, %493 : i64
+    %497 = arith.divui %496, %c512_i64_266 : i64
+    %498 = arith.muli %493, %c3_i64_265 : i64
+    %499 = arith.addi %497, %498 : i64
+    %c3_i64_267 = arith.constant 3 : i64
+    %c512_i64_268 = arith.constant 512 : i64
+    %500 = arith.muli %489, %489 : i64
+    %501 = arith.divui %500, %c512_i64_268 : i64
+    %502 = arith.muli %489, %c3_i64_267 : i64
+    %503 = arith.addi %501, %502 : i64
+    %504 = arith.subi %503, %499 : i64
+    %505 = llvm.load %arg1 : !llvm.ptr -> i64
+    %506 = arith.cmpi ult, %505, %504 : i64
+    scf.if %506 {
     } else {
-      %553 = arith.subi %547, %546 : i64
-      llvm.store %553, %arg1 : i64, !llvm.ptr
+      %511 = arith.subi %505, %504 : i64
+      llvm.store %511, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_309 = arith.constant 80 : i8
-    cf.cond_br %548, ^bb1(%c80_i8_309 : i8), ^bb170
+    %c80_i8_269 = arith.constant 80 : i8
+    cf.cond_br %506, ^bb1(%c80_i8_269 : i8), ^bb170
   ^bb170:  // pred: ^bb169
-    %549 = call @dora_fn_extend_memory(%arg0, %532) : (!llvm.ptr, i64) -> !llvm.ptr
-    %550 = llvm.getelementptr %549[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %551 = llvm.load %550 : !llvm.ptr -> i8
-    %c0_i8_310 = arith.constant 0 : i8
-    %552 = arith.cmpi ne, %551, %c0_i8_310 : i8
-    cf.cond_br %552, ^bb1(%551 : i8), ^bb171
+    %507 = call @dora_fn_extend_memory(%arg0, %490) : (!llvm.ptr, i64) -> !llvm.ptr
+    %508 = llvm.getelementptr %507[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %509 = llvm.load %508 : !llvm.ptr -> i8
+    %c0_i8_270 = arith.constant 0 : i8
+    %510 = arith.cmpi ne, %509, %c0_i8_270 : i8
+    cf.cond_br %510, ^bb1(%509 : i8), ^bb171
   ^bb171:  // pred: ^bb170
     cf.br ^bb168
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 105 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb70, ^bb71, ^bb73, ^bb74, ^bb76, ^bb77, ^bb80, ^bb81, ^bb84, ^bb85, ^bb87, ^bb88, ^bb90, ^bb91, ^bb94, ^bb95, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb110, ^bb111, ^bb114, ^bb115, ^bb118, ^bb119, ^bb121, ^bb122, ^bb124, ^bb125, ^bb127, ^bb128, ^bb130, ^bb131, ^bb134, ^bb135, ^bb136, ^bb139, ^bb140, ^bb142, ^bb143, ^bb144, ^bb145, ^bb146, ^bb149, ^bb150, ^bb152, ^bb153, ^bb154, ^bb157, ^bb158, ^bb160, ^bb161, ^bb162, ^bb165, ^bb166, ^bb168, ^bb169, ^bb170, ^bb173, ^bb174, ^bb176, ^bb177, ^bb178, ^bb181, ^bb182
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 105 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb70, ^bb71, ^bb73, ^bb74, ^bb76, ^bb77, ^bb80, ^bb81, ^bb84, ^bb85, ^bb87, ^bb88, ^bb90, ^bb91, ^bb94, ^bb95, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb110, ^bb111, ^bb114, ^bb115, ^bb118, ^bb119, ^bb121, ^bb122, ^bb124, ^bb125, ^bb127, ^bb128, ^bb130, ^bb131, ^bb134, ^bb135, ^bb136, ^bb139, ^bb140, ^bb142, ^bb143, ^bb144, ^bb145, ^bb146, ^bb149, ^bb150, ^bb152, ^bb153, ^bb154, ^bb157, ^bb158, ^bb160, ^bb161, ^bb162, ^bb165, ^bb166, ^bb168, ^bb169, ^bb170, ^bb173, ^bb174, ^bb176, ^bb177, ^bb178, ^bb181, ^bb182
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c35176690763027899028215972788860354566387_i256 = arith.constant 35176690763027899028215972788860354566387 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c35176690763027899028215972788860354566387_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,1474 +96,1409 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb134, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb134, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb138
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c15_i256 = arith.constant 15 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c15_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %c0_i256_25 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_26 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_25, %59 : i256, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb25:  // pred: ^bb27
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_28 : i64
-    %63 = arith.cmpi ult, %c1024_i64_27, %62 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_29 : i8), ^bb24
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_22 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_21, %56 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_23 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_31 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_30 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_24 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb36
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_32 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_33 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_34 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
-    %79 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %80 = arith.cmpi ne, %79, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %80, ^bb1(%c87_i8 : i8), ^bb29
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb30
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %82 = arith.trunci %78 : i256 to i64
-    %c0_i64_35 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_35 : i64
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_36 : i8), ^bb31
+    %73 = arith.trunci %69 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_37 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_37 : i64
-    cf.cond_br %84, ^bb142, ^bb32
+    %c0_i64_28 = arith.constant 0 : i64
+    %75 = arith.cmpi ne, %73, %c0_i64_28 : i64
+    cf.cond_br %75, ^bb142, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb148
     %c32000_i64 = arith.constant 32000 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %c32000_i64 : i64
-    scf.if %86 {
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %c32000_i64 : i64
+    scf.if %77 {
     } else {
-      %588 = arith.subi %85, %c32000_i64 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %76, %c32000_i64 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_38 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c1_i256 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %70, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %89 = arith.trunci %74 : i256 to i64
-    %90 = call @dora_fn_create(%arg0, %82, %89, %87, %88) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %91 = llvm.getelementptr %90[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %92 = llvm.load %91 : !llvm.ptr -> i8
-    %c0_i8_39 = arith.constant 0 : i8
-    %93 = arith.cmpi ne, %92, %c0_i8_39 : i8
-    cf.cond_br %93, ^bb1(%92 : i8), ^bb34
+    %78 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %80 = arith.trunci %66 : i256 to i64
+    %81 = call @dora_fn_create(%arg0, %73, %80, %78, %79) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %82 = llvm.getelementptr %81[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %83 = llvm.load %82 : !llvm.ptr -> i8
+    %c0_i8_30 = arith.constant 0 : i8
+    %84 = arith.cmpi ne, %83, %c0_i8_30 : i8
+    cf.cond_br %84, ^bb1(%83 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %94 = llvm.getelementptr %90[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %85 = llvm.getelementptr %81[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %588 = arith.subi %96, %95 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %87, %86 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_40 : i8), ^bb35
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_31 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = llvm.load %87 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %101 = arith.addi %99, %c1_i64_41 : i64
-    llvm.store %101, %arg3 : i64, !llvm.ptr
-    llvm.store %98, %100 : i256, !llvm.ptr
+    %89 = llvm.load %78 : !llvm.ptr -> i256
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %90 : i256, !llvm.ptr
+    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb41
   ^bb36:  // pred: ^bb38
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_43 = arith.constant -2 : i64
-    %103 = arith.addi %102, %c-2_i64_43 : i64
-    %c3_i64_44 = arith.constant 3 : i64
-    %104 = arith.cmpi ult, %102, %c3_i64_44 : i64
-    %c91_i8_45 = arith.constant 91 : i8
-    cf.cond_br %104, ^bb1(%c91_i8_45 : i8), ^bb28
+    %c1024_i64_32 = arith.constant 1024 : i64
+    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_33 = arith.constant -2 : i64
+    %93 = arith.addi %92, %c-2_i64_33 : i64
+    llvm.store %93, %arg3 : i64, !llvm.ptr
+    %c3_i64_34 = arith.constant 3 : i64
+    %94 = arith.cmpi ult, %92, %c3_i64_34 : i64
+    %c91_i8_35 = arith.constant 91 : i8
+    cf.cond_br %94, ^bb1(%c91_i8_35 : i8), ^bb28
   ^bb37:  // pred: ^bb24
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_36 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %106 = arith.cmpi uge, %105, %c0_i64_46 : i64
-    %c80_i8_47 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb38, ^bb1(%c80_i8_47 : i8)
+    %96 = arith.cmpi uge, %95, %c0_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %96, ^bb38, ^bb1(%c80_i8_37 : i8)
   ^bb38:  // pred: ^bb37
-    %107 = arith.subi %105, %c0_i64_46 : i64
-    llvm.store %107, %arg1 : i64, !llvm.ptr
+    %97 = arith.subi %95, %c0_i64_36 : i64
+    llvm.store %97, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb40
-    %c0_i256_48 = arith.constant 0 : i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %109 = llvm.getelementptr %arg2[%108] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_49 = arith.constant 1 : i64
-    %110 = arith.addi %108, %c1_i64_49 : i64
-    llvm.store %110, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_48, %109 : i256, !llvm.ptr
+    %c0_i256_38 = arith.constant 0 : i256
+    %98 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_38, %98 : i256, !llvm.ptr
+    %99 = llvm.getelementptr %98[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %99, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb45
   ^bb40:  // pred: ^bb42
-    %c1024_i64_50 = arith.constant 1024 : i64
-    %111 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_51 = arith.constant 1 : i64
-    %112 = arith.addi %111, %c1_i64_51 : i64
-    %113 = arith.cmpi ult, %c1024_i64_50, %112 : i64
-    %c92_i8_52 = arith.constant 92 : i8
-    cf.cond_br %113, ^bb1(%c92_i8_52 : i8), ^bb39
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %100 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %101 = arith.addi %100, %c1_i64_40 : i64
+    llvm.store %101, %arg3 : i64, !llvm.ptr
+    %102 = arith.cmpi ult, %c1024_i64_39, %101 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %102, ^bb1(%c92_i8_41 : i8), ^bb39
   ^bb41:  // pred: ^bb35
-    %114 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_53 = arith.constant 3 : i64
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_42 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %115 = arith.cmpi uge, %114, %c3_i64_53 : i64
-    %c80_i8_54 = arith.constant 80 : i8
-    cf.cond_br %115, ^bb42, ^bb1(%c80_i8_54 : i8)
+    %104 = arith.cmpi uge, %103, %c3_i64_42 : i64
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %104, ^bb42, ^bb1(%c80_i8_43 : i8)
   ^bb42:  // pred: ^bb41
-    %116 = arith.subi %114, %c3_i64_53 : i64
-    llvm.store %116, %arg1 : i64, !llvm.ptr
+    %105 = arith.subi %103, %c3_i64_42 : i64
+    llvm.store %105, %arg1 : i64, !llvm.ptr
     cf.br ^bb40
   ^bb43:  // pred: ^bb44
-    %c0_i256_55 = arith.constant 0 : i256
-    %117 = llvm.load %arg3 : !llvm.ptr -> i64
-    %118 = llvm.getelementptr %arg2[%117] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_56 = arith.constant 1 : i64
-    %119 = arith.addi %117, %c1_i64_56 : i64
-    llvm.store %119, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_55, %118 : i256, !llvm.ptr
+    %c0_i256_44 = arith.constant 0 : i256
+    %106 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_44, %106 : i256, !llvm.ptr
+    %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %107, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb49
   ^bb44:  // pred: ^bb46
-    %c1024_i64_57 = arith.constant 1024 : i64
-    %120 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_58 : i64
-    %122 = arith.cmpi ult, %c1024_i64_57, %121 : i64
-    %c92_i8_59 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_59 : i8), ^bb43
+    %c1024_i64_45 = arith.constant 1024 : i64
+    %108 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_46 = arith.constant 1 : i64
+    %109 = arith.addi %108, %c1_i64_46 : i64
+    llvm.store %109, %arg3 : i64, !llvm.ptr
+    %110 = arith.cmpi ult, %c1024_i64_45, %109 : i64
+    %c92_i8_47 = arith.constant 92 : i8
+    cf.cond_br %110, ^bb1(%c92_i8_47 : i8), ^bb43
   ^bb45:  // pred: ^bb39
-    %123 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_60 = arith.constant 3 : i64
+    %111 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_48 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %124 = arith.cmpi uge, %123, %c3_i64_60 : i64
-    %c80_i8_61 = arith.constant 80 : i8
-    cf.cond_br %124, ^bb46, ^bb1(%c80_i8_61 : i8)
+    %112 = arith.cmpi uge, %111, %c3_i64_48 : i64
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %112, ^bb46, ^bb1(%c80_i8_49 : i8)
   ^bb46:  // pred: ^bb45
-    %125 = arith.subi %123, %c3_i64_60 : i64
-    llvm.store %125, %arg1 : i64, !llvm.ptr
+    %113 = arith.subi %111, %c3_i64_48 : i64
+    llvm.store %113, %arg1 : i64, !llvm.ptr
     cf.br ^bb44
   ^bb47:  // pred: ^bb48
-    %c0_i256_62 = arith.constant 0 : i256
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
-    %127 = llvm.getelementptr %arg2[%126] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_63 = arith.constant 1 : i64
-    %128 = arith.addi %126, %c1_i64_63 : i64
-    llvm.store %128, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_62, %127 : i256, !llvm.ptr
+    %c0_i256_50 = arith.constant 0 : i256
+    %114 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_50, %114 : i256, !llvm.ptr
+    %115 = llvm.getelementptr %114[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %115, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb53
   ^bb48:  // pred: ^bb50
-    %c1024_i64_64 = arith.constant 1024 : i64
-    %129 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_65 = arith.constant 1 : i64
-    %130 = arith.addi %129, %c1_i64_65 : i64
-    %131 = arith.cmpi ult, %c1024_i64_64, %130 : i64
-    %c92_i8_66 = arith.constant 92 : i8
-    cf.cond_br %131, ^bb1(%c92_i8_66 : i8), ^bb47
+    %c1024_i64_51 = arith.constant 1024 : i64
+    %116 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_52 = arith.constant 1 : i64
+    %117 = arith.addi %116, %c1_i64_52 : i64
+    llvm.store %117, %arg3 : i64, !llvm.ptr
+    %118 = arith.cmpi ult, %c1024_i64_51, %117 : i64
+    %c92_i8_53 = arith.constant 92 : i8
+    cf.cond_br %118, ^bb1(%c92_i8_53 : i8), ^bb47
   ^bb49:  // pred: ^bb43
-    %132 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_67 = arith.constant 3 : i64
+    %119 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_54 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %133 = arith.cmpi uge, %132, %c3_i64_67 : i64
-    %c80_i8_68 = arith.constant 80 : i8
-    cf.cond_br %133, ^bb50, ^bb1(%c80_i8_68 : i8)
+    %120 = arith.cmpi uge, %119, %c3_i64_54 : i64
+    %c80_i8_55 = arith.constant 80 : i8
+    cf.cond_br %120, ^bb50, ^bb1(%c80_i8_55 : i8)
   ^bb50:  // pred: ^bb49
-    %134 = arith.subi %132, %c3_i64_67 : i64
-    llvm.store %134, %arg1 : i64, !llvm.ptr
+    %121 = arith.subi %119, %c3_i64_54 : i64
+    llvm.store %121, %arg1 : i64, !llvm.ptr
     cf.br ^bb48
   ^bb51:  // pred: ^bb52
-    %c0_i256_69 = arith.constant 0 : i256
-    %135 = llvm.load %arg3 : !llvm.ptr -> i64
-    %136 = llvm.getelementptr %arg2[%135] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_70 = arith.constant 1 : i64
-    %137 = arith.addi %135, %c1_i64_70 : i64
-    llvm.store %137, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_69, %136 : i256, !llvm.ptr
+    %c0_i256_56 = arith.constant 0 : i256
+    %122 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_56, %122 : i256, !llvm.ptr
+    %123 = llvm.getelementptr %122[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %123, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb57
   ^bb52:  // pred: ^bb54
-    %c1024_i64_71 = arith.constant 1024 : i64
-    %138 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_72 : i64
-    %140 = arith.cmpi ult, %c1024_i64_71, %139 : i64
-    %c92_i8_73 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_73 : i8), ^bb51
+    %c1024_i64_57 = arith.constant 1024 : i64
+    %124 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_58 = arith.constant 1 : i64
+    %125 = arith.addi %124, %c1_i64_58 : i64
+    llvm.store %125, %arg3 : i64, !llvm.ptr
+    %126 = arith.cmpi ult, %c1024_i64_57, %125 : i64
+    %c92_i8_59 = arith.constant 92 : i8
+    cf.cond_br %126, ^bb1(%c92_i8_59 : i8), ^bb51
   ^bb53:  // pred: ^bb47
-    %141 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_74 = arith.constant 3 : i64
+    %127 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_60 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %142 = arith.cmpi uge, %141, %c3_i64_74 : i64
-    %c80_i8_75 = arith.constant 80 : i8
-    cf.cond_br %142, ^bb54, ^bb1(%c80_i8_75 : i8)
+    %128 = arith.cmpi uge, %127, %c3_i64_60 : i64
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %128, ^bb54, ^bb1(%c80_i8_61 : i8)
   ^bb54:  // pred: ^bb53
-    %143 = arith.subi %141, %c3_i64_74 : i64
-    llvm.store %143, %arg1 : i64, !llvm.ptr
+    %129 = arith.subi %127, %c3_i64_60 : i64
+    llvm.store %129, %arg1 : i64, !llvm.ptr
     cf.br ^bb52
   ^bb55:  // pred: ^bb56
-    %c0_i256_76 = arith.constant 0 : i256
-    %144 = llvm.load %arg3 : !llvm.ptr -> i64
-    %145 = llvm.getelementptr %arg2[%144] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_77 = arith.constant 1 : i64
-    %146 = arith.addi %144, %c1_i64_77 : i64
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_76, %145 : i256, !llvm.ptr
+    %c0_i256_62 = arith.constant 0 : i256
+    %130 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_62, %130 : i256, !llvm.ptr
+    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %131, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb61
   ^bb56:  // pred: ^bb58
-    %c1024_i64_78 = arith.constant 1024 : i64
-    %147 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %148 = arith.addi %147, %c1_i64_79 : i64
-    %149 = arith.cmpi ult, %c1024_i64_78, %148 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %149, ^bb1(%c92_i8_80 : i8), ^bb55
+    %c1024_i64_63 = arith.constant 1024 : i64
+    %132 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_64 = arith.constant 1 : i64
+    %133 = arith.addi %132, %c1_i64_64 : i64
+    llvm.store %133, %arg3 : i64, !llvm.ptr
+    %134 = arith.cmpi ult, %c1024_i64_63, %133 : i64
+    %c92_i8_65 = arith.constant 92 : i8
+    cf.cond_br %134, ^bb1(%c92_i8_65 : i8), ^bb55
   ^bb57:  // pred: ^bb51
-    %150 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_81 = arith.constant 3 : i64
+    %135 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_66 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %151 = arith.cmpi uge, %150, %c3_i64_81 : i64
-    %c80_i8_82 = arith.constant 80 : i8
-    cf.cond_br %151, ^bb58, ^bb1(%c80_i8_82 : i8)
+    %136 = arith.cmpi uge, %135, %c3_i64_66 : i64
+    %c80_i8_67 = arith.constant 80 : i8
+    cf.cond_br %136, ^bb58, ^bb1(%c80_i8_67 : i8)
   ^bb58:  // pred: ^bb57
-    %152 = arith.subi %150, %c3_i64_81 : i64
-    llvm.store %152, %arg1 : i64, !llvm.ptr
+    %137 = arith.subi %135, %c3_i64_66 : i64
+    llvm.store %137, %arg1 : i64, !llvm.ptr
     cf.br ^bb56
   ^bb59:  // pred: ^bb60
-    %153 = llvm.load %arg3 : !llvm.ptr -> i64
-    %154 = llvm.getelementptr %arg2[%153] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %155 = llvm.getelementptr %154[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.load %arg3 : !llvm.ptr -> i64
-    %158 = llvm.getelementptr %arg2[%157] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_83 = arith.constant 1 : i64
-    %159 = arith.addi %157, %c1_i64_83 : i64
-    llvm.store %159, %arg3 : i64, !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
+    %138 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %139 = llvm.getelementptr %138[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %140 = llvm.load %139 : !llvm.ptr -> i256
+    %141 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %140, %141 : i256, !llvm.ptr
+    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %142, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb65
   ^bb60:  // pred: ^bb62
-    %c1024_i64_84 = arith.constant 1024 : i64
-    %160 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_85 : i64
+    %c1024_i64_68 = arith.constant 1024 : i64
+    %143 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_69 = arith.constant 1 : i64
+    %144 = arith.addi %143, %c1_i64_69 : i64
+    llvm.store %144, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %162 = arith.cmpi ult, %160, %c6_i64 : i64
-    %163 = arith.cmpi ult, %c1024_i64_84, %161 : i64
-    %164 = arith.xori %162, %163 : i1
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %164, ^bb1(%c92_i8_86 : i8), ^bb59
+    %145 = arith.cmpi ult, %143, %c6_i64 : i64
+    %146 = arith.cmpi ult, %c1024_i64_68, %144 : i64
+    %147 = arith.xori %145, %146 : i1
+    %c92_i8_70 = arith.constant 92 : i8
+    cf.cond_br %147, ^bb1(%c92_i8_70 : i8), ^bb59
   ^bb61:  // pred: ^bb55
-    %165 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_87 = arith.constant 3 : i64
+    %148 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_71 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %166 = arith.cmpi uge, %165, %c3_i64_87 : i64
-    %c80_i8_88 = arith.constant 80 : i8
-    cf.cond_br %166, ^bb62, ^bb1(%c80_i8_88 : i8)
+    %149 = arith.cmpi uge, %148, %c3_i64_71 : i64
+    %c80_i8_72 = arith.constant 80 : i8
+    cf.cond_br %149, ^bb62, ^bb1(%c80_i8_72 : i8)
   ^bb62:  // pred: ^bb61
-    %167 = arith.subi %165, %c3_i64_87 : i64
-    llvm.store %167, %arg1 : i64, !llvm.ptr
+    %150 = arith.subi %148, %c3_i64_71 : i64
+    llvm.store %150, %arg1 : i64, !llvm.ptr
     cf.br ^bb60
   ^bb63:  // pred: ^bb64
     %c65535_i256 = arith.constant 65535 : i256
-    %168 = llvm.load %arg3 : !llvm.ptr -> i64
-    %169 = llvm.getelementptr %arg2[%168] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_89 = arith.constant 1 : i64
-    %170 = arith.addi %168, %c1_i64_89 : i64
-    llvm.store %170, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256, %169 : i256, !llvm.ptr
+    %151 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %151 : i256, !llvm.ptr
+    %152 = llvm.getelementptr %151[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %152, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb77
   ^bb64:  // pred: ^bb66
-    %c1024_i64_90 = arith.constant 1024 : i64
-    %171 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_91 = arith.constant 1 : i64
-    %172 = arith.addi %171, %c1_i64_91 : i64
-    %173 = arith.cmpi ult, %c1024_i64_90, %172 : i64
-    %c92_i8_92 = arith.constant 92 : i8
-    cf.cond_br %173, ^bb1(%c92_i8_92 : i8), ^bb63
+    %c1024_i64_73 = arith.constant 1024 : i64
+    %153 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_74 = arith.constant 1 : i64
+    %154 = arith.addi %153, %c1_i64_74 : i64
+    llvm.store %154, %arg3 : i64, !llvm.ptr
+    %155 = arith.cmpi ult, %c1024_i64_73, %154 : i64
+    %c92_i8_75 = arith.constant 92 : i8
+    cf.cond_br %155, ^bb1(%c92_i8_75 : i8), ^bb63
   ^bb65:  // pred: ^bb59
-    %174 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_93 = arith.constant 3 : i64
+    %156 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_76 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %175 = arith.cmpi uge, %174, %c3_i64_93 : i64
-    %c80_i8_94 = arith.constant 80 : i8
-    cf.cond_br %175, ^bb66, ^bb1(%c80_i8_94 : i8)
+    %157 = arith.cmpi uge, %156, %c3_i64_76 : i64
+    %c80_i8_77 = arith.constant 80 : i8
+    cf.cond_br %157, ^bb66, ^bb1(%c80_i8_77 : i8)
   ^bb66:  // pred: ^bb65
-    %176 = arith.subi %174, %c3_i64_93 : i64
-    llvm.store %176, %arg1 : i64, !llvm.ptr
+    %158 = arith.subi %156, %c3_i64_76 : i64
+    llvm.store %158, %arg1 : i64, !llvm.ptr
     cf.br ^bb64
   ^bb67:  // pred: ^bb76
-    %177 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_95 = arith.constant 1 : i64
-    %178 = arith.subi %177, %c1_i64_95 : i64
-    %179 = llvm.getelementptr %arg2[%178] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %178, %arg3 : i64, !llvm.ptr
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    %181 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %182 = arith.subi %181, %c1_i64_96 : i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %182, %arg3 : i64, !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_97 = arith.constant 1 : i64
-    %186 = arith.subi %185, %c1_i64_97 : i64
-    %187 = llvm.getelementptr %arg2[%186] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %186, %arg3 : i64, !llvm.ptr
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    %189 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_98 = arith.constant 1 : i64
-    %190 = arith.subi %189, %c1_i64_98 : i64
-    %191 = llvm.getelementptr %arg2[%190] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %190, %arg3 : i64, !llvm.ptr
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    %193 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_99 = arith.constant 1 : i64
-    %194 = arith.subi %193, %c1_i64_99 : i64
-    %195 = llvm.getelementptr %arg2[%194] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %194, %arg3 : i64, !llvm.ptr
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    %197 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_100 = arith.constant 1 : i64
-    %198 = arith.subi %197, %c1_i64_100 : i64
-    %199 = llvm.getelementptr %arg2[%198] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %198, %arg3 : i64, !llvm.ptr
-    %200 = llvm.load %199 : !llvm.ptr -> i256
-    %201 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_101 = arith.constant 1 : i64
-    %202 = arith.subi %201, %c1_i64_101 : i64
-    %203 = llvm.getelementptr %arg2[%202] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %202, %arg3 : i64, !llvm.ptr
-    %204 = llvm.load %203 : !llvm.ptr -> i256
-    %c18446744073709551615_i256_102 = arith.constant 18446744073709551615 : i256
-    %205 = arith.cmpi sgt, %196, %c18446744073709551615_i256_102 : i256
-    %c84_i8_103 = arith.constant 84 : i8
-    cf.cond_br %205, ^bb1(%c84_i8_103 : i8), ^bb68
+    %159 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %160 = llvm.getelementptr %159[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %161 = llvm.load %160 : !llvm.ptr -> i256
+    llvm.store %160, %0 : !llvm.ptr, !llvm.ptr
+    %162 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %163 = llvm.getelementptr %162[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %164 = llvm.load %163 : !llvm.ptr -> i256
+    llvm.store %163, %0 : !llvm.ptr, !llvm.ptr
+    %165 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %166 = llvm.getelementptr %165[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %167 = llvm.load %166 : !llvm.ptr -> i256
+    llvm.store %166, %0 : !llvm.ptr, !llvm.ptr
+    %168 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %170 = llvm.load %169 : !llvm.ptr -> i256
+    llvm.store %169, %0 : !llvm.ptr, !llvm.ptr
+    %171 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %0 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %176 = llvm.load %175 : !llvm.ptr -> i256
+    llvm.store %175, %0 : !llvm.ptr, !llvm.ptr
+    %177 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %178 = llvm.getelementptr %177[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %179 = llvm.load %178 : !llvm.ptr -> i256
+    llvm.store %178, %0 : !llvm.ptr, !llvm.ptr
+    %c18446744073709551615_i256_78 = arith.constant 18446744073709551615 : i256
+    %180 = arith.cmpi sgt, %173, %c18446744073709551615_i256_78 : i256
+    %c84_i8_79 = arith.constant 84 : i8
+    cf.cond_br %180, ^bb1(%c84_i8_79 : i8), ^bb68
   ^bb68:  // pred: ^bb67
-    %206 = arith.trunci %196 : i256 to i64
-    %c0_i64_104 = arith.constant 0 : i64
-    %207 = arith.cmpi slt, %206, %c0_i64_104 : i64
-    %c84_i8_105 = arith.constant 84 : i8
-    cf.cond_br %207, ^bb1(%c84_i8_105 : i8), ^bb69
+    %181 = arith.trunci %173 : i256 to i64
+    %c0_i64_80 = arith.constant 0 : i64
+    %182 = arith.cmpi slt, %181, %c0_i64_80 : i64
+    %c84_i8_81 = arith.constant 84 : i8
+    cf.cond_br %182, ^bb1(%c84_i8_81 : i8), ^bb69
   ^bb69:  // pred: ^bb68
-    %c0_i64_106 = arith.constant 0 : i64
-    %208 = arith.cmpi ne, %206, %c0_i64_106 : i64
-    cf.cond_br %208, ^bb152, ^bb70
+    %c0_i64_82 = arith.constant 0 : i64
+    %183 = arith.cmpi ne, %181, %c0_i64_82 : i64
+    cf.cond_br %183, ^bb152, ^bb70
   ^bb70:  // 2 preds: ^bb69, ^bb156
-    %c18446744073709551615_i256_107 = arith.constant 18446744073709551615 : i256
-    %209 = arith.cmpi sgt, %204, %c18446744073709551615_i256_107 : i256
-    %c84_i8_108 = arith.constant 84 : i8
-    cf.cond_br %209, ^bb1(%c84_i8_108 : i8), ^bb71
+    %c18446744073709551615_i256_83 = arith.constant 18446744073709551615 : i256
+    %184 = arith.cmpi sgt, %179, %c18446744073709551615_i256_83 : i256
+    %c84_i8_84 = arith.constant 84 : i8
+    cf.cond_br %184, ^bb1(%c84_i8_84 : i8), ^bb71
   ^bb71:  // pred: ^bb70
-    %210 = arith.trunci %204 : i256 to i64
-    %c0_i64_109 = arith.constant 0 : i64
-    %211 = arith.cmpi slt, %210, %c0_i64_109 : i64
-    %c84_i8_110 = arith.constant 84 : i8
-    cf.cond_br %211, ^bb1(%c84_i8_110 : i8), ^bb72
+    %185 = arith.trunci %179 : i256 to i64
+    %c0_i64_85 = arith.constant 0 : i64
+    %186 = arith.cmpi slt, %185, %c0_i64_85 : i64
+    %c84_i8_86 = arith.constant 84 : i8
+    cf.cond_br %186, ^bb1(%c84_i8_86 : i8), ^bb72
   ^bb72:  // pred: ^bb71
-    %c0_i64_111 = arith.constant 0 : i64
-    %212 = arith.cmpi ne, %210, %c0_i64_111 : i64
-    cf.cond_br %212, ^bb160, ^bb73
+    %c0_i64_87 = arith.constant 0 : i64
+    %187 = arith.cmpi ne, %185, %c0_i64_87 : i64
+    cf.cond_br %187, ^bb160, ^bb73
   ^bb73:  // 2 preds: ^bb72, ^bb164
-    %213 = arith.trunci %192 : i256 to i64
-    %214 = arith.trunci %200 : i256 to i64
-    %215 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_112 = arith.constant 1 : i256
-    %216 = llvm.alloca %c1_i256_112 x i256 : (i256) -> !llvm.ptr
-    llvm.store %188, %216 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_113 = arith.constant 1 : i256
-    %217 = llvm.alloca %c1_i256_113 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %217 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_114 = arith.constant 1 : i256
-    %218 = llvm.alloca %c1_i256_114 x i256 : (i256) -> !llvm.ptr
-    llvm.store %184, %218 {alignment = 1 : i64} : i256, !llvm.ptr
+    %188 = arith.trunci %170 : i256 to i64
+    %189 = arith.trunci %176 : i256 to i64
+    %190 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_88 = arith.constant 1 : i256
+    %191 = llvm.alloca %c1_i256_88 x i256 : (i256) -> !llvm.ptr
+    llvm.store %167, %191 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_89 = arith.constant 1 : i256
+    %192 = llvm.alloca %c1_i256_89 x i256 : (i256) -> !llvm.ptr
+    llvm.store %161, %192 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_90 = arith.constant 1 : i256
+    %193 = llvm.alloca %c1_i256_90 x i256 : (i256) -> !llvm.ptr
+    llvm.store %164, %193 {alignment = 1 : i64} : i256, !llvm.ptr
     %c3_i8 = arith.constant 3 : i8
-    %219 = call @dora_fn_call(%arg0, %217, %218, %216, %213, %206, %214, %210, %215, %c3_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %220 = llvm.getelementptr %219[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %221 = llvm.load %220 : !llvm.ptr -> i8
-    %222 = llvm.getelementptr %219[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %223 = llvm.load %222 : !llvm.ptr -> i8
-    %c0_i8_115 = arith.constant 0 : i8
-    %224 = arith.cmpi ne, %223, %c0_i8_115 : i8
-    cf.cond_br %224, ^bb1(%223 : i8), ^bb74
+    %194 = call @dora_fn_call(%arg0, %192, %193, %191, %188, %181, %189, %185, %190, %c3_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %195 = llvm.getelementptr %194[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %196 = llvm.load %195 : !llvm.ptr -> i8
+    %197 = llvm.getelementptr %194[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %198 = llvm.load %197 : !llvm.ptr -> i8
+    %c0_i8_91 = arith.constant 0 : i8
+    %199 = arith.cmpi ne, %198, %c0_i8_91 : i8
+    cf.cond_br %199, ^bb1(%198 : i8), ^bb74
   ^bb74:  // pred: ^bb73
-    %225 = llvm.getelementptr %219[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %226 = llvm.load %225 : !llvm.ptr -> i64
-    %227 = llvm.load %arg1 : !llvm.ptr -> i64
-    %228 = arith.cmpi ult, %227, %226 : i64
-    scf.if %228 {
+    %200 = llvm.getelementptr %194[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %201 = llvm.load %200 : !llvm.ptr -> i64
+    %202 = llvm.load %arg1 : !llvm.ptr -> i64
+    %203 = arith.cmpi ult, %202, %201 : i64
+    scf.if %203 {
     } else {
-      %588 = arith.subi %227, %226 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %202, %201 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_116 = arith.constant 80 : i8
-    cf.cond_br %228, ^bb1(%c80_i8_116 : i8), ^bb75
+    %c80_i8_92 = arith.constant 80 : i8
+    cf.cond_br %203, ^bb1(%c80_i8_92 : i8), ^bb75
   ^bb75:  // pred: ^bb74
-    %229 = arith.extui %221 : i8 to i256
-    %230 = llvm.load %arg3 : !llvm.ptr -> i64
-    %231 = llvm.getelementptr %arg2[%230] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_117 = arith.constant 1 : i64
-    %232 = arith.addi %230, %c1_i64_117 : i64
-    llvm.store %232, %arg3 : i64, !llvm.ptr
-    llvm.store %229, %231 : i256, !llvm.ptr
+    %204 = arith.extui %196 : i8 to i256
+    %205 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %204, %205 : i256, !llvm.ptr
+    %206 = llvm.getelementptr %205[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %206, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb81
   ^bb76:  // pred: ^bb78
-    %c1024_i64_118 = arith.constant 1024 : i64
-    %233 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_93 = arith.constant 1024 : i64
+    %207 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-6_i64 = arith.constant -6 : i64
-    %234 = arith.addi %233, %c-6_i64 : i64
+    %208 = arith.addi %207, %c-6_i64 : i64
+    llvm.store %208, %arg3 : i64, !llvm.ptr
     %c7_i64 = arith.constant 7 : i64
-    %235 = arith.cmpi ult, %233, %c7_i64 : i64
-    %c91_i8_119 = arith.constant 91 : i8
-    cf.cond_br %235, ^bb1(%c91_i8_119 : i8), ^bb67
+    %209 = arith.cmpi ult, %207, %c7_i64 : i64
+    %c91_i8_94 = arith.constant 91 : i8
+    cf.cond_br %209, ^bb1(%c91_i8_94 : i8), ^bb67
   ^bb77:  // pred: ^bb63
-    %236 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_120 = arith.constant 0 : i64
+    %210 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_95 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %237 = arith.cmpi uge, %236, %c0_i64_120 : i64
-    %c80_i8_121 = arith.constant 80 : i8
-    cf.cond_br %237, ^bb78, ^bb1(%c80_i8_121 : i8)
+    %211 = arith.cmpi uge, %210, %c0_i64_95 : i64
+    %c80_i8_96 = arith.constant 80 : i8
+    cf.cond_br %211, ^bb78, ^bb1(%c80_i8_96 : i8)
   ^bb78:  // pred: ^bb77
-    %238 = arith.subi %236, %c0_i64_120 : i64
-    llvm.store %238, %arg1 : i64, !llvm.ptr
+    %212 = arith.subi %210, %c0_i64_95 : i64
+    llvm.store %212, %arg1 : i64, !llvm.ptr
     cf.br ^bb76
   ^bb79:  // pred: ^bb80
-    %c1_i256_122 = arith.constant 1 : i256
-    %239 = llvm.load %arg3 : !llvm.ptr -> i64
-    %240 = llvm.getelementptr %arg2[%239] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_123 = arith.constant 1 : i64
-    %241 = arith.addi %239, %c1_i64_123 : i64
-    llvm.store %241, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_122, %240 : i256, !llvm.ptr
+    %c1_i256_97 = arith.constant 1 : i256
+    %213 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_97, %213 : i256, !llvm.ptr
+    %214 = llvm.getelementptr %213[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %214, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb85
   ^bb80:  // pred: ^bb82
-    %c1024_i64_124 = arith.constant 1024 : i64
-    %242 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_125 = arith.constant 1 : i64
-    %243 = arith.addi %242, %c1_i64_125 : i64
-    %244 = arith.cmpi ult, %c1024_i64_124, %243 : i64
-    %c92_i8_126 = arith.constant 92 : i8
-    cf.cond_br %244, ^bb1(%c92_i8_126 : i8), ^bb79
+    %c1024_i64_98 = arith.constant 1024 : i64
+    %215 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_99 = arith.constant 1 : i64
+    %216 = arith.addi %215, %c1_i64_99 : i64
+    llvm.store %216, %arg3 : i64, !llvm.ptr
+    %217 = arith.cmpi ult, %c1024_i64_98, %216 : i64
+    %c92_i8_100 = arith.constant 92 : i8
+    cf.cond_br %217, ^bb1(%c92_i8_100 : i8), ^bb79
   ^bb81:  // pred: ^bb75
-    %245 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_127 = arith.constant 3 : i64
+    %218 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_101 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %246 = arith.cmpi uge, %245, %c3_i64_127 : i64
-    %c80_i8_128 = arith.constant 80 : i8
-    cf.cond_br %246, ^bb82, ^bb1(%c80_i8_128 : i8)
+    %219 = arith.cmpi uge, %218, %c3_i64_101 : i64
+    %c80_i8_102 = arith.constant 80 : i8
+    cf.cond_br %219, ^bb82, ^bb1(%c80_i8_102 : i8)
   ^bb82:  // pred: ^bb81
-    %247 = arith.subi %245, %c3_i64_127 : i64
-    llvm.store %247, %arg1 : i64, !llvm.ptr
+    %220 = arith.subi %218, %c3_i64_101 : i64
+    llvm.store %220, %arg1 : i64, !llvm.ptr
     cf.br ^bb80
   ^bb83:  // pred: ^bb84
-    %c0_i256_129 = arith.constant 0 : i256
-    %248 = llvm.load %arg3 : !llvm.ptr -> i64
-    %249 = llvm.getelementptr %arg2[%248] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_130 = arith.constant 1 : i64
-    %250 = arith.addi %248, %c1_i64_130 : i64
-    llvm.store %250, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_129, %249 : i256, !llvm.ptr
+    %c0_i256_103 = arith.constant 0 : i256
+    %221 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_103, %221 : i256, !llvm.ptr
+    %222 = llvm.getelementptr %221[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %222, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb91
   ^bb84:  // pred: ^bb86
-    %c1024_i64_131 = arith.constant 1024 : i64
-    %251 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_132 = arith.constant 1 : i64
-    %252 = arith.addi %251, %c1_i64_132 : i64
-    %253 = arith.cmpi ult, %c1024_i64_131, %252 : i64
-    %c92_i8_133 = arith.constant 92 : i8
-    cf.cond_br %253, ^bb1(%c92_i8_133 : i8), ^bb83
+    %c1024_i64_104 = arith.constant 1024 : i64
+    %223 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_105 = arith.constant 1 : i64
+    %224 = arith.addi %223, %c1_i64_105 : i64
+    llvm.store %224, %arg3 : i64, !llvm.ptr
+    %225 = arith.cmpi ult, %c1024_i64_104, %224 : i64
+    %c92_i8_106 = arith.constant 92 : i8
+    cf.cond_br %225, ^bb1(%c92_i8_106 : i8), ^bb83
   ^bb85:  // pred: ^bb79
-    %254 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_134 = arith.constant 3 : i64
+    %226 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_107 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %255 = arith.cmpi uge, %254, %c3_i64_134 : i64
-    %c80_i8_135 = arith.constant 80 : i8
-    cf.cond_br %255, ^bb86, ^bb1(%c80_i8_135 : i8)
+    %227 = arith.cmpi uge, %226, %c3_i64_107 : i64
+    %c80_i8_108 = arith.constant 80 : i8
+    cf.cond_br %227, ^bb86, ^bb1(%c80_i8_108 : i8)
   ^bb86:  // pred: ^bb85
-    %256 = arith.subi %254, %c3_i64_134 : i64
-    llvm.store %256, %arg1 : i64, !llvm.ptr
+    %228 = arith.subi %226, %c3_i64_107 : i64
+    llvm.store %228, %arg1 : i64, !llvm.ptr
     cf.br ^bb84
   ^bb87:  // pred: ^bb90
-    %257 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_136 = arith.constant 1 : i64
-    %258 = arith.subi %257, %c1_i64_136 : i64
-    %259 = llvm.getelementptr %arg2[%258] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %258, %arg3 : i64, !llvm.ptr
-    %260 = llvm.load %259 : !llvm.ptr -> i256
-    %261 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_137 = arith.constant 1 : i64
-    %262 = arith.subi %261, %c1_i64_137 : i64
-    %263 = llvm.getelementptr %arg2[%262] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %262, %arg3 : i64, !llvm.ptr
-    %264 = llvm.load %263 : !llvm.ptr -> i256
-    %c1_i256_138 = arith.constant 1 : i256
-    %265 = llvm.alloca %c1_i256_138 x i256 : (i256) -> !llvm.ptr
-    llvm.store %260, %265 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_139 = arith.constant 1 : i256
-    %266 = llvm.alloca %c1_i256_139 x i256 : (i256) -> !llvm.ptr
-    llvm.store %264, %266 {alignment = 1 : i64} : i256, !llvm.ptr
-    %267 = llvm.load %arg1 : !llvm.ptr -> i64
-    %268 = call @dora_fn_sstore(%arg0, %265, %266, %267) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %269 = llvm.getelementptr %268[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %270 = llvm.load %269 : !llvm.ptr -> i8
-    %c0_i8_140 = arith.constant 0 : i8
-    %271 = arith.cmpi ne, %270, %c0_i8_140 : i8
-    cf.cond_br %271, ^bb1(%270 : i8), ^bb88
+    %229 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    llvm.store %230, %0 : !llvm.ptr, !llvm.ptr
+    %232 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %233 = llvm.getelementptr %232[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %234 = llvm.load %233 : !llvm.ptr -> i256
+    llvm.store %233, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_109 = arith.constant 1 : i256
+    %235 = llvm.alloca %c1_i256_109 x i256 : (i256) -> !llvm.ptr
+    llvm.store %231, %235 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_110 = arith.constant 1 : i256
+    %236 = llvm.alloca %c1_i256_110 x i256 : (i256) -> !llvm.ptr
+    llvm.store %234, %236 {alignment = 1 : i64} : i256, !llvm.ptr
+    %237 = llvm.load %arg1 : !llvm.ptr -> i64
+    %238 = call @dora_fn_sstore(%arg0, %235, %236, %237) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %239 = llvm.getelementptr %238[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %240 = llvm.load %239 : !llvm.ptr -> i8
+    %c0_i8_111 = arith.constant 0 : i8
+    %241 = arith.cmpi ne, %240, %c0_i8_111 : i8
+    cf.cond_br %241, ^bb1(%240 : i8), ^bb88
   ^bb88:  // pred: ^bb87
-    %272 = llvm.getelementptr %268[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %273 = llvm.load %272 : !llvm.ptr -> i64
-    %274 = llvm.load %arg1 : !llvm.ptr -> i64
-    %275 = arith.cmpi ult, %274, %273 : i64
-    scf.if %275 {
+    %242 = llvm.getelementptr %238[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %243 = llvm.load %242 : !llvm.ptr -> i64
+    %244 = llvm.load %arg1 : !llvm.ptr -> i64
+    %245 = arith.cmpi ult, %244, %243 : i64
+    scf.if %245 {
     } else {
-      %588 = arith.subi %274, %273 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %244, %243 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_141 = arith.constant 80 : i8
-    cf.cond_br %275, ^bb1(%c80_i8_141 : i8), ^bb89
+    %c80_i8_112 = arith.constant 80 : i8
+    cf.cond_br %245, ^bb1(%c80_i8_112 : i8), ^bb89
   ^bb89:  // pred: ^bb88
     cf.br ^bb95
   ^bb90:  // pred: ^bb92
-    %c1024_i64_142 = arith.constant 1024 : i64
-    %276 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_143 = arith.constant -2 : i64
-    %277 = arith.addi %276, %c-2_i64_143 : i64
-    %c2_i64_144 = arith.constant 2 : i64
-    %278 = arith.cmpi ult, %276, %c2_i64_144 : i64
-    %c91_i8_145 = arith.constant 91 : i8
-    cf.cond_br %278, ^bb1(%c91_i8_145 : i8), ^bb87
+    %c1024_i64_113 = arith.constant 1024 : i64
+    %246 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_114 = arith.constant -2 : i64
+    %247 = arith.addi %246, %c-2_i64_114 : i64
+    llvm.store %247, %arg3 : i64, !llvm.ptr
+    %c2_i64_115 = arith.constant 2 : i64
+    %248 = arith.cmpi ult, %246, %c2_i64_115 : i64
+    %c91_i8_116 = arith.constant 91 : i8
+    cf.cond_br %248, ^bb1(%c91_i8_116 : i8), ^bb87
   ^bb91:  // pred: ^bb83
-    %279 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_146 = arith.constant 0 : i64
+    %249 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_117 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %280 = arith.cmpi uge, %279, %c0_i64_146 : i64
-    %c80_i8_147 = arith.constant 80 : i8
-    cf.cond_br %280, ^bb92, ^bb1(%c80_i8_147 : i8)
+    %250 = arith.cmpi uge, %249, %c0_i64_117 : i64
+    %c80_i8_118 = arith.constant 80 : i8
+    cf.cond_br %250, ^bb92, ^bb1(%c80_i8_118 : i8)
   ^bb92:  // pred: ^bb91
-    %281 = arith.subi %279, %c0_i64_146 : i64
-    llvm.store %281, %arg1 : i64, !llvm.ptr
+    %251 = arith.subi %249, %c0_i64_117 : i64
+    llvm.store %251, %arg1 : i64, !llvm.ptr
     cf.br ^bb90
   ^bb93:  // pred: ^bb94
-    %c0_i256_148 = arith.constant 0 : i256
-    %282 = llvm.load %arg3 : !llvm.ptr -> i64
-    %283 = llvm.getelementptr %arg2[%282] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_149 = arith.constant 1 : i64
-    %284 = arith.addi %282, %c1_i64_149 : i64
-    llvm.store %284, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_148, %283 : i256, !llvm.ptr
+    %c0_i256_119 = arith.constant 0 : i256
+    %252 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_119, %252 : i256, !llvm.ptr
+    %253 = llvm.getelementptr %252[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %253, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb99
   ^bb94:  // pred: ^bb96
-    %c1024_i64_150 = arith.constant 1024 : i64
-    %285 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_151 = arith.constant 1 : i64
-    %286 = arith.addi %285, %c1_i64_151 : i64
-    %287 = arith.cmpi ult, %c1024_i64_150, %286 : i64
-    %c92_i8_152 = arith.constant 92 : i8
-    cf.cond_br %287, ^bb1(%c92_i8_152 : i8), ^bb93
+    %c1024_i64_120 = arith.constant 1024 : i64
+    %254 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_121 = arith.constant 1 : i64
+    %255 = arith.addi %254, %c1_i64_121 : i64
+    llvm.store %255, %arg3 : i64, !llvm.ptr
+    %256 = arith.cmpi ult, %c1024_i64_120, %255 : i64
+    %c92_i8_122 = arith.constant 92 : i8
+    cf.cond_br %256, ^bb1(%c92_i8_122 : i8), ^bb93
   ^bb95:  // pred: ^bb89
-    %288 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_153 = arith.constant 3 : i64
+    %257 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_123 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %289 = arith.cmpi uge, %288, %c3_i64_153 : i64
-    %c80_i8_154 = arith.constant 80 : i8
-    cf.cond_br %289, ^bb96, ^bb1(%c80_i8_154 : i8)
+    %258 = arith.cmpi uge, %257, %c3_i64_123 : i64
+    %c80_i8_124 = arith.constant 80 : i8
+    cf.cond_br %258, ^bb96, ^bb1(%c80_i8_124 : i8)
   ^bb96:  // pred: ^bb95
-    %290 = arith.subi %288, %c3_i64_153 : i64
-    llvm.store %290, %arg1 : i64, !llvm.ptr
+    %259 = arith.subi %257, %c3_i64_123 : i64
+    llvm.store %259, %arg1 : i64, !llvm.ptr
     cf.br ^bb94
   ^bb97:  // pred: ^bb98
-    %c0_i256_155 = arith.constant 0 : i256
-    %291 = llvm.load %arg3 : !llvm.ptr -> i64
-    %292 = llvm.getelementptr %arg2[%291] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_156 = arith.constant 1 : i64
-    %293 = arith.addi %291, %c1_i64_156 : i64
-    llvm.store %293, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_155, %292 : i256, !llvm.ptr
+    %c0_i256_125 = arith.constant 0 : i256
+    %260 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_125, %260 : i256, !llvm.ptr
+    %261 = llvm.getelementptr %260[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %261, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb103
   ^bb98:  // pred: ^bb100
-    %c1024_i64_157 = arith.constant 1024 : i64
-    %294 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_158 = arith.constant 1 : i64
-    %295 = arith.addi %294, %c1_i64_158 : i64
-    %296 = arith.cmpi ult, %c1024_i64_157, %295 : i64
-    %c92_i8_159 = arith.constant 92 : i8
-    cf.cond_br %296, ^bb1(%c92_i8_159 : i8), ^bb97
+    %c1024_i64_126 = arith.constant 1024 : i64
+    %262 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_127 = arith.constant 1 : i64
+    %263 = arith.addi %262, %c1_i64_127 : i64
+    llvm.store %263, %arg3 : i64, !llvm.ptr
+    %264 = arith.cmpi ult, %c1024_i64_126, %263 : i64
+    %c92_i8_128 = arith.constant 92 : i8
+    cf.cond_br %264, ^bb1(%c92_i8_128 : i8), ^bb97
   ^bb99:  // pred: ^bb93
-    %297 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_160 = arith.constant 3 : i64
+    %265 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_129 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %298 = arith.cmpi uge, %297, %c3_i64_160 : i64
-    %c80_i8_161 = arith.constant 80 : i8
-    cf.cond_br %298, ^bb100, ^bb1(%c80_i8_161 : i8)
+    %266 = arith.cmpi uge, %265, %c3_i64_129 : i64
+    %c80_i8_130 = arith.constant 80 : i8
+    cf.cond_br %266, ^bb100, ^bb1(%c80_i8_130 : i8)
   ^bb100:  // pred: ^bb99
-    %299 = arith.subi %297, %c3_i64_160 : i64
-    llvm.store %299, %arg1 : i64, !llvm.ptr
+    %267 = arith.subi %265, %c3_i64_129 : i64
+    llvm.store %267, %arg1 : i64, !llvm.ptr
     cf.br ^bb98
   ^bb101:  // pred: ^bb102
     %c32_i256 = arith.constant 32 : i256
-    %300 = llvm.load %arg3 : !llvm.ptr -> i64
-    %301 = llvm.getelementptr %arg2[%300] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_162 = arith.constant 1 : i64
-    %302 = arith.addi %300, %c1_i64_162 : i64
-    llvm.store %302, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %301 : i256, !llvm.ptr
+    %268 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %268 : i256, !llvm.ptr
+    %269 = llvm.getelementptr %268[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %269, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb107
   ^bb102:  // pred: ^bb104
-    %c1024_i64_163 = arith.constant 1024 : i64
-    %303 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_164 = arith.constant 1 : i64
-    %304 = arith.addi %303, %c1_i64_164 : i64
-    %305 = arith.cmpi ult, %c1024_i64_163, %304 : i64
-    %c92_i8_165 = arith.constant 92 : i8
-    cf.cond_br %305, ^bb1(%c92_i8_165 : i8), ^bb101
+    %c1024_i64_131 = arith.constant 1024 : i64
+    %270 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_132 = arith.constant 1 : i64
+    %271 = arith.addi %270, %c1_i64_132 : i64
+    llvm.store %271, %arg3 : i64, !llvm.ptr
+    %272 = arith.cmpi ult, %c1024_i64_131, %271 : i64
+    %c92_i8_133 = arith.constant 92 : i8
+    cf.cond_br %272, ^bb1(%c92_i8_133 : i8), ^bb101
   ^bb103:  // pred: ^bb97
-    %306 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_166 = arith.constant 3 : i64
+    %273 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_134 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %307 = arith.cmpi uge, %306, %c3_i64_166 : i64
-    %c80_i8_167 = arith.constant 80 : i8
-    cf.cond_br %307, ^bb104, ^bb1(%c80_i8_167 : i8)
+    %274 = arith.cmpi uge, %273, %c3_i64_134 : i64
+    %c80_i8_135 = arith.constant 80 : i8
+    cf.cond_br %274, ^bb104, ^bb1(%c80_i8_135 : i8)
   ^bb104:  // pred: ^bb103
-    %308 = arith.subi %306, %c3_i64_166 : i64
-    llvm.store %308, %arg1 : i64, !llvm.ptr
+    %275 = arith.subi %273, %c3_i64_134 : i64
+    llvm.store %275, %arg1 : i64, !llvm.ptr
     cf.br ^bb102
   ^bb105:  // pred: ^bb106
-    %c0_i256_168 = arith.constant 0 : i256
-    %309 = llvm.load %arg3 : !llvm.ptr -> i64
-    %310 = llvm.getelementptr %arg2[%309] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_169 = arith.constant 1 : i64
-    %311 = arith.addi %309, %c1_i64_169 : i64
-    llvm.store %311, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_168, %310 : i256, !llvm.ptr
+    %c0_i256_136 = arith.constant 0 : i256
+    %276 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_136, %276 : i256, !llvm.ptr
+    %277 = llvm.getelementptr %276[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %277, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb111
   ^bb106:  // pred: ^bb108
-    %c1024_i64_170 = arith.constant 1024 : i64
-    %312 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_171 = arith.constant 1 : i64
-    %313 = arith.addi %312, %c1_i64_171 : i64
-    %314 = arith.cmpi ult, %c1024_i64_170, %313 : i64
-    %c92_i8_172 = arith.constant 92 : i8
-    cf.cond_br %314, ^bb1(%c92_i8_172 : i8), ^bb105
+    %c1024_i64_137 = arith.constant 1024 : i64
+    %278 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_138 = arith.constant 1 : i64
+    %279 = arith.addi %278, %c1_i64_138 : i64
+    llvm.store %279, %arg3 : i64, !llvm.ptr
+    %280 = arith.cmpi ult, %c1024_i64_137, %279 : i64
+    %c92_i8_139 = arith.constant 92 : i8
+    cf.cond_br %280, ^bb1(%c92_i8_139 : i8), ^bb105
   ^bb107:  // pred: ^bb101
-    %315 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_173 = arith.constant 3 : i64
+    %281 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_140 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %316 = arith.cmpi uge, %315, %c3_i64_173 : i64
-    %c80_i8_174 = arith.constant 80 : i8
-    cf.cond_br %316, ^bb108, ^bb1(%c80_i8_174 : i8)
+    %282 = arith.cmpi uge, %281, %c3_i64_140 : i64
+    %c80_i8_141 = arith.constant 80 : i8
+    cf.cond_br %282, ^bb108, ^bb1(%c80_i8_141 : i8)
   ^bb108:  // pred: ^bb107
-    %317 = arith.subi %315, %c3_i64_173 : i64
-    llvm.store %317, %arg1 : i64, !llvm.ptr
+    %283 = arith.subi %281, %c3_i64_140 : i64
+    llvm.store %283, %arg1 : i64, !llvm.ptr
     cf.br ^bb106
   ^bb109:  // pred: ^bb110
-    %c0_i256_175 = arith.constant 0 : i256
-    %318 = llvm.load %arg3 : !llvm.ptr -> i64
-    %319 = llvm.getelementptr %arg2[%318] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_176 = arith.constant 1 : i64
-    %320 = arith.addi %318, %c1_i64_176 : i64
-    llvm.store %320, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_175, %319 : i256, !llvm.ptr
+    %c0_i256_142 = arith.constant 0 : i256
+    %284 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_142, %284 : i256, !llvm.ptr
+    %285 = llvm.getelementptr %284[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %285, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb115
   ^bb110:  // pred: ^bb112
-    %c1024_i64_177 = arith.constant 1024 : i64
-    %321 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_178 = arith.constant 1 : i64
-    %322 = arith.addi %321, %c1_i64_178 : i64
-    %323 = arith.cmpi ult, %c1024_i64_177, %322 : i64
-    %c92_i8_179 = arith.constant 92 : i8
-    cf.cond_br %323, ^bb1(%c92_i8_179 : i8), ^bb109
+    %c1024_i64_143 = arith.constant 1024 : i64
+    %286 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_144 = arith.constant 1 : i64
+    %287 = arith.addi %286, %c1_i64_144 : i64
+    llvm.store %287, %arg3 : i64, !llvm.ptr
+    %288 = arith.cmpi ult, %c1024_i64_143, %287 : i64
+    %c92_i8_145 = arith.constant 92 : i8
+    cf.cond_br %288, ^bb1(%c92_i8_145 : i8), ^bb109
   ^bb111:  // pred: ^bb105
-    %324 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_180 = arith.constant 3 : i64
+    %289 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_146 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %325 = arith.cmpi uge, %324, %c3_i64_180 : i64
-    %c80_i8_181 = arith.constant 80 : i8
-    cf.cond_br %325, ^bb112, ^bb1(%c80_i8_181 : i8)
+    %290 = arith.cmpi uge, %289, %c3_i64_146 : i64
+    %c80_i8_147 = arith.constant 80 : i8
+    cf.cond_br %290, ^bb112, ^bb1(%c80_i8_147 : i8)
   ^bb112:  // pred: ^bb111
-    %326 = arith.subi %324, %c3_i64_180 : i64
-    llvm.store %326, %arg1 : i64, !llvm.ptr
+    %291 = arith.subi %289, %c3_i64_146 : i64
+    llvm.store %291, %arg1 : i64, !llvm.ptr
     cf.br ^bb110
   ^bb113:  // pred: ^bb114
-    %327 = llvm.load %arg3 : !llvm.ptr -> i64
-    %328 = llvm.getelementptr %arg2[%327] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %329 = llvm.getelementptr %328[-7] : (!llvm.ptr) -> !llvm.ptr, i256
-    %330 = llvm.load %329 : !llvm.ptr -> i256
-    %331 = llvm.load %arg3 : !llvm.ptr -> i64
-    %332 = llvm.getelementptr %arg2[%331] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_182 = arith.constant 1 : i64
-    %333 = arith.addi %331, %c1_i64_182 : i64
-    llvm.store %333, %arg3 : i64, !llvm.ptr
-    llvm.store %330, %332 : i256, !llvm.ptr
+    %292 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %293 = llvm.getelementptr %292[-7] : (!llvm.ptr) -> !llvm.ptr, i256
+    %294 = llvm.load %293 : !llvm.ptr -> i256
+    %295 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %294, %295 : i256, !llvm.ptr
+    %296 = llvm.getelementptr %295[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %296, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb119
   ^bb114:  // pred: ^bb116
-    %c1024_i64_183 = arith.constant 1024 : i64
-    %334 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_184 = arith.constant 1 : i64
-    %335 = arith.addi %334, %c1_i64_184 : i64
-    %c7_i64_185 = arith.constant 7 : i64
-    %336 = arith.cmpi ult, %334, %c7_i64_185 : i64
-    %337 = arith.cmpi ult, %c1024_i64_183, %335 : i64
-    %338 = arith.xori %336, %337 : i1
-    %c92_i8_186 = arith.constant 92 : i8
-    cf.cond_br %338, ^bb1(%c92_i8_186 : i8), ^bb113
+    %c1024_i64_148 = arith.constant 1024 : i64
+    %297 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_149 = arith.constant 1 : i64
+    %298 = arith.addi %297, %c1_i64_149 : i64
+    llvm.store %298, %arg3 : i64, !llvm.ptr
+    %c7_i64_150 = arith.constant 7 : i64
+    %299 = arith.cmpi ult, %297, %c7_i64_150 : i64
+    %300 = arith.cmpi ult, %c1024_i64_148, %298 : i64
+    %301 = arith.xori %299, %300 : i1
+    %c92_i8_151 = arith.constant 92 : i8
+    cf.cond_br %301, ^bb1(%c92_i8_151 : i8), ^bb113
   ^bb115:  // pred: ^bb109
-    %339 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_187 = arith.constant 3 : i64
+    %302 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_152 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %340 = arith.cmpi uge, %339, %c3_i64_187 : i64
-    %c80_i8_188 = arith.constant 80 : i8
-    cf.cond_br %340, ^bb116, ^bb1(%c80_i8_188 : i8)
+    %303 = arith.cmpi uge, %302, %c3_i64_152 : i64
+    %c80_i8_153 = arith.constant 80 : i8
+    cf.cond_br %303, ^bb116, ^bb1(%c80_i8_153 : i8)
   ^bb116:  // pred: ^bb115
-    %341 = arith.subi %339, %c3_i64_187 : i64
-    llvm.store %341, %arg1 : i64, !llvm.ptr
+    %304 = arith.subi %302, %c3_i64_152 : i64
+    llvm.store %304, %arg1 : i64, !llvm.ptr
     cf.br ^bb114
   ^bb117:  // pred: ^bb118
-    %c65535_i256_189 = arith.constant 65535 : i256
-    %342 = llvm.load %arg3 : !llvm.ptr -> i64
-    %343 = llvm.getelementptr %arg2[%342] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_190 = arith.constant 1 : i64
-    %344 = arith.addi %342, %c1_i64_190 : i64
-    llvm.store %344, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256_189, %343 : i256, !llvm.ptr
+    %c65535_i256_154 = arith.constant 65535 : i256
+    %305 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_154, %305 : i256, !llvm.ptr
+    %306 = llvm.getelementptr %305[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %306, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb131
   ^bb118:  // pred: ^bb120
-    %c1024_i64_191 = arith.constant 1024 : i64
-    %345 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_192 = arith.constant 1 : i64
-    %346 = arith.addi %345, %c1_i64_192 : i64
-    %347 = arith.cmpi ult, %c1024_i64_191, %346 : i64
-    %c92_i8_193 = arith.constant 92 : i8
-    cf.cond_br %347, ^bb1(%c92_i8_193 : i8), ^bb117
+    %c1024_i64_155 = arith.constant 1024 : i64
+    %307 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_156 = arith.constant 1 : i64
+    %308 = arith.addi %307, %c1_i64_156 : i64
+    llvm.store %308, %arg3 : i64, !llvm.ptr
+    %309 = arith.cmpi ult, %c1024_i64_155, %308 : i64
+    %c92_i8_157 = arith.constant 92 : i8
+    cf.cond_br %309, ^bb1(%c92_i8_157 : i8), ^bb117
   ^bb119:  // pred: ^bb113
-    %348 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_194 = arith.constant 3 : i64
+    %310 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_158 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %349 = arith.cmpi uge, %348, %c3_i64_194 : i64
-    %c80_i8_195 = arith.constant 80 : i8
-    cf.cond_br %349, ^bb120, ^bb1(%c80_i8_195 : i8)
+    %311 = arith.cmpi uge, %310, %c3_i64_158 : i64
+    %c80_i8_159 = arith.constant 80 : i8
+    cf.cond_br %311, ^bb120, ^bb1(%c80_i8_159 : i8)
   ^bb120:  // pred: ^bb119
-    %350 = arith.subi %348, %c3_i64_194 : i64
-    llvm.store %350, %arg1 : i64, !llvm.ptr
+    %312 = arith.subi %310, %c3_i64_158 : i64
+    llvm.store %312, %arg1 : i64, !llvm.ptr
     cf.br ^bb118
   ^bb121:  // pred: ^bb130
-    %351 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_196 = arith.constant 1 : i64
-    %352 = arith.subi %351, %c1_i64_196 : i64
-    %353 = llvm.getelementptr %arg2[%352] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %352, %arg3 : i64, !llvm.ptr
-    %354 = llvm.load %353 : !llvm.ptr -> i256
-    %355 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_197 = arith.constant 1 : i64
-    %356 = arith.subi %355, %c1_i64_197 : i64
-    %357 = llvm.getelementptr %arg2[%356] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %356, %arg3 : i64, !llvm.ptr
-    %358 = llvm.load %357 : !llvm.ptr -> i256
-    %359 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_198 = arith.constant 1 : i64
-    %360 = arith.subi %359, %c1_i64_198 : i64
-    %361 = llvm.getelementptr %arg2[%360] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %360, %arg3 : i64, !llvm.ptr
-    %362 = llvm.load %361 : !llvm.ptr -> i256
-    %363 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_199 = arith.constant 1 : i64
-    %364 = arith.subi %363, %c1_i64_199 : i64
-    %365 = llvm.getelementptr %arg2[%364] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %364, %arg3 : i64, !llvm.ptr
-    %366 = llvm.load %365 : !llvm.ptr -> i256
-    %367 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_200 = arith.constant 1 : i64
-    %368 = arith.subi %367, %c1_i64_200 : i64
-    %369 = llvm.getelementptr %arg2[%368] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %368, %arg3 : i64, !llvm.ptr
-    %370 = llvm.load %369 : !llvm.ptr -> i256
-    %371 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_201 = arith.constant 1 : i64
-    %372 = arith.subi %371, %c1_i64_201 : i64
-    %373 = llvm.getelementptr %arg2[%372] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %372, %arg3 : i64, !llvm.ptr
-    %374 = llvm.load %373 : !llvm.ptr -> i256
-    %375 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_202 = arith.constant 1 : i64
-    %376 = arith.subi %375, %c1_i64_202 : i64
-    %377 = llvm.getelementptr %arg2[%376] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %376, %arg3 : i64, !llvm.ptr
-    %378 = llvm.load %377 : !llvm.ptr -> i256
-    %c18446744073709551615_i256_203 = arith.constant 18446744073709551615 : i256
-    %379 = arith.cmpi sgt, %370, %c18446744073709551615_i256_203 : i256
-    %c84_i8_204 = arith.constant 84 : i8
-    cf.cond_br %379, ^bb1(%c84_i8_204 : i8), ^bb122
+    %313 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %314 = llvm.getelementptr %313[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %315 = llvm.load %314 : !llvm.ptr -> i256
+    llvm.store %314, %0 : !llvm.ptr, !llvm.ptr
+    %316 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %317 = llvm.getelementptr %316[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %318 = llvm.load %317 : !llvm.ptr -> i256
+    llvm.store %317, %0 : !llvm.ptr, !llvm.ptr
+    %319 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %320 = llvm.getelementptr %319[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %321 = llvm.load %320 : !llvm.ptr -> i256
+    llvm.store %320, %0 : !llvm.ptr, !llvm.ptr
+    %322 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %323 = llvm.getelementptr %322[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %324 = llvm.load %323 : !llvm.ptr -> i256
+    llvm.store %323, %0 : !llvm.ptr, !llvm.ptr
+    %325 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %326 = llvm.getelementptr %325[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %327 = llvm.load %326 : !llvm.ptr -> i256
+    llvm.store %326, %0 : !llvm.ptr, !llvm.ptr
+    %328 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %329 = llvm.getelementptr %328[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %330 = llvm.load %329 : !llvm.ptr -> i256
+    llvm.store %329, %0 : !llvm.ptr, !llvm.ptr
+    %331 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %332 = llvm.getelementptr %331[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %333 = llvm.load %332 : !llvm.ptr -> i256
+    llvm.store %332, %0 : !llvm.ptr, !llvm.ptr
+    %c18446744073709551615_i256_160 = arith.constant 18446744073709551615 : i256
+    %334 = arith.cmpi sgt, %327, %c18446744073709551615_i256_160 : i256
+    %c84_i8_161 = arith.constant 84 : i8
+    cf.cond_br %334, ^bb1(%c84_i8_161 : i8), ^bb122
   ^bb122:  // pred: ^bb121
-    %380 = arith.trunci %370 : i256 to i64
-    %c0_i64_205 = arith.constant 0 : i64
-    %381 = arith.cmpi slt, %380, %c0_i64_205 : i64
-    %c84_i8_206 = arith.constant 84 : i8
-    cf.cond_br %381, ^bb1(%c84_i8_206 : i8), ^bb123
+    %335 = arith.trunci %327 : i256 to i64
+    %c0_i64_162 = arith.constant 0 : i64
+    %336 = arith.cmpi slt, %335, %c0_i64_162 : i64
+    %c84_i8_163 = arith.constant 84 : i8
+    cf.cond_br %336, ^bb1(%c84_i8_163 : i8), ^bb123
   ^bb123:  // pred: ^bb122
-    %c0_i64_207 = arith.constant 0 : i64
-    %382 = arith.cmpi ne, %380, %c0_i64_207 : i64
-    cf.cond_br %382, ^bb168, ^bb124
+    %c0_i64_164 = arith.constant 0 : i64
+    %337 = arith.cmpi ne, %335, %c0_i64_164 : i64
+    cf.cond_br %337, ^bb168, ^bb124
   ^bb124:  // 2 preds: ^bb123, ^bb172
-    %c18446744073709551615_i256_208 = arith.constant 18446744073709551615 : i256
-    %383 = arith.cmpi sgt, %378, %c18446744073709551615_i256_208 : i256
-    %c84_i8_209 = arith.constant 84 : i8
-    cf.cond_br %383, ^bb1(%c84_i8_209 : i8), ^bb125
+    %c18446744073709551615_i256_165 = arith.constant 18446744073709551615 : i256
+    %338 = arith.cmpi sgt, %333, %c18446744073709551615_i256_165 : i256
+    %c84_i8_166 = arith.constant 84 : i8
+    cf.cond_br %338, ^bb1(%c84_i8_166 : i8), ^bb125
   ^bb125:  // pred: ^bb124
-    %384 = arith.trunci %378 : i256 to i64
-    %c0_i64_210 = arith.constant 0 : i64
-    %385 = arith.cmpi slt, %384, %c0_i64_210 : i64
-    %c84_i8_211 = arith.constant 84 : i8
-    cf.cond_br %385, ^bb1(%c84_i8_211 : i8), ^bb126
+    %339 = arith.trunci %333 : i256 to i64
+    %c0_i64_167 = arith.constant 0 : i64
+    %340 = arith.cmpi slt, %339, %c0_i64_167 : i64
+    %c84_i8_168 = arith.constant 84 : i8
+    cf.cond_br %340, ^bb1(%c84_i8_168 : i8), ^bb126
   ^bb126:  // pred: ^bb125
-    %c0_i64_212 = arith.constant 0 : i64
-    %386 = arith.cmpi ne, %384, %c0_i64_212 : i64
-    cf.cond_br %386, ^bb176, ^bb127
+    %c0_i64_169 = arith.constant 0 : i64
+    %341 = arith.cmpi ne, %339, %c0_i64_169 : i64
+    cf.cond_br %341, ^bb176, ^bb127
   ^bb127:  // 2 preds: ^bb126, ^bb180
-    %387 = arith.trunci %366 : i256 to i64
-    %388 = arith.trunci %374 : i256 to i64
-    %389 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_213 = arith.constant 1 : i256
-    %390 = llvm.alloca %c1_i256_213 x i256 : (i256) -> !llvm.ptr
-    llvm.store %362, %390 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_214 = arith.constant 1 : i256
-    %391 = llvm.alloca %c1_i256_214 x i256 : (i256) -> !llvm.ptr
-    llvm.store %354, %391 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_215 = arith.constant 1 : i256
-    %392 = llvm.alloca %c1_i256_215 x i256 : (i256) -> !llvm.ptr
-    llvm.store %358, %392 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c3_i8_216 = arith.constant 3 : i8
-    %393 = call @dora_fn_call(%arg0, %391, %392, %390, %387, %380, %388, %384, %389, %c3_i8_216) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %394 = llvm.getelementptr %393[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %395 = llvm.load %394 : !llvm.ptr -> i8
-    %396 = llvm.getelementptr %393[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %397 = llvm.load %396 : !llvm.ptr -> i8
-    %c0_i8_217 = arith.constant 0 : i8
-    %398 = arith.cmpi ne, %397, %c0_i8_217 : i8
-    cf.cond_br %398, ^bb1(%397 : i8), ^bb128
+    %342 = arith.trunci %324 : i256 to i64
+    %343 = arith.trunci %330 : i256 to i64
+    %344 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_170 = arith.constant 1 : i256
+    %345 = llvm.alloca %c1_i256_170 x i256 : (i256) -> !llvm.ptr
+    llvm.store %321, %345 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_171 = arith.constant 1 : i256
+    %346 = llvm.alloca %c1_i256_171 x i256 : (i256) -> !llvm.ptr
+    llvm.store %315, %346 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_172 = arith.constant 1 : i256
+    %347 = llvm.alloca %c1_i256_172 x i256 : (i256) -> !llvm.ptr
+    llvm.store %318, %347 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c3_i8_173 = arith.constant 3 : i8
+    %348 = call @dora_fn_call(%arg0, %346, %347, %345, %342, %335, %343, %339, %344, %c3_i8_173) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %349 = llvm.getelementptr %348[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %350 = llvm.load %349 : !llvm.ptr -> i8
+    %351 = llvm.getelementptr %348[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %352 = llvm.load %351 : !llvm.ptr -> i8
+    %c0_i8_174 = arith.constant 0 : i8
+    %353 = arith.cmpi ne, %352, %c0_i8_174 : i8
+    cf.cond_br %353, ^bb1(%352 : i8), ^bb128
   ^bb128:  // pred: ^bb127
-    %399 = llvm.getelementptr %393[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %400 = llvm.load %399 : !llvm.ptr -> i64
-    %401 = llvm.load %arg1 : !llvm.ptr -> i64
-    %402 = arith.cmpi ult, %401, %400 : i64
-    scf.if %402 {
+    %354 = llvm.getelementptr %348[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %355 = llvm.load %354 : !llvm.ptr -> i64
+    %356 = llvm.load %arg1 : !llvm.ptr -> i64
+    %357 = arith.cmpi ult, %356, %355 : i64
+    scf.if %357 {
     } else {
-      %588 = arith.subi %401, %400 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %356, %355 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_218 = arith.constant 80 : i8
-    cf.cond_br %402, ^bb1(%c80_i8_218 : i8), ^bb129
+    %c80_i8_175 = arith.constant 80 : i8
+    cf.cond_br %357, ^bb1(%c80_i8_175 : i8), ^bb129
   ^bb129:  // pred: ^bb128
-    %403 = arith.extui %395 : i8 to i256
-    %404 = llvm.load %arg3 : !llvm.ptr -> i64
-    %405 = llvm.getelementptr %arg2[%404] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_219 = arith.constant 1 : i64
-    %406 = arith.addi %404, %c1_i64_219 : i64
-    llvm.store %406, %arg3 : i64, !llvm.ptr
-    llvm.store %403, %405 : i256, !llvm.ptr
+    %358 = arith.extui %350 : i8 to i256
+    %359 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %358, %359 : i256, !llvm.ptr
+    %360 = llvm.getelementptr %359[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %360, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb133
   ^bb130:  // pred: ^bb132
-    %c1024_i64_220 = arith.constant 1024 : i64
-    %407 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-6_i64_221 = arith.constant -6 : i64
-    %408 = arith.addi %407, %c-6_i64_221 : i64
-    %c7_i64_222 = arith.constant 7 : i64
-    %409 = arith.cmpi ult, %407, %c7_i64_222 : i64
-    %c91_i8_223 = arith.constant 91 : i8
-    cf.cond_br %409, ^bb1(%c91_i8_223 : i8), ^bb121
+    %c1024_i64_176 = arith.constant 1024 : i64
+    %361 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-6_i64_177 = arith.constant -6 : i64
+    %362 = arith.addi %361, %c-6_i64_177 : i64
+    llvm.store %362, %arg3 : i64, !llvm.ptr
+    %c7_i64_178 = arith.constant 7 : i64
+    %363 = arith.cmpi ult, %361, %c7_i64_178 : i64
+    %c91_i8_179 = arith.constant 91 : i8
+    cf.cond_br %363, ^bb1(%c91_i8_179 : i8), ^bb121
   ^bb131:  // pred: ^bb117
-    %410 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_224 = arith.constant 0 : i64
+    %364 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_180 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %411 = arith.cmpi uge, %410, %c0_i64_224 : i64
-    %c80_i8_225 = arith.constant 80 : i8
-    cf.cond_br %411, ^bb132, ^bb1(%c80_i8_225 : i8)
+    %365 = arith.cmpi uge, %364, %c0_i64_180 : i64
+    %c80_i8_181 = arith.constant 80 : i8
+    cf.cond_br %365, ^bb132, ^bb1(%c80_i8_181 : i8)
   ^bb132:  // pred: ^bb131
-    %412 = arith.subi %410, %c0_i64_224 : i64
-    llvm.store %412, %arg1 : i64, !llvm.ptr
+    %366 = arith.subi %364, %c0_i64_180 : i64
+    llvm.store %366, %arg1 : i64, !llvm.ptr
     cf.br ^bb130
   ^bb133:  // pred: ^bb129
-    %c0_i64_226 = arith.constant 0 : i64
+    %c0_i64_182 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %413 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_226, %c0_i64_226, %413, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %367 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_182, %c0_i64_182, %367, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb134:  // pred: ^bb11
-    %c18446744073709551615_i256_227 = arith.constant 18446744073709551615 : i256
-    %414 = arith.cmpi sgt, %24, %c18446744073709551615_i256_227 : i256
-    %c84_i8_228 = arith.constant 84 : i8
-    cf.cond_br %414, ^bb1(%c84_i8_228 : i8), ^bb135
+    %c18446744073709551615_i256_183 = arith.constant 18446744073709551615 : i256
+    %368 = arith.cmpi sgt, %22, %c18446744073709551615_i256_183 : i256
+    %c84_i8_184 = arith.constant 84 : i8
+    cf.cond_br %368, ^bb1(%c84_i8_184 : i8), ^bb135
   ^bb135:  // pred: ^bb134
-    %415 = arith.trunci %24 : i256 to i64
-    %c0_i64_229 = arith.constant 0 : i64
-    %416 = arith.cmpi slt, %415, %c0_i64_229 : i64
-    %c84_i8_230 = arith.constant 84 : i8
-    cf.cond_br %416, ^bb1(%c84_i8_230 : i8), ^bb136
+    %369 = arith.trunci %22 : i256 to i64
+    %c0_i64_185 = arith.constant 0 : i64
+    %370 = arith.cmpi slt, %369, %c0_i64_185 : i64
+    %c84_i8_186 = arith.constant 84 : i8
+    cf.cond_br %370, ^bb1(%c84_i8_186 : i8), ^bb136
   ^bb136:  // pred: ^bb135
-    %417 = arith.addi %415, %c32_i64 : i64
-    %c0_i64_231 = arith.constant 0 : i64
-    %418 = arith.cmpi slt, %417, %c0_i64_231 : i64
-    %c84_i8_232 = arith.constant 84 : i8
-    cf.cond_br %418, ^bb1(%c84_i8_232 : i8), ^bb137
+    %371 = arith.addi %369, %c32_i64 : i64
+    %c0_i64_187 = arith.constant 0 : i64
+    %372 = arith.cmpi slt, %371, %c0_i64_187 : i64
+    %c84_i8_188 = arith.constant 84 : i8
+    cf.cond_br %372, ^bb1(%c84_i8_188 : i8), ^bb137
   ^bb137:  // pred: ^bb136
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_233 = arith.constant 32 : i64
-    %419 = arith.addi %417, %c31_i64 : i64
-    %420 = arith.divui %419, %c32_i64_233 : i64
-    %c32_i64_234 = arith.constant 32 : i64
-    %421 = arith.muli %420, %c32_i64_234 : i64
-    %422 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_235 = arith.constant 31 : i64
-    %c32_i64_236 = arith.constant 32 : i64
-    %423 = arith.addi %422, %c31_i64_235 : i64
-    %424 = arith.divui %423, %c32_i64_236 : i64
-    %425 = arith.muli %424, %c32_i64_234 : i64
-    %426 = arith.cmpi ult, %425, %421 : i64
-    cf.cond_br %426, ^bb139, ^bb138
+    %c32_i64_189 = arith.constant 32 : i64
+    %373 = arith.addi %371, %c31_i64 : i64
+    %374 = arith.divui %373, %c32_i64_189 : i64
+    %c32_i64_190 = arith.constant 32 : i64
+    %375 = arith.muli %374, %c32_i64_190 : i64
+    %376 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_191 = arith.constant 31 : i64
+    %c32_i64_192 = arith.constant 32 : i64
+    %377 = arith.addi %376, %c31_i64_191 : i64
+    %378 = arith.divui %377, %c32_i64_192 : i64
+    %379 = arith.muli %378, %c32_i64_190 : i64
+    %380 = arith.cmpi ult, %379, %375 : i64
+    cf.cond_br %380, ^bb139, ^bb138
   ^bb138:  // 2 preds: ^bb137, ^bb141
     cf.br ^bb12
   ^bb139:  // pred: ^bb137
-    %c3_i64_237 = arith.constant 3 : i64
+    %c3_i64_193 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %427 = arith.muli %424, %424 : i64
-    %428 = arith.divui %427, %c512_i64 : i64
-    %429 = arith.muli %424, %c3_i64_237 : i64
-    %430 = arith.addi %428, %429 : i64
-    %c3_i64_238 = arith.constant 3 : i64
-    %c512_i64_239 = arith.constant 512 : i64
-    %431 = arith.muli %420, %420 : i64
-    %432 = arith.divui %431, %c512_i64_239 : i64
-    %433 = arith.muli %420, %c3_i64_238 : i64
-    %434 = arith.addi %432, %433 : i64
-    %435 = arith.subi %434, %430 : i64
-    %436 = llvm.load %arg1 : !llvm.ptr -> i64
-    %437 = arith.cmpi ult, %436, %435 : i64
-    scf.if %437 {
+    %381 = arith.muli %378, %378 : i64
+    %382 = arith.divui %381, %c512_i64 : i64
+    %383 = arith.muli %378, %c3_i64_193 : i64
+    %384 = arith.addi %382, %383 : i64
+    %c3_i64_194 = arith.constant 3 : i64
+    %c512_i64_195 = arith.constant 512 : i64
+    %385 = arith.muli %374, %374 : i64
+    %386 = arith.divui %385, %c512_i64_195 : i64
+    %387 = arith.muli %374, %c3_i64_194 : i64
+    %388 = arith.addi %386, %387 : i64
+    %389 = arith.subi %388, %384 : i64
+    %390 = llvm.load %arg1 : !llvm.ptr -> i64
+    %391 = arith.cmpi ult, %390, %389 : i64
+    scf.if %391 {
     } else {
-      %588 = arith.subi %436, %435 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %390, %389 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_240 = arith.constant 80 : i8
-    cf.cond_br %437, ^bb1(%c80_i8_240 : i8), ^bb140
+    %c80_i8_196 = arith.constant 80 : i8
+    cf.cond_br %391, ^bb1(%c80_i8_196 : i8), ^bb140
   ^bb140:  // pred: ^bb139
-    %438 = call @dora_fn_extend_memory(%arg0, %421) : (!llvm.ptr, i64) -> !llvm.ptr
-    %439 = llvm.getelementptr %438[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %440 = llvm.load %439 : !llvm.ptr -> i8
-    %c0_i8_241 = arith.constant 0 : i8
-    %441 = arith.cmpi ne, %440, %c0_i8_241 : i8
-    cf.cond_br %441, ^bb1(%440 : i8), ^bb141
+    %392 = call @dora_fn_extend_memory(%arg0, %375) : (!llvm.ptr, i64) -> !llvm.ptr
+    %393 = llvm.getelementptr %392[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %394 = llvm.load %393 : !llvm.ptr -> i8
+    %c0_i8_197 = arith.constant 0 : i8
+    %395 = arith.cmpi ne, %394, %c0_i8_197 : i8
+    cf.cond_br %395, ^bb1(%394 : i8), ^bb141
   ^bb141:  // pred: ^bb140
     cf.br ^bb138
   ^bb142:  // pred: ^bb31
     %c49152_i64 = arith.constant 49152 : i64
-    %442 = arith.cmpi ugt, %82, %c49152_i64 : i64
+    %396 = arith.cmpi ugt, %73, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %442, ^bb1(%c100_i8 : i8), ^bb143
+    cf.cond_br %396, ^bb1(%c100_i8 : i8), ^bb143
   ^bb143:  // pred: ^bb142
-    %c31_i64_242 = arith.constant 31 : i64
-    %c32_i64_243 = arith.constant 32 : i64
-    %443 = arith.addi %82, %c31_i64_242 : i64
-    %444 = arith.divui %443, %c32_i64_243 : i64
-    %c2_i64_244 = arith.constant 2 : i64
-    %445 = arith.muli %444, %c2_i64_244 : i64
-    %446 = llvm.load %arg1 : !llvm.ptr -> i64
-    %447 = arith.cmpi ult, %446, %445 : i64
-    scf.if %447 {
+    %c31_i64_198 = arith.constant 31 : i64
+    %c32_i64_199 = arith.constant 32 : i64
+    %397 = arith.addi %73, %c31_i64_198 : i64
+    %398 = arith.divui %397, %c32_i64_199 : i64
+    %c2_i64_200 = arith.constant 2 : i64
+    %399 = arith.muli %398, %c2_i64_200 : i64
+    %400 = llvm.load %arg1 : !llvm.ptr -> i64
+    %401 = arith.cmpi ult, %400, %399 : i64
+    scf.if %401 {
     } else {
-      %588 = arith.subi %446, %445 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %400, %399 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_245 = arith.constant 80 : i8
-    cf.cond_br %447, ^bb1(%c80_i8_245 : i8), ^bb144
+    %c80_i8_201 = arith.constant 80 : i8
+    cf.cond_br %401, ^bb1(%c80_i8_201 : i8), ^bb144
   ^bb144:  // pred: ^bb143
-    %c18446744073709551615_i256_246 = arith.constant 18446744073709551615 : i256
-    %448 = arith.cmpi sgt, %74, %c18446744073709551615_i256_246 : i256
-    %c84_i8_247 = arith.constant 84 : i8
-    cf.cond_br %448, ^bb1(%c84_i8_247 : i8), ^bb145
+    %c18446744073709551615_i256_202 = arith.constant 18446744073709551615 : i256
+    %402 = arith.cmpi sgt, %66, %c18446744073709551615_i256_202 : i256
+    %c84_i8_203 = arith.constant 84 : i8
+    cf.cond_br %402, ^bb1(%c84_i8_203 : i8), ^bb145
   ^bb145:  // pred: ^bb144
-    %449 = arith.trunci %74 : i256 to i64
-    %c0_i64_248 = arith.constant 0 : i64
-    %450 = arith.cmpi slt, %449, %c0_i64_248 : i64
-    %c84_i8_249 = arith.constant 84 : i8
-    cf.cond_br %450, ^bb1(%c84_i8_249 : i8), ^bb146
+    %403 = arith.trunci %66 : i256 to i64
+    %c0_i64_204 = arith.constant 0 : i64
+    %404 = arith.cmpi slt, %403, %c0_i64_204 : i64
+    %c84_i8_205 = arith.constant 84 : i8
+    cf.cond_br %404, ^bb1(%c84_i8_205 : i8), ^bb146
   ^bb146:  // pred: ^bb145
-    %451 = arith.addi %449, %82 : i64
-    %c0_i64_250 = arith.constant 0 : i64
-    %452 = arith.cmpi slt, %451, %c0_i64_250 : i64
-    %c84_i8_251 = arith.constant 84 : i8
-    cf.cond_br %452, ^bb1(%c84_i8_251 : i8), ^bb147
+    %405 = arith.addi %403, %73 : i64
+    %c0_i64_206 = arith.constant 0 : i64
+    %406 = arith.cmpi slt, %405, %c0_i64_206 : i64
+    %c84_i8_207 = arith.constant 84 : i8
+    cf.cond_br %406, ^bb1(%c84_i8_207 : i8), ^bb147
   ^bb147:  // pred: ^bb146
-    %c31_i64_252 = arith.constant 31 : i64
-    %c32_i64_253 = arith.constant 32 : i64
-    %453 = arith.addi %451, %c31_i64_252 : i64
-    %454 = arith.divui %453, %c32_i64_253 : i64
-    %c32_i64_254 = arith.constant 32 : i64
-    %455 = arith.muli %454, %c32_i64_254 : i64
-    %456 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_255 = arith.constant 31 : i64
-    %c32_i64_256 = arith.constant 32 : i64
-    %457 = arith.addi %456, %c31_i64_255 : i64
-    %458 = arith.divui %457, %c32_i64_256 : i64
-    %459 = arith.muli %458, %c32_i64_254 : i64
-    %460 = arith.cmpi ult, %459, %455 : i64
-    cf.cond_br %460, ^bb149, ^bb148
+    %c31_i64_208 = arith.constant 31 : i64
+    %c32_i64_209 = arith.constant 32 : i64
+    %407 = arith.addi %405, %c31_i64_208 : i64
+    %408 = arith.divui %407, %c32_i64_209 : i64
+    %c32_i64_210 = arith.constant 32 : i64
+    %409 = arith.muli %408, %c32_i64_210 : i64
+    %410 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_211 = arith.constant 31 : i64
+    %c32_i64_212 = arith.constant 32 : i64
+    %411 = arith.addi %410, %c31_i64_211 : i64
+    %412 = arith.divui %411, %c32_i64_212 : i64
+    %413 = arith.muli %412, %c32_i64_210 : i64
+    %414 = arith.cmpi ult, %413, %409 : i64
+    cf.cond_br %414, ^bb149, ^bb148
   ^bb148:  // 2 preds: ^bb147, ^bb151
     cf.br ^bb32
   ^bb149:  // pred: ^bb147
-    %c3_i64_257 = arith.constant 3 : i64
-    %c512_i64_258 = arith.constant 512 : i64
-    %461 = arith.muli %458, %458 : i64
-    %462 = arith.divui %461, %c512_i64_258 : i64
-    %463 = arith.muli %458, %c3_i64_257 : i64
-    %464 = arith.addi %462, %463 : i64
-    %c3_i64_259 = arith.constant 3 : i64
-    %c512_i64_260 = arith.constant 512 : i64
-    %465 = arith.muli %454, %454 : i64
-    %466 = arith.divui %465, %c512_i64_260 : i64
-    %467 = arith.muli %454, %c3_i64_259 : i64
-    %468 = arith.addi %466, %467 : i64
-    %469 = arith.subi %468, %464 : i64
-    %470 = llvm.load %arg1 : !llvm.ptr -> i64
-    %471 = arith.cmpi ult, %470, %469 : i64
-    scf.if %471 {
+    %c3_i64_213 = arith.constant 3 : i64
+    %c512_i64_214 = arith.constant 512 : i64
+    %415 = arith.muli %412, %412 : i64
+    %416 = arith.divui %415, %c512_i64_214 : i64
+    %417 = arith.muli %412, %c3_i64_213 : i64
+    %418 = arith.addi %416, %417 : i64
+    %c3_i64_215 = arith.constant 3 : i64
+    %c512_i64_216 = arith.constant 512 : i64
+    %419 = arith.muli %408, %408 : i64
+    %420 = arith.divui %419, %c512_i64_216 : i64
+    %421 = arith.muli %408, %c3_i64_215 : i64
+    %422 = arith.addi %420, %421 : i64
+    %423 = arith.subi %422, %418 : i64
+    %424 = llvm.load %arg1 : !llvm.ptr -> i64
+    %425 = arith.cmpi ult, %424, %423 : i64
+    scf.if %425 {
     } else {
-      %588 = arith.subi %470, %469 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %424, %423 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_261 = arith.constant 80 : i8
-    cf.cond_br %471, ^bb1(%c80_i8_261 : i8), ^bb150
+    %c80_i8_217 = arith.constant 80 : i8
+    cf.cond_br %425, ^bb1(%c80_i8_217 : i8), ^bb150
   ^bb150:  // pred: ^bb149
-    %472 = call @dora_fn_extend_memory(%arg0, %455) : (!llvm.ptr, i64) -> !llvm.ptr
-    %473 = llvm.getelementptr %472[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %474 = llvm.load %473 : !llvm.ptr -> i8
-    %c0_i8_262 = arith.constant 0 : i8
-    %475 = arith.cmpi ne, %474, %c0_i8_262 : i8
-    cf.cond_br %475, ^bb1(%474 : i8), ^bb151
+    %426 = call @dora_fn_extend_memory(%arg0, %409) : (!llvm.ptr, i64) -> !llvm.ptr
+    %427 = llvm.getelementptr %426[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %428 = llvm.load %427 : !llvm.ptr -> i8
+    %c0_i8_218 = arith.constant 0 : i8
+    %429 = arith.cmpi ne, %428, %c0_i8_218 : i8
+    cf.cond_br %429, ^bb1(%428 : i8), ^bb151
   ^bb151:  // pred: ^bb150
     cf.br ^bb148
   ^bb152:  // pred: ^bb69
-    %c18446744073709551615_i256_263 = arith.constant 18446744073709551615 : i256
-    %476 = arith.cmpi sgt, %192, %c18446744073709551615_i256_263 : i256
-    %c84_i8_264 = arith.constant 84 : i8
-    cf.cond_br %476, ^bb1(%c84_i8_264 : i8), ^bb153
+    %c18446744073709551615_i256_219 = arith.constant 18446744073709551615 : i256
+    %430 = arith.cmpi sgt, %170, %c18446744073709551615_i256_219 : i256
+    %c84_i8_220 = arith.constant 84 : i8
+    cf.cond_br %430, ^bb1(%c84_i8_220 : i8), ^bb153
   ^bb153:  // pred: ^bb152
-    %477 = arith.trunci %192 : i256 to i64
-    %c0_i64_265 = arith.constant 0 : i64
-    %478 = arith.cmpi slt, %477, %c0_i64_265 : i64
-    %c84_i8_266 = arith.constant 84 : i8
-    cf.cond_br %478, ^bb1(%c84_i8_266 : i8), ^bb154
+    %431 = arith.trunci %170 : i256 to i64
+    %c0_i64_221 = arith.constant 0 : i64
+    %432 = arith.cmpi slt, %431, %c0_i64_221 : i64
+    %c84_i8_222 = arith.constant 84 : i8
+    cf.cond_br %432, ^bb1(%c84_i8_222 : i8), ^bb154
   ^bb154:  // pred: ^bb153
-    %479 = arith.addi %477, %206 : i64
-    %c0_i64_267 = arith.constant 0 : i64
-    %480 = arith.cmpi slt, %479, %c0_i64_267 : i64
-    %c84_i8_268 = arith.constant 84 : i8
-    cf.cond_br %480, ^bb1(%c84_i8_268 : i8), ^bb155
+    %433 = arith.addi %431, %181 : i64
+    %c0_i64_223 = arith.constant 0 : i64
+    %434 = arith.cmpi slt, %433, %c0_i64_223 : i64
+    %c84_i8_224 = arith.constant 84 : i8
+    cf.cond_br %434, ^bb1(%c84_i8_224 : i8), ^bb155
   ^bb155:  // pred: ^bb154
-    %c31_i64_269 = arith.constant 31 : i64
-    %c32_i64_270 = arith.constant 32 : i64
-    %481 = arith.addi %479, %c31_i64_269 : i64
-    %482 = arith.divui %481, %c32_i64_270 : i64
-    %c32_i64_271 = arith.constant 32 : i64
-    %483 = arith.muli %482, %c32_i64_271 : i64
-    %484 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_272 = arith.constant 31 : i64
-    %c32_i64_273 = arith.constant 32 : i64
-    %485 = arith.addi %484, %c31_i64_272 : i64
-    %486 = arith.divui %485, %c32_i64_273 : i64
-    %487 = arith.muli %486, %c32_i64_271 : i64
-    %488 = arith.cmpi ult, %487, %483 : i64
-    cf.cond_br %488, ^bb157, ^bb156
+    %c31_i64_225 = arith.constant 31 : i64
+    %c32_i64_226 = arith.constant 32 : i64
+    %435 = arith.addi %433, %c31_i64_225 : i64
+    %436 = arith.divui %435, %c32_i64_226 : i64
+    %c32_i64_227 = arith.constant 32 : i64
+    %437 = arith.muli %436, %c32_i64_227 : i64
+    %438 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_228 = arith.constant 31 : i64
+    %c32_i64_229 = arith.constant 32 : i64
+    %439 = arith.addi %438, %c31_i64_228 : i64
+    %440 = arith.divui %439, %c32_i64_229 : i64
+    %441 = arith.muli %440, %c32_i64_227 : i64
+    %442 = arith.cmpi ult, %441, %437 : i64
+    cf.cond_br %442, ^bb157, ^bb156
   ^bb156:  // 2 preds: ^bb155, ^bb159
     cf.br ^bb70
   ^bb157:  // pred: ^bb155
-    %c3_i64_274 = arith.constant 3 : i64
-    %c512_i64_275 = arith.constant 512 : i64
-    %489 = arith.muli %486, %486 : i64
-    %490 = arith.divui %489, %c512_i64_275 : i64
-    %491 = arith.muli %486, %c3_i64_274 : i64
-    %492 = arith.addi %490, %491 : i64
-    %c3_i64_276 = arith.constant 3 : i64
-    %c512_i64_277 = arith.constant 512 : i64
-    %493 = arith.muli %482, %482 : i64
-    %494 = arith.divui %493, %c512_i64_277 : i64
-    %495 = arith.muli %482, %c3_i64_276 : i64
-    %496 = arith.addi %494, %495 : i64
-    %497 = arith.subi %496, %492 : i64
-    %498 = llvm.load %arg1 : !llvm.ptr -> i64
-    %499 = arith.cmpi ult, %498, %497 : i64
-    scf.if %499 {
+    %c3_i64_230 = arith.constant 3 : i64
+    %c512_i64_231 = arith.constant 512 : i64
+    %443 = arith.muli %440, %440 : i64
+    %444 = arith.divui %443, %c512_i64_231 : i64
+    %445 = arith.muli %440, %c3_i64_230 : i64
+    %446 = arith.addi %444, %445 : i64
+    %c3_i64_232 = arith.constant 3 : i64
+    %c512_i64_233 = arith.constant 512 : i64
+    %447 = arith.muli %436, %436 : i64
+    %448 = arith.divui %447, %c512_i64_233 : i64
+    %449 = arith.muli %436, %c3_i64_232 : i64
+    %450 = arith.addi %448, %449 : i64
+    %451 = arith.subi %450, %446 : i64
+    %452 = llvm.load %arg1 : !llvm.ptr -> i64
+    %453 = arith.cmpi ult, %452, %451 : i64
+    scf.if %453 {
     } else {
-      %588 = arith.subi %498, %497 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %452, %451 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_278 = arith.constant 80 : i8
-    cf.cond_br %499, ^bb1(%c80_i8_278 : i8), ^bb158
+    %c80_i8_234 = arith.constant 80 : i8
+    cf.cond_br %453, ^bb1(%c80_i8_234 : i8), ^bb158
   ^bb158:  // pred: ^bb157
-    %500 = call @dora_fn_extend_memory(%arg0, %483) : (!llvm.ptr, i64) -> !llvm.ptr
-    %501 = llvm.getelementptr %500[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %502 = llvm.load %501 : !llvm.ptr -> i8
-    %c0_i8_279 = arith.constant 0 : i8
-    %503 = arith.cmpi ne, %502, %c0_i8_279 : i8
-    cf.cond_br %503, ^bb1(%502 : i8), ^bb159
+    %454 = call @dora_fn_extend_memory(%arg0, %437) : (!llvm.ptr, i64) -> !llvm.ptr
+    %455 = llvm.getelementptr %454[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %456 = llvm.load %455 : !llvm.ptr -> i8
+    %c0_i8_235 = arith.constant 0 : i8
+    %457 = arith.cmpi ne, %456, %c0_i8_235 : i8
+    cf.cond_br %457, ^bb1(%456 : i8), ^bb159
   ^bb159:  // pred: ^bb158
     cf.br ^bb156
   ^bb160:  // pred: ^bb72
-    %c18446744073709551615_i256_280 = arith.constant 18446744073709551615 : i256
-    %504 = arith.cmpi sgt, %200, %c18446744073709551615_i256_280 : i256
-    %c84_i8_281 = arith.constant 84 : i8
-    cf.cond_br %504, ^bb1(%c84_i8_281 : i8), ^bb161
+    %c18446744073709551615_i256_236 = arith.constant 18446744073709551615 : i256
+    %458 = arith.cmpi sgt, %176, %c18446744073709551615_i256_236 : i256
+    %c84_i8_237 = arith.constant 84 : i8
+    cf.cond_br %458, ^bb1(%c84_i8_237 : i8), ^bb161
   ^bb161:  // pred: ^bb160
-    %505 = arith.trunci %200 : i256 to i64
-    %c0_i64_282 = arith.constant 0 : i64
-    %506 = arith.cmpi slt, %505, %c0_i64_282 : i64
-    %c84_i8_283 = arith.constant 84 : i8
-    cf.cond_br %506, ^bb1(%c84_i8_283 : i8), ^bb162
+    %459 = arith.trunci %176 : i256 to i64
+    %c0_i64_238 = arith.constant 0 : i64
+    %460 = arith.cmpi slt, %459, %c0_i64_238 : i64
+    %c84_i8_239 = arith.constant 84 : i8
+    cf.cond_br %460, ^bb1(%c84_i8_239 : i8), ^bb162
   ^bb162:  // pred: ^bb161
-    %507 = arith.addi %505, %210 : i64
-    %c0_i64_284 = arith.constant 0 : i64
-    %508 = arith.cmpi slt, %507, %c0_i64_284 : i64
-    %c84_i8_285 = arith.constant 84 : i8
-    cf.cond_br %508, ^bb1(%c84_i8_285 : i8), ^bb163
+    %461 = arith.addi %459, %185 : i64
+    %c0_i64_240 = arith.constant 0 : i64
+    %462 = arith.cmpi slt, %461, %c0_i64_240 : i64
+    %c84_i8_241 = arith.constant 84 : i8
+    cf.cond_br %462, ^bb1(%c84_i8_241 : i8), ^bb163
   ^bb163:  // pred: ^bb162
-    %c31_i64_286 = arith.constant 31 : i64
-    %c32_i64_287 = arith.constant 32 : i64
-    %509 = arith.addi %507, %c31_i64_286 : i64
-    %510 = arith.divui %509, %c32_i64_287 : i64
-    %c32_i64_288 = arith.constant 32 : i64
-    %511 = arith.muli %510, %c32_i64_288 : i64
-    %512 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_289 = arith.constant 31 : i64
-    %c32_i64_290 = arith.constant 32 : i64
-    %513 = arith.addi %512, %c31_i64_289 : i64
-    %514 = arith.divui %513, %c32_i64_290 : i64
-    %515 = arith.muli %514, %c32_i64_288 : i64
-    %516 = arith.cmpi ult, %515, %511 : i64
-    cf.cond_br %516, ^bb165, ^bb164
+    %c31_i64_242 = arith.constant 31 : i64
+    %c32_i64_243 = arith.constant 32 : i64
+    %463 = arith.addi %461, %c31_i64_242 : i64
+    %464 = arith.divui %463, %c32_i64_243 : i64
+    %c32_i64_244 = arith.constant 32 : i64
+    %465 = arith.muli %464, %c32_i64_244 : i64
+    %466 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_245 = arith.constant 31 : i64
+    %c32_i64_246 = arith.constant 32 : i64
+    %467 = arith.addi %466, %c31_i64_245 : i64
+    %468 = arith.divui %467, %c32_i64_246 : i64
+    %469 = arith.muli %468, %c32_i64_244 : i64
+    %470 = arith.cmpi ult, %469, %465 : i64
+    cf.cond_br %470, ^bb165, ^bb164
   ^bb164:  // 2 preds: ^bb163, ^bb167
     cf.br ^bb73
   ^bb165:  // pred: ^bb163
-    %c3_i64_291 = arith.constant 3 : i64
-    %c512_i64_292 = arith.constant 512 : i64
-    %517 = arith.muli %514, %514 : i64
-    %518 = arith.divui %517, %c512_i64_292 : i64
-    %519 = arith.muli %514, %c3_i64_291 : i64
-    %520 = arith.addi %518, %519 : i64
-    %c3_i64_293 = arith.constant 3 : i64
-    %c512_i64_294 = arith.constant 512 : i64
-    %521 = arith.muli %510, %510 : i64
-    %522 = arith.divui %521, %c512_i64_294 : i64
-    %523 = arith.muli %510, %c3_i64_293 : i64
-    %524 = arith.addi %522, %523 : i64
-    %525 = arith.subi %524, %520 : i64
-    %526 = llvm.load %arg1 : !llvm.ptr -> i64
-    %527 = arith.cmpi ult, %526, %525 : i64
-    scf.if %527 {
+    %c3_i64_247 = arith.constant 3 : i64
+    %c512_i64_248 = arith.constant 512 : i64
+    %471 = arith.muli %468, %468 : i64
+    %472 = arith.divui %471, %c512_i64_248 : i64
+    %473 = arith.muli %468, %c3_i64_247 : i64
+    %474 = arith.addi %472, %473 : i64
+    %c3_i64_249 = arith.constant 3 : i64
+    %c512_i64_250 = arith.constant 512 : i64
+    %475 = arith.muli %464, %464 : i64
+    %476 = arith.divui %475, %c512_i64_250 : i64
+    %477 = arith.muli %464, %c3_i64_249 : i64
+    %478 = arith.addi %476, %477 : i64
+    %479 = arith.subi %478, %474 : i64
+    %480 = llvm.load %arg1 : !llvm.ptr -> i64
+    %481 = arith.cmpi ult, %480, %479 : i64
+    scf.if %481 {
     } else {
-      %588 = arith.subi %526, %525 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %480, %479 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_295 = arith.constant 80 : i8
-    cf.cond_br %527, ^bb1(%c80_i8_295 : i8), ^bb166
+    %c80_i8_251 = arith.constant 80 : i8
+    cf.cond_br %481, ^bb1(%c80_i8_251 : i8), ^bb166
   ^bb166:  // pred: ^bb165
-    %528 = call @dora_fn_extend_memory(%arg0, %511) : (!llvm.ptr, i64) -> !llvm.ptr
-    %529 = llvm.getelementptr %528[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %530 = llvm.load %529 : !llvm.ptr -> i8
-    %c0_i8_296 = arith.constant 0 : i8
-    %531 = arith.cmpi ne, %530, %c0_i8_296 : i8
-    cf.cond_br %531, ^bb1(%530 : i8), ^bb167
+    %482 = call @dora_fn_extend_memory(%arg0, %465) : (!llvm.ptr, i64) -> !llvm.ptr
+    %483 = llvm.getelementptr %482[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %484 = llvm.load %483 : !llvm.ptr -> i8
+    %c0_i8_252 = arith.constant 0 : i8
+    %485 = arith.cmpi ne, %484, %c0_i8_252 : i8
+    cf.cond_br %485, ^bb1(%484 : i8), ^bb167
   ^bb167:  // pred: ^bb166
     cf.br ^bb164
   ^bb168:  // pred: ^bb123
-    %c18446744073709551615_i256_297 = arith.constant 18446744073709551615 : i256
-    %532 = arith.cmpi sgt, %366, %c18446744073709551615_i256_297 : i256
-    %c84_i8_298 = arith.constant 84 : i8
-    cf.cond_br %532, ^bb1(%c84_i8_298 : i8), ^bb169
+    %c18446744073709551615_i256_253 = arith.constant 18446744073709551615 : i256
+    %486 = arith.cmpi sgt, %324, %c18446744073709551615_i256_253 : i256
+    %c84_i8_254 = arith.constant 84 : i8
+    cf.cond_br %486, ^bb1(%c84_i8_254 : i8), ^bb169
   ^bb169:  // pred: ^bb168
-    %533 = arith.trunci %366 : i256 to i64
-    %c0_i64_299 = arith.constant 0 : i64
-    %534 = arith.cmpi slt, %533, %c0_i64_299 : i64
-    %c84_i8_300 = arith.constant 84 : i8
-    cf.cond_br %534, ^bb1(%c84_i8_300 : i8), ^bb170
+    %487 = arith.trunci %324 : i256 to i64
+    %c0_i64_255 = arith.constant 0 : i64
+    %488 = arith.cmpi slt, %487, %c0_i64_255 : i64
+    %c84_i8_256 = arith.constant 84 : i8
+    cf.cond_br %488, ^bb1(%c84_i8_256 : i8), ^bb170
   ^bb170:  // pred: ^bb169
-    %535 = arith.addi %533, %380 : i64
-    %c0_i64_301 = arith.constant 0 : i64
-    %536 = arith.cmpi slt, %535, %c0_i64_301 : i64
-    %c84_i8_302 = arith.constant 84 : i8
-    cf.cond_br %536, ^bb1(%c84_i8_302 : i8), ^bb171
+    %489 = arith.addi %487, %335 : i64
+    %c0_i64_257 = arith.constant 0 : i64
+    %490 = arith.cmpi slt, %489, %c0_i64_257 : i64
+    %c84_i8_258 = arith.constant 84 : i8
+    cf.cond_br %490, ^bb1(%c84_i8_258 : i8), ^bb171
   ^bb171:  // pred: ^bb170
-    %c31_i64_303 = arith.constant 31 : i64
-    %c32_i64_304 = arith.constant 32 : i64
-    %537 = arith.addi %535, %c31_i64_303 : i64
-    %538 = arith.divui %537, %c32_i64_304 : i64
-    %c32_i64_305 = arith.constant 32 : i64
-    %539 = arith.muli %538, %c32_i64_305 : i64
-    %540 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_306 = arith.constant 31 : i64
-    %c32_i64_307 = arith.constant 32 : i64
-    %541 = arith.addi %540, %c31_i64_306 : i64
-    %542 = arith.divui %541, %c32_i64_307 : i64
-    %543 = arith.muli %542, %c32_i64_305 : i64
-    %544 = arith.cmpi ult, %543, %539 : i64
-    cf.cond_br %544, ^bb173, ^bb172
+    %c31_i64_259 = arith.constant 31 : i64
+    %c32_i64_260 = arith.constant 32 : i64
+    %491 = arith.addi %489, %c31_i64_259 : i64
+    %492 = arith.divui %491, %c32_i64_260 : i64
+    %c32_i64_261 = arith.constant 32 : i64
+    %493 = arith.muli %492, %c32_i64_261 : i64
+    %494 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_262 = arith.constant 31 : i64
+    %c32_i64_263 = arith.constant 32 : i64
+    %495 = arith.addi %494, %c31_i64_262 : i64
+    %496 = arith.divui %495, %c32_i64_263 : i64
+    %497 = arith.muli %496, %c32_i64_261 : i64
+    %498 = arith.cmpi ult, %497, %493 : i64
+    cf.cond_br %498, ^bb173, ^bb172
   ^bb172:  // 2 preds: ^bb171, ^bb175
     cf.br ^bb124
   ^bb173:  // pred: ^bb171
-    %c3_i64_308 = arith.constant 3 : i64
-    %c512_i64_309 = arith.constant 512 : i64
-    %545 = arith.muli %542, %542 : i64
-    %546 = arith.divui %545, %c512_i64_309 : i64
-    %547 = arith.muli %542, %c3_i64_308 : i64
-    %548 = arith.addi %546, %547 : i64
-    %c3_i64_310 = arith.constant 3 : i64
-    %c512_i64_311 = arith.constant 512 : i64
-    %549 = arith.muli %538, %538 : i64
-    %550 = arith.divui %549, %c512_i64_311 : i64
-    %551 = arith.muli %538, %c3_i64_310 : i64
-    %552 = arith.addi %550, %551 : i64
-    %553 = arith.subi %552, %548 : i64
-    %554 = llvm.load %arg1 : !llvm.ptr -> i64
-    %555 = arith.cmpi ult, %554, %553 : i64
-    scf.if %555 {
+    %c3_i64_264 = arith.constant 3 : i64
+    %c512_i64_265 = arith.constant 512 : i64
+    %499 = arith.muli %496, %496 : i64
+    %500 = arith.divui %499, %c512_i64_265 : i64
+    %501 = arith.muli %496, %c3_i64_264 : i64
+    %502 = arith.addi %500, %501 : i64
+    %c3_i64_266 = arith.constant 3 : i64
+    %c512_i64_267 = arith.constant 512 : i64
+    %503 = arith.muli %492, %492 : i64
+    %504 = arith.divui %503, %c512_i64_267 : i64
+    %505 = arith.muli %492, %c3_i64_266 : i64
+    %506 = arith.addi %504, %505 : i64
+    %507 = arith.subi %506, %502 : i64
+    %508 = llvm.load %arg1 : !llvm.ptr -> i64
+    %509 = arith.cmpi ult, %508, %507 : i64
+    scf.if %509 {
     } else {
-      %588 = arith.subi %554, %553 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %508, %507 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_312 = arith.constant 80 : i8
-    cf.cond_br %555, ^bb1(%c80_i8_312 : i8), ^bb174
+    %c80_i8_268 = arith.constant 80 : i8
+    cf.cond_br %509, ^bb1(%c80_i8_268 : i8), ^bb174
   ^bb174:  // pred: ^bb173
-    %556 = call @dora_fn_extend_memory(%arg0, %539) : (!llvm.ptr, i64) -> !llvm.ptr
-    %557 = llvm.getelementptr %556[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %558 = llvm.load %557 : !llvm.ptr -> i8
-    %c0_i8_313 = arith.constant 0 : i8
-    %559 = arith.cmpi ne, %558, %c0_i8_313 : i8
-    cf.cond_br %559, ^bb1(%558 : i8), ^bb175
+    %510 = call @dora_fn_extend_memory(%arg0, %493) : (!llvm.ptr, i64) -> !llvm.ptr
+    %511 = llvm.getelementptr %510[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %512 = llvm.load %511 : !llvm.ptr -> i8
+    %c0_i8_269 = arith.constant 0 : i8
+    %513 = arith.cmpi ne, %512, %c0_i8_269 : i8
+    cf.cond_br %513, ^bb1(%512 : i8), ^bb175
   ^bb175:  // pred: ^bb174
     cf.br ^bb172
   ^bb176:  // pred: ^bb126
-    %c18446744073709551615_i256_314 = arith.constant 18446744073709551615 : i256
-    %560 = arith.cmpi sgt, %374, %c18446744073709551615_i256_314 : i256
-    %c84_i8_315 = arith.constant 84 : i8
-    cf.cond_br %560, ^bb1(%c84_i8_315 : i8), ^bb177
+    %c18446744073709551615_i256_270 = arith.constant 18446744073709551615 : i256
+    %514 = arith.cmpi sgt, %330, %c18446744073709551615_i256_270 : i256
+    %c84_i8_271 = arith.constant 84 : i8
+    cf.cond_br %514, ^bb1(%c84_i8_271 : i8), ^bb177
   ^bb177:  // pred: ^bb176
-    %561 = arith.trunci %374 : i256 to i64
-    %c0_i64_316 = arith.constant 0 : i64
-    %562 = arith.cmpi slt, %561, %c0_i64_316 : i64
-    %c84_i8_317 = arith.constant 84 : i8
-    cf.cond_br %562, ^bb1(%c84_i8_317 : i8), ^bb178
+    %515 = arith.trunci %330 : i256 to i64
+    %c0_i64_272 = arith.constant 0 : i64
+    %516 = arith.cmpi slt, %515, %c0_i64_272 : i64
+    %c84_i8_273 = arith.constant 84 : i8
+    cf.cond_br %516, ^bb1(%c84_i8_273 : i8), ^bb178
   ^bb178:  // pred: ^bb177
-    %563 = arith.addi %561, %384 : i64
-    %c0_i64_318 = arith.constant 0 : i64
-    %564 = arith.cmpi slt, %563, %c0_i64_318 : i64
-    %c84_i8_319 = arith.constant 84 : i8
-    cf.cond_br %564, ^bb1(%c84_i8_319 : i8), ^bb179
+    %517 = arith.addi %515, %339 : i64
+    %c0_i64_274 = arith.constant 0 : i64
+    %518 = arith.cmpi slt, %517, %c0_i64_274 : i64
+    %c84_i8_275 = arith.constant 84 : i8
+    cf.cond_br %518, ^bb1(%c84_i8_275 : i8), ^bb179
   ^bb179:  // pred: ^bb178
-    %c31_i64_320 = arith.constant 31 : i64
-    %c32_i64_321 = arith.constant 32 : i64
-    %565 = arith.addi %563, %c31_i64_320 : i64
-    %566 = arith.divui %565, %c32_i64_321 : i64
-    %c32_i64_322 = arith.constant 32 : i64
-    %567 = arith.muli %566, %c32_i64_322 : i64
-    %568 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_323 = arith.constant 31 : i64
-    %c32_i64_324 = arith.constant 32 : i64
-    %569 = arith.addi %568, %c31_i64_323 : i64
-    %570 = arith.divui %569, %c32_i64_324 : i64
-    %571 = arith.muli %570, %c32_i64_322 : i64
-    %572 = arith.cmpi ult, %571, %567 : i64
-    cf.cond_br %572, ^bb181, ^bb180
+    %c31_i64_276 = arith.constant 31 : i64
+    %c32_i64_277 = arith.constant 32 : i64
+    %519 = arith.addi %517, %c31_i64_276 : i64
+    %520 = arith.divui %519, %c32_i64_277 : i64
+    %c32_i64_278 = arith.constant 32 : i64
+    %521 = arith.muli %520, %c32_i64_278 : i64
+    %522 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_279 = arith.constant 31 : i64
+    %c32_i64_280 = arith.constant 32 : i64
+    %523 = arith.addi %522, %c31_i64_279 : i64
+    %524 = arith.divui %523, %c32_i64_280 : i64
+    %525 = arith.muli %524, %c32_i64_278 : i64
+    %526 = arith.cmpi ult, %525, %521 : i64
+    cf.cond_br %526, ^bb181, ^bb180
   ^bb180:  // 2 preds: ^bb179, ^bb183
     cf.br ^bb127
   ^bb181:  // pred: ^bb179
-    %c3_i64_325 = arith.constant 3 : i64
-    %c512_i64_326 = arith.constant 512 : i64
-    %573 = arith.muli %570, %570 : i64
-    %574 = arith.divui %573, %c512_i64_326 : i64
-    %575 = arith.muli %570, %c3_i64_325 : i64
-    %576 = arith.addi %574, %575 : i64
-    %c3_i64_327 = arith.constant 3 : i64
-    %c512_i64_328 = arith.constant 512 : i64
-    %577 = arith.muli %566, %566 : i64
-    %578 = arith.divui %577, %c512_i64_328 : i64
-    %579 = arith.muli %566, %c3_i64_327 : i64
-    %580 = arith.addi %578, %579 : i64
-    %581 = arith.subi %580, %576 : i64
-    %582 = llvm.load %arg1 : !llvm.ptr -> i64
-    %583 = arith.cmpi ult, %582, %581 : i64
-    scf.if %583 {
+    %c3_i64_281 = arith.constant 3 : i64
+    %c512_i64_282 = arith.constant 512 : i64
+    %527 = arith.muli %524, %524 : i64
+    %528 = arith.divui %527, %c512_i64_282 : i64
+    %529 = arith.muli %524, %c3_i64_281 : i64
+    %530 = arith.addi %528, %529 : i64
+    %c3_i64_283 = arith.constant 3 : i64
+    %c512_i64_284 = arith.constant 512 : i64
+    %531 = arith.muli %520, %520 : i64
+    %532 = arith.divui %531, %c512_i64_284 : i64
+    %533 = arith.muli %520, %c3_i64_283 : i64
+    %534 = arith.addi %532, %533 : i64
+    %535 = arith.subi %534, %530 : i64
+    %536 = llvm.load %arg1 : !llvm.ptr -> i64
+    %537 = arith.cmpi ult, %536, %535 : i64
+    scf.if %537 {
     } else {
-      %588 = arith.subi %582, %581 : i64
-      llvm.store %588, %arg1 : i64, !llvm.ptr
+      %542 = arith.subi %536, %535 : i64
+      llvm.store %542, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_329 = arith.constant 80 : i8
-    cf.cond_br %583, ^bb1(%c80_i8_329 : i8), ^bb182
+    %c80_i8_285 = arith.constant 80 : i8
+    cf.cond_br %537, ^bb1(%c80_i8_285 : i8), ^bb182
   ^bb182:  // pred: ^bb181
-    %584 = call @dora_fn_extend_memory(%arg0, %567) : (!llvm.ptr, i64) -> !llvm.ptr
-    %585 = llvm.getelementptr %584[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %586 = llvm.load %585 : !llvm.ptr -> i8
-    %c0_i8_330 = arith.constant 0 : i8
-    %587 = arith.cmpi ne, %586, %c0_i8_330 : i8
-    cf.cond_br %587, ^bb1(%586 : i8), ^bb183
+    %538 = call @dora_fn_extend_memory(%arg0, %521) : (!llvm.ptr, i64) -> !llvm.ptr
+    %539 = llvm.getelementptr %538[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %540 = llvm.load %539 : !llvm.ptr -> i8
+    %c0_i8_286 = arith.constant 0 : i8
+    %541 = arith.cmpi ne, %540, %c0_i8_286 : i8
+    cf.cond_br %541, ^bb1(%540 : i8), ^bb183
   ^bb183:  // pred: ^bb182
     cf.br ^bb180
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 103 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb70, ^bb71, ^bb73, ^bb74, ^bb76, ^bb77, ^bb80, ^bb81, ^bb84, ^bb85, ^bb87, ^bb88, ^bb90, ^bb91, ^bb94, ^bb95, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb110, ^bb111, ^bb114, ^bb115, ^bb117, ^bb118, ^bb120, ^bb121, ^bb123, ^bb124, ^bb126, ^bb127, ^bb130, ^bb131, ^bb132, ^bb135, ^bb136, ^bb138, ^bb139, ^bb140, ^bb141, ^bb142, ^bb145, ^bb146, ^bb148, ^bb149, ^bb150, ^bb153, ^bb154, ^bb156, ^bb157, ^bb158, ^bb161, ^bb162, ^bb164, ^bb165, ^bb166, ^bb169, ^bb170, ^bb172, ^bb173, ^bb174, ^bb177, ^bb178
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 103 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb44, ^bb45, ^bb48, ^bb49, ^bb52, ^bb53, ^bb56, ^bb57, ^bb60, ^bb61, ^bb64, ^bb65, ^bb67, ^bb68, ^bb70, ^bb71, ^bb73, ^bb74, ^bb76, ^bb77, ^bb80, ^bb81, ^bb84, ^bb85, ^bb87, ^bb88, ^bb90, ^bb91, ^bb94, ^bb95, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb110, ^bb111, ^bb114, ^bb115, ^bb117, ^bb118, ^bb120, ^bb121, ^bb123, ^bb124, ^bb126, ^bb127, ^bb130, ^bb131, ^bb132, ^bb135, ^bb136, ^bb138, ^bb139, ^bb140, ^bb141, ^bb142, ^bb145, ^bb146, ^bb148, ^bb149, ^bb150, ^bb153, ^bb154, ^bb156, ^bb157, ^bb158, ^bb161, ^bb162, ^bb164, ^bb165, ^bb166, ^bb169, ^bb170, ^bb172, ^bb173, ^bb174, ^bb177, ^bb178
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c35176690763027899028215972788860354566387_i256 = arith.constant 35176690763027899028215972788860354566387 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c35176690763027899028215972788860354566387_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,1436 +96,1376 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb130, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb130, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb134
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c17_i256 = arith.constant 17 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c17_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c15_i256 = arith.constant 15 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c15_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c15_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %c0_i256_25 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_26 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_26 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_25, %59 : i256, !llvm.ptr
+    %c0_i256_20 = arith.constant 0 : i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_20, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb25:  // pred: ^bb27
-    %c1024_i64_27 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_28 : i64
-    %63 = arith.cmpi ult, %c1024_i64_27, %62 : i64
-    %c92_i8_29 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_29 : i8), ^bb24
+    %c1024_i64_21 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_22 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_22 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_21, %56 : i64
+    %c92_i8_23 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_23 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_30 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_24 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_31 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_25 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_30 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_24 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb36
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_32 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_32 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_33 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_34 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
-    %79 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %80 = arith.cmpi ne, %79, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %80, ^bb1(%c87_i8 : i8), ^bb29
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb30
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %82 = arith.trunci %78 : i256 to i64
-    %c0_i64_35 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_35 : i64
-    %c84_i8_36 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_36 : i8), ^bb31
+    %73 = arith.trunci %69 : i256 to i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_27 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_37 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_37 : i64
-    cf.cond_br %84, ^bb138, ^bb32
+    %c0_i64_28 = arith.constant 0 : i64
+    %75 = arith.cmpi ne, %73, %c0_i64_28 : i64
+    cf.cond_br %75, ^bb138, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb144
     %c32000_i64 = arith.constant 32000 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %c32000_i64 : i64
-    scf.if %86 {
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %c32000_i64 : i64
+    scf.if %77 {
     } else {
-      %571 = arith.subi %85, %c32000_i64 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %76, %c32000_i64 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_38 : i8), ^bb33
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_29 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c1_i256 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %70, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %89 = arith.trunci %74 : i256 to i64
-    %90 = call @dora_fn_create(%arg0, %82, %89, %87, %88) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %91 = llvm.getelementptr %90[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %92 = llvm.load %91 : !llvm.ptr -> i8
-    %c0_i8_39 = arith.constant 0 : i8
-    %93 = arith.cmpi ne, %92, %c0_i8_39 : i8
-    cf.cond_br %93, ^bb1(%92 : i8), ^bb34
+    %78 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %80 = arith.trunci %66 : i256 to i64
+    %81 = call @dora_fn_create(%arg0, %73, %80, %78, %79) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %82 = llvm.getelementptr %81[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %83 = llvm.load %82 : !llvm.ptr -> i8
+    %c0_i8_30 = arith.constant 0 : i8
+    %84 = arith.cmpi ne, %83, %c0_i8_30 : i8
+    cf.cond_br %84, ^bb1(%83 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %94 = llvm.getelementptr %90[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %85 = llvm.getelementptr %81[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %571 = arith.subi %96, %95 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %87, %86 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_40 : i8), ^bb35
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_31 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = llvm.load %87 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %101 = arith.addi %99, %c1_i64_41 : i64
-    llvm.store %101, %arg3 : i64, !llvm.ptr
-    llvm.store %98, %100 : i256, !llvm.ptr
+    %89 = llvm.load %78 : !llvm.ptr -> i256
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %90 : i256, !llvm.ptr
+    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb41
   ^bb36:  // pred: ^bb38
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_43 = arith.constant -2 : i64
-    %103 = arith.addi %102, %c-2_i64_43 : i64
-    %c3_i64_44 = arith.constant 3 : i64
-    %104 = arith.cmpi ult, %102, %c3_i64_44 : i64
-    %c91_i8_45 = arith.constant 91 : i8
-    cf.cond_br %104, ^bb1(%c91_i8_45 : i8), ^bb28
+    %c1024_i64_32 = arith.constant 1024 : i64
+    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_33 = arith.constant -2 : i64
+    %93 = arith.addi %92, %c-2_i64_33 : i64
+    llvm.store %93, %arg3 : i64, !llvm.ptr
+    %c3_i64_34 = arith.constant 3 : i64
+    %94 = arith.cmpi ult, %92, %c3_i64_34 : i64
+    %c91_i8_35 = arith.constant 91 : i8
+    cf.cond_br %94, ^bb1(%c91_i8_35 : i8), ^bb28
   ^bb37:  // pred: ^bb24
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_46 = arith.constant 0 : i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_36 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %106 = arith.cmpi uge, %105, %c0_i64_46 : i64
-    %c80_i8_47 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb38, ^bb1(%c80_i8_47 : i8)
+    %96 = arith.cmpi uge, %95, %c0_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %96, ^bb38, ^bb1(%c80_i8_37 : i8)
   ^bb38:  // pred: ^bb37
-    %107 = arith.subi %105, %c0_i64_46 : i64
-    llvm.store %107, %arg1 : i64, !llvm.ptr
+    %97 = arith.subi %95, %c0_i64_36 : i64
+    llvm.store %97, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb40
-    %c0_i256_48 = arith.constant 0 : i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %109 = llvm.getelementptr %arg2[%108] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_49 = arith.constant 1 : i64
-    %110 = arith.addi %108, %c1_i64_49 : i64
-    llvm.store %110, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_48, %109 : i256, !llvm.ptr
+    %c0_i256_38 = arith.constant 0 : i256
+    %98 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_38, %98 : i256, !llvm.ptr
+    %99 = llvm.getelementptr %98[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %99, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb45
   ^bb40:  // pred: ^bb42
-    %c1024_i64_50 = arith.constant 1024 : i64
-    %111 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_51 = arith.constant 1 : i64
-    %112 = arith.addi %111, %c1_i64_51 : i64
-    %113 = arith.cmpi ult, %c1024_i64_50, %112 : i64
-    %c92_i8_52 = arith.constant 92 : i8
-    cf.cond_br %113, ^bb1(%c92_i8_52 : i8), ^bb39
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %100 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %101 = arith.addi %100, %c1_i64_40 : i64
+    llvm.store %101, %arg3 : i64, !llvm.ptr
+    %102 = arith.cmpi ult, %c1024_i64_39, %101 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %102, ^bb1(%c92_i8_41 : i8), ^bb39
   ^bb41:  // pred: ^bb35
-    %114 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_53 = arith.constant 3 : i64
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_42 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %115 = arith.cmpi uge, %114, %c3_i64_53 : i64
-    %c80_i8_54 = arith.constant 80 : i8
-    cf.cond_br %115, ^bb42, ^bb1(%c80_i8_54 : i8)
+    %104 = arith.cmpi uge, %103, %c3_i64_42 : i64
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %104, ^bb42, ^bb1(%c80_i8_43 : i8)
   ^bb42:  // pred: ^bb41
-    %116 = arith.subi %114, %c3_i64_53 : i64
-    llvm.store %116, %arg1 : i64, !llvm.ptr
+    %105 = arith.subi %103, %c3_i64_42 : i64
+    llvm.store %105, %arg1 : i64, !llvm.ptr
     cf.br ^bb40
   ^bb43:  // pred: ^bb44
-    %c0_i256_55 = arith.constant 0 : i256
-    %117 = llvm.load %arg3 : !llvm.ptr -> i64
-    %118 = llvm.getelementptr %arg2[%117] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_56 = arith.constant 1 : i64
-    %119 = arith.addi %117, %c1_i64_56 : i64
-    llvm.store %119, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_55, %118 : i256, !llvm.ptr
+    %c0_i256_44 = arith.constant 0 : i256
+    %106 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_44, %106 : i256, !llvm.ptr
+    %107 = llvm.getelementptr %106[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %107, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb49
   ^bb44:  // pred: ^bb46
-    %c1024_i64_57 = arith.constant 1024 : i64
-    %120 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %121 = arith.addi %120, %c1_i64_58 : i64
-    %122 = arith.cmpi ult, %c1024_i64_57, %121 : i64
-    %c92_i8_59 = arith.constant 92 : i8
-    cf.cond_br %122, ^bb1(%c92_i8_59 : i8), ^bb43
+    %c1024_i64_45 = arith.constant 1024 : i64
+    %108 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_46 = arith.constant 1 : i64
+    %109 = arith.addi %108, %c1_i64_46 : i64
+    llvm.store %109, %arg3 : i64, !llvm.ptr
+    %110 = arith.cmpi ult, %c1024_i64_45, %109 : i64
+    %c92_i8_47 = arith.constant 92 : i8
+    cf.cond_br %110, ^bb1(%c92_i8_47 : i8), ^bb43
   ^bb45:  // pred: ^bb39
-    %123 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_60 = arith.constant 3 : i64
+    %111 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_48 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %124 = arith.cmpi uge, %123, %c3_i64_60 : i64
-    %c80_i8_61 = arith.constant 80 : i8
-    cf.cond_br %124, ^bb46, ^bb1(%c80_i8_61 : i8)
+    %112 = arith.cmpi uge, %111, %c3_i64_48 : i64
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %112, ^bb46, ^bb1(%c80_i8_49 : i8)
   ^bb46:  // pred: ^bb45
-    %125 = arith.subi %123, %c3_i64_60 : i64
-    llvm.store %125, %arg1 : i64, !llvm.ptr
+    %113 = arith.subi %111, %c3_i64_48 : i64
+    llvm.store %113, %arg1 : i64, !llvm.ptr
     cf.br ^bb44
   ^bb47:  // pred: ^bb48
-    %c0_i256_62 = arith.constant 0 : i256
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
-    %127 = llvm.getelementptr %arg2[%126] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_63 = arith.constant 1 : i64
-    %128 = arith.addi %126, %c1_i64_63 : i64
-    llvm.store %128, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_62, %127 : i256, !llvm.ptr
+    %c0_i256_50 = arith.constant 0 : i256
+    %114 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_50, %114 : i256, !llvm.ptr
+    %115 = llvm.getelementptr %114[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %115, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb53
   ^bb48:  // pred: ^bb50
-    %c1024_i64_64 = arith.constant 1024 : i64
-    %129 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_65 = arith.constant 1 : i64
-    %130 = arith.addi %129, %c1_i64_65 : i64
-    %131 = arith.cmpi ult, %c1024_i64_64, %130 : i64
-    %c92_i8_66 = arith.constant 92 : i8
-    cf.cond_br %131, ^bb1(%c92_i8_66 : i8), ^bb47
+    %c1024_i64_51 = arith.constant 1024 : i64
+    %116 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_52 = arith.constant 1 : i64
+    %117 = arith.addi %116, %c1_i64_52 : i64
+    llvm.store %117, %arg3 : i64, !llvm.ptr
+    %118 = arith.cmpi ult, %c1024_i64_51, %117 : i64
+    %c92_i8_53 = arith.constant 92 : i8
+    cf.cond_br %118, ^bb1(%c92_i8_53 : i8), ^bb47
   ^bb49:  // pred: ^bb43
-    %132 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_67 = arith.constant 3 : i64
+    %119 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_54 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %133 = arith.cmpi uge, %132, %c3_i64_67 : i64
-    %c80_i8_68 = arith.constant 80 : i8
-    cf.cond_br %133, ^bb50, ^bb1(%c80_i8_68 : i8)
+    %120 = arith.cmpi uge, %119, %c3_i64_54 : i64
+    %c80_i8_55 = arith.constant 80 : i8
+    cf.cond_br %120, ^bb50, ^bb1(%c80_i8_55 : i8)
   ^bb50:  // pred: ^bb49
-    %134 = arith.subi %132, %c3_i64_67 : i64
-    llvm.store %134, %arg1 : i64, !llvm.ptr
+    %121 = arith.subi %119, %c3_i64_54 : i64
+    llvm.store %121, %arg1 : i64, !llvm.ptr
     cf.br ^bb48
   ^bb51:  // pred: ^bb52
-    %c0_i256_69 = arith.constant 0 : i256
-    %135 = llvm.load %arg3 : !llvm.ptr -> i64
-    %136 = llvm.getelementptr %arg2[%135] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_70 = arith.constant 1 : i64
-    %137 = arith.addi %135, %c1_i64_70 : i64
-    llvm.store %137, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_69, %136 : i256, !llvm.ptr
+    %c0_i256_56 = arith.constant 0 : i256
+    %122 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_56, %122 : i256, !llvm.ptr
+    %123 = llvm.getelementptr %122[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %123, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb57
   ^bb52:  // pred: ^bb54
-    %c1024_i64_71 = arith.constant 1024 : i64
-    %138 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %139 = arith.addi %138, %c1_i64_72 : i64
-    %140 = arith.cmpi ult, %c1024_i64_71, %139 : i64
-    %c92_i8_73 = arith.constant 92 : i8
-    cf.cond_br %140, ^bb1(%c92_i8_73 : i8), ^bb51
+    %c1024_i64_57 = arith.constant 1024 : i64
+    %124 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_58 = arith.constant 1 : i64
+    %125 = arith.addi %124, %c1_i64_58 : i64
+    llvm.store %125, %arg3 : i64, !llvm.ptr
+    %126 = arith.cmpi ult, %c1024_i64_57, %125 : i64
+    %c92_i8_59 = arith.constant 92 : i8
+    cf.cond_br %126, ^bb1(%c92_i8_59 : i8), ^bb51
   ^bb53:  // pred: ^bb47
-    %141 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_74 = arith.constant 3 : i64
+    %127 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_60 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %142 = arith.cmpi uge, %141, %c3_i64_74 : i64
-    %c80_i8_75 = arith.constant 80 : i8
-    cf.cond_br %142, ^bb54, ^bb1(%c80_i8_75 : i8)
+    %128 = arith.cmpi uge, %127, %c3_i64_60 : i64
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %128, ^bb54, ^bb1(%c80_i8_61 : i8)
   ^bb54:  // pred: ^bb53
-    %143 = arith.subi %141, %c3_i64_74 : i64
-    llvm.store %143, %arg1 : i64, !llvm.ptr
+    %129 = arith.subi %127, %c3_i64_60 : i64
+    llvm.store %129, %arg1 : i64, !llvm.ptr
     cf.br ^bb52
   ^bb55:  // pred: ^bb56
-    %c0_i256_76 = arith.constant 0 : i256
-    %144 = llvm.load %arg3 : !llvm.ptr -> i64
-    %145 = llvm.getelementptr %arg2[%144] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_77 = arith.constant 1 : i64
-    %146 = arith.addi %144, %c1_i64_77 : i64
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_76, %145 : i256, !llvm.ptr
+    %c0_i256_62 = arith.constant 0 : i256
+    %130 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_62, %130 : i256, !llvm.ptr
+    %131 = llvm.getelementptr %130[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %131, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb61
   ^bb56:  // pred: ^bb58
-    %c1024_i64_78 = arith.constant 1024 : i64
-    %147 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %148 = arith.addi %147, %c1_i64_79 : i64
-    %149 = arith.cmpi ult, %c1024_i64_78, %148 : i64
-    %c92_i8_80 = arith.constant 92 : i8
-    cf.cond_br %149, ^bb1(%c92_i8_80 : i8), ^bb55
+    %c1024_i64_63 = arith.constant 1024 : i64
+    %132 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_64 = arith.constant 1 : i64
+    %133 = arith.addi %132, %c1_i64_64 : i64
+    llvm.store %133, %arg3 : i64, !llvm.ptr
+    %134 = arith.cmpi ult, %c1024_i64_63, %133 : i64
+    %c92_i8_65 = arith.constant 92 : i8
+    cf.cond_br %134, ^bb1(%c92_i8_65 : i8), ^bb55
   ^bb57:  // pred: ^bb51
-    %150 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_81 = arith.constant 3 : i64
+    %135 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_66 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %151 = arith.cmpi uge, %150, %c3_i64_81 : i64
-    %c80_i8_82 = arith.constant 80 : i8
-    cf.cond_br %151, ^bb58, ^bb1(%c80_i8_82 : i8)
+    %136 = arith.cmpi uge, %135, %c3_i64_66 : i64
+    %c80_i8_67 = arith.constant 80 : i8
+    cf.cond_br %136, ^bb58, ^bb1(%c80_i8_67 : i8)
   ^bb58:  // pred: ^bb57
-    %152 = arith.subi %150, %c3_i64_81 : i64
-    llvm.store %152, %arg1 : i64, !llvm.ptr
+    %137 = arith.subi %135, %c3_i64_66 : i64
+    llvm.store %137, %arg1 : i64, !llvm.ptr
     cf.br ^bb56
   ^bb59:  // pred: ^bb60
-    %153 = llvm.load %arg3 : !llvm.ptr -> i64
-    %154 = llvm.getelementptr %arg2[%153] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %155 = llvm.getelementptr %154[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %156 = llvm.load %155 : !llvm.ptr -> i256
-    %157 = llvm.load %arg3 : !llvm.ptr -> i64
-    %158 = llvm.getelementptr %arg2[%157] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_83 = arith.constant 1 : i64
-    %159 = arith.addi %157, %c1_i64_83 : i64
-    llvm.store %159, %arg3 : i64, !llvm.ptr
-    llvm.store %156, %158 : i256, !llvm.ptr
+    %138 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %139 = llvm.getelementptr %138[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %140 = llvm.load %139 : !llvm.ptr -> i256
+    %141 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %140, %141 : i256, !llvm.ptr
+    %142 = llvm.getelementptr %141[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %142, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb65
   ^bb60:  // pred: ^bb62
-    %c1024_i64_84 = arith.constant 1024 : i64
-    %160 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_85 = arith.constant 1 : i64
-    %161 = arith.addi %160, %c1_i64_85 : i64
+    %c1024_i64_68 = arith.constant 1024 : i64
+    %143 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_69 = arith.constant 1 : i64
+    %144 = arith.addi %143, %c1_i64_69 : i64
+    llvm.store %144, %arg3 : i64, !llvm.ptr
     %c5_i64 = arith.constant 5 : i64
-    %162 = arith.cmpi ult, %160, %c5_i64 : i64
-    %163 = arith.cmpi ult, %c1024_i64_84, %161 : i64
-    %164 = arith.xori %162, %163 : i1
-    %c92_i8_86 = arith.constant 92 : i8
-    cf.cond_br %164, ^bb1(%c92_i8_86 : i8), ^bb59
+    %145 = arith.cmpi ult, %143, %c5_i64 : i64
+    %146 = arith.cmpi ult, %c1024_i64_68, %144 : i64
+    %147 = arith.xori %145, %146 : i1
+    %c92_i8_70 = arith.constant 92 : i8
+    cf.cond_br %147, ^bb1(%c92_i8_70 : i8), ^bb59
   ^bb61:  // pred: ^bb55
-    %165 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_87 = arith.constant 3 : i64
+    %148 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_71 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %166 = arith.cmpi uge, %165, %c3_i64_87 : i64
-    %c80_i8_88 = arith.constant 80 : i8
-    cf.cond_br %166, ^bb62, ^bb1(%c80_i8_88 : i8)
+    %149 = arith.cmpi uge, %148, %c3_i64_71 : i64
+    %c80_i8_72 = arith.constant 80 : i8
+    cf.cond_br %149, ^bb62, ^bb1(%c80_i8_72 : i8)
   ^bb62:  // pred: ^bb61
-    %167 = arith.subi %165, %c3_i64_87 : i64
-    llvm.store %167, %arg1 : i64, !llvm.ptr
+    %150 = arith.subi %148, %c3_i64_71 : i64
+    llvm.store %150, %arg1 : i64, !llvm.ptr
     cf.br ^bb60
   ^bb63:  // pred: ^bb64
     %c65535_i256 = arith.constant 65535 : i256
-    %168 = llvm.load %arg3 : !llvm.ptr -> i64
-    %169 = llvm.getelementptr %arg2[%168] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_89 = arith.constant 1 : i64
-    %170 = arith.addi %168, %c1_i64_89 : i64
-    llvm.store %170, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256, %169 : i256, !llvm.ptr
+    %151 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256, %151 : i256, !llvm.ptr
+    %152 = llvm.getelementptr %151[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %152, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb77
   ^bb64:  // pred: ^bb66
-    %c1024_i64_90 = arith.constant 1024 : i64
-    %171 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_91 = arith.constant 1 : i64
-    %172 = arith.addi %171, %c1_i64_91 : i64
-    %173 = arith.cmpi ult, %c1024_i64_90, %172 : i64
-    %c92_i8_92 = arith.constant 92 : i8
-    cf.cond_br %173, ^bb1(%c92_i8_92 : i8), ^bb63
+    %c1024_i64_73 = arith.constant 1024 : i64
+    %153 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_74 = arith.constant 1 : i64
+    %154 = arith.addi %153, %c1_i64_74 : i64
+    llvm.store %154, %arg3 : i64, !llvm.ptr
+    %155 = arith.cmpi ult, %c1024_i64_73, %154 : i64
+    %c92_i8_75 = arith.constant 92 : i8
+    cf.cond_br %155, ^bb1(%c92_i8_75 : i8), ^bb63
   ^bb65:  // pred: ^bb59
-    %174 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_93 = arith.constant 3 : i64
+    %156 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_76 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %175 = arith.cmpi uge, %174, %c3_i64_93 : i64
-    %c80_i8_94 = arith.constant 80 : i8
-    cf.cond_br %175, ^bb66, ^bb1(%c80_i8_94 : i8)
+    %157 = arith.cmpi uge, %156, %c3_i64_76 : i64
+    %c80_i8_77 = arith.constant 80 : i8
+    cf.cond_br %157, ^bb66, ^bb1(%c80_i8_77 : i8)
   ^bb66:  // pred: ^bb65
-    %176 = arith.subi %174, %c3_i64_93 : i64
-    llvm.store %176, %arg1 : i64, !llvm.ptr
+    %158 = arith.subi %156, %c3_i64_76 : i64
+    llvm.store %158, %arg1 : i64, !llvm.ptr
     cf.br ^bb64
   ^bb67:  // pred: ^bb76
-    %177 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_95 = arith.constant 1 : i64
-    %178 = arith.subi %177, %c1_i64_95 : i64
-    %179 = llvm.getelementptr %arg2[%178] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %178, %arg3 : i64, !llvm.ptr
-    %180 = llvm.load %179 : !llvm.ptr -> i256
-    %181 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %182 = arith.subi %181, %c1_i64_96 : i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %182, %arg3 : i64, !llvm.ptr
-    %184 = llvm.load %183 : !llvm.ptr -> i256
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_97 = arith.constant 1 : i64
-    %186 = arith.subi %185, %c1_i64_97 : i64
-    %187 = llvm.getelementptr %arg2[%186] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %186, %arg3 : i64, !llvm.ptr
-    %188 = llvm.load %187 : !llvm.ptr -> i256
-    %189 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_98 = arith.constant 1 : i64
-    %190 = arith.subi %189, %c1_i64_98 : i64
-    %191 = llvm.getelementptr %arg2[%190] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %190, %arg3 : i64, !llvm.ptr
-    %192 = llvm.load %191 : !llvm.ptr -> i256
-    %193 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_99 = arith.constant 1 : i64
-    %194 = arith.subi %193, %c1_i64_99 : i64
-    %195 = llvm.getelementptr %arg2[%194] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %194, %arg3 : i64, !llvm.ptr
-    %196 = llvm.load %195 : !llvm.ptr -> i256
-    %197 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_100 = arith.constant 1 : i64
-    %198 = arith.subi %197, %c1_i64_100 : i64
-    %199 = llvm.getelementptr %arg2[%198] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %198, %arg3 : i64, !llvm.ptr
-    %200 = llvm.load %199 : !llvm.ptr -> i256
-    %c0_i256_101 = arith.constant 0 : i256
-    %c18446744073709551615_i256_102 = arith.constant 18446744073709551615 : i256
-    %201 = arith.cmpi sgt, %192, %c18446744073709551615_i256_102 : i256
-    %c84_i8_103 = arith.constant 84 : i8
-    cf.cond_br %201, ^bb1(%c84_i8_103 : i8), ^bb68
+    %159 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %160 = llvm.getelementptr %159[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %161 = llvm.load %160 : !llvm.ptr -> i256
+    llvm.store %160, %0 : !llvm.ptr, !llvm.ptr
+    %162 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %163 = llvm.getelementptr %162[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %164 = llvm.load %163 : !llvm.ptr -> i256
+    llvm.store %163, %0 : !llvm.ptr, !llvm.ptr
+    %165 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %166 = llvm.getelementptr %165[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %167 = llvm.load %166 : !llvm.ptr -> i256
+    llvm.store %166, %0 : !llvm.ptr, !llvm.ptr
+    %168 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %169 = llvm.getelementptr %168[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %170 = llvm.load %169 : !llvm.ptr -> i256
+    llvm.store %169, %0 : !llvm.ptr, !llvm.ptr
+    %171 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %172 = llvm.getelementptr %171[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %173 = llvm.load %172 : !llvm.ptr -> i256
+    llvm.store %172, %0 : !llvm.ptr, !llvm.ptr
+    %174 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %175 = llvm.getelementptr %174[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %176 = llvm.load %175 : !llvm.ptr -> i256
+    llvm.store %175, %0 : !llvm.ptr, !llvm.ptr
+    %c0_i256_78 = arith.constant 0 : i256
+    %c18446744073709551615_i256_79 = arith.constant 18446744073709551615 : i256
+    %177 = arith.cmpi sgt, %170, %c18446744073709551615_i256_79 : i256
+    %c84_i8_80 = arith.constant 84 : i8
+    cf.cond_br %177, ^bb1(%c84_i8_80 : i8), ^bb68
   ^bb68:  // pred: ^bb67
-    %202 = arith.trunci %192 : i256 to i64
-    %c0_i64_104 = arith.constant 0 : i64
-    %203 = arith.cmpi slt, %202, %c0_i64_104 : i64
-    %c84_i8_105 = arith.constant 84 : i8
-    cf.cond_br %203, ^bb1(%c84_i8_105 : i8), ^bb69
+    %178 = arith.trunci %170 : i256 to i64
+    %c0_i64_81 = arith.constant 0 : i64
+    %179 = arith.cmpi slt, %178, %c0_i64_81 : i64
+    %c84_i8_82 = arith.constant 84 : i8
+    cf.cond_br %179, ^bb1(%c84_i8_82 : i8), ^bb69
   ^bb69:  // pred: ^bb68
-    %c0_i64_106 = arith.constant 0 : i64
-    %204 = arith.cmpi ne, %202, %c0_i64_106 : i64
-    cf.cond_br %204, ^bb148, ^bb70
+    %c0_i64_83 = arith.constant 0 : i64
+    %180 = arith.cmpi ne, %178, %c0_i64_83 : i64
+    cf.cond_br %180, ^bb148, ^bb70
   ^bb70:  // 2 preds: ^bb69, ^bb152
-    %c18446744073709551615_i256_107 = arith.constant 18446744073709551615 : i256
-    %205 = arith.cmpi sgt, %200, %c18446744073709551615_i256_107 : i256
-    %c84_i8_108 = arith.constant 84 : i8
-    cf.cond_br %205, ^bb1(%c84_i8_108 : i8), ^bb71
+    %c18446744073709551615_i256_84 = arith.constant 18446744073709551615 : i256
+    %181 = arith.cmpi sgt, %176, %c18446744073709551615_i256_84 : i256
+    %c84_i8_85 = arith.constant 84 : i8
+    cf.cond_br %181, ^bb1(%c84_i8_85 : i8), ^bb71
   ^bb71:  // pred: ^bb70
-    %206 = arith.trunci %200 : i256 to i64
-    %c0_i64_109 = arith.constant 0 : i64
-    %207 = arith.cmpi slt, %206, %c0_i64_109 : i64
-    %c84_i8_110 = arith.constant 84 : i8
-    cf.cond_br %207, ^bb1(%c84_i8_110 : i8), ^bb72
+    %182 = arith.trunci %176 : i256 to i64
+    %c0_i64_86 = arith.constant 0 : i64
+    %183 = arith.cmpi slt, %182, %c0_i64_86 : i64
+    %c84_i8_87 = arith.constant 84 : i8
+    cf.cond_br %183, ^bb1(%c84_i8_87 : i8), ^bb72
   ^bb72:  // pred: ^bb71
-    %c0_i64_111 = arith.constant 0 : i64
-    %208 = arith.cmpi ne, %206, %c0_i64_111 : i64
-    cf.cond_br %208, ^bb156, ^bb73
+    %c0_i64_88 = arith.constant 0 : i64
+    %184 = arith.cmpi ne, %182, %c0_i64_88 : i64
+    cf.cond_br %184, ^bb156, ^bb73
   ^bb73:  // 2 preds: ^bb72, ^bb160
-    %209 = arith.trunci %188 : i256 to i64
-    %210 = arith.trunci %196 : i256 to i64
-    %211 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_112 = arith.constant 1 : i256
-    %212 = llvm.alloca %c1_i256_112 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_101, %212 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_113 = arith.constant 1 : i256
-    %213 = llvm.alloca %c1_i256_113 x i256 : (i256) -> !llvm.ptr
-    llvm.store %180, %213 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_114 = arith.constant 1 : i256
-    %214 = llvm.alloca %c1_i256_114 x i256 : (i256) -> !llvm.ptr
-    llvm.store %184, %214 {alignment = 1 : i64} : i256, !llvm.ptr
+    %185 = arith.trunci %167 : i256 to i64
+    %186 = arith.trunci %173 : i256 to i64
+    %187 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_89 = arith.constant 1 : i256
+    %188 = llvm.alloca %c1_i256_89 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_78, %188 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_90 = arith.constant 1 : i256
+    %189 = llvm.alloca %c1_i256_90 x i256 : (i256) -> !llvm.ptr
+    llvm.store %161, %189 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_91 = arith.constant 1 : i256
+    %190 = llvm.alloca %c1_i256_91 x i256 : (i256) -> !llvm.ptr
+    llvm.store %164, %190 {alignment = 1 : i64} : i256, !llvm.ptr
     %c2_i8 = arith.constant 2 : i8
-    %215 = call @dora_fn_call(%arg0, %213, %214, %212, %209, %202, %210, %206, %211, %c2_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %216 = llvm.getelementptr %215[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %217 = llvm.load %216 : !llvm.ptr -> i8
-    %218 = llvm.getelementptr %215[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %219 = llvm.load %218 : !llvm.ptr -> i8
-    %c0_i8_115 = arith.constant 0 : i8
-    %220 = arith.cmpi ne, %219, %c0_i8_115 : i8
-    cf.cond_br %220, ^bb1(%219 : i8), ^bb74
+    %191 = call @dora_fn_call(%arg0, %189, %190, %188, %185, %178, %186, %182, %187, %c2_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %192 = llvm.getelementptr %191[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %193 = llvm.load %192 : !llvm.ptr -> i8
+    %194 = llvm.getelementptr %191[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %195 = llvm.load %194 : !llvm.ptr -> i8
+    %c0_i8_92 = arith.constant 0 : i8
+    %196 = arith.cmpi ne, %195, %c0_i8_92 : i8
+    cf.cond_br %196, ^bb1(%195 : i8), ^bb74
   ^bb74:  // pred: ^bb73
-    %221 = llvm.getelementptr %215[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %222 = llvm.load %221 : !llvm.ptr -> i64
-    %223 = llvm.load %arg1 : !llvm.ptr -> i64
-    %224 = arith.cmpi ult, %223, %222 : i64
-    scf.if %224 {
+    %197 = llvm.getelementptr %191[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %198 = llvm.load %197 : !llvm.ptr -> i64
+    %199 = llvm.load %arg1 : !llvm.ptr -> i64
+    %200 = arith.cmpi ult, %199, %198 : i64
+    scf.if %200 {
     } else {
-      %571 = arith.subi %223, %222 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %199, %198 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_116 = arith.constant 80 : i8
-    cf.cond_br %224, ^bb1(%c80_i8_116 : i8), ^bb75
+    %c80_i8_93 = arith.constant 80 : i8
+    cf.cond_br %200, ^bb1(%c80_i8_93 : i8), ^bb75
   ^bb75:  // pred: ^bb74
-    %225 = arith.extui %217 : i8 to i256
-    %226 = llvm.load %arg3 : !llvm.ptr -> i64
-    %227 = llvm.getelementptr %arg2[%226] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_117 = arith.constant 1 : i64
-    %228 = arith.addi %226, %c1_i64_117 : i64
-    llvm.store %228, %arg3 : i64, !llvm.ptr
-    llvm.store %225, %227 : i256, !llvm.ptr
+    %201 = arith.extui %193 : i8 to i256
+    %202 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %201, %202 : i256, !llvm.ptr
+    %203 = llvm.getelementptr %202[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %203, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb81
   ^bb76:  // pred: ^bb78
-    %c1024_i64_118 = arith.constant 1024 : i64
-    %229 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_94 = arith.constant 1024 : i64
+    %204 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %230 = arith.addi %229, %c-5_i64 : i64
+    %205 = arith.addi %204, %c-5_i64 : i64
+    llvm.store %205, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %231 = arith.cmpi ult, %229, %c6_i64 : i64
-    %c91_i8_119 = arith.constant 91 : i8
-    cf.cond_br %231, ^bb1(%c91_i8_119 : i8), ^bb67
+    %206 = arith.cmpi ult, %204, %c6_i64 : i64
+    %c91_i8_95 = arith.constant 91 : i8
+    cf.cond_br %206, ^bb1(%c91_i8_95 : i8), ^bb67
   ^bb77:  // pred: ^bb63
-    %232 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_120 = arith.constant 0 : i64
+    %207 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_96 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %233 = arith.cmpi uge, %232, %c0_i64_120 : i64
-    %c80_i8_121 = arith.constant 80 : i8
-    cf.cond_br %233, ^bb78, ^bb1(%c80_i8_121 : i8)
+    %208 = arith.cmpi uge, %207, %c0_i64_96 : i64
+    %c80_i8_97 = arith.constant 80 : i8
+    cf.cond_br %208, ^bb78, ^bb1(%c80_i8_97 : i8)
   ^bb78:  // pred: ^bb77
-    %234 = arith.subi %232, %c0_i64_120 : i64
-    llvm.store %234, %arg1 : i64, !llvm.ptr
+    %209 = arith.subi %207, %c0_i64_96 : i64
+    llvm.store %209, %arg1 : i64, !llvm.ptr
     cf.br ^bb76
   ^bb79:  // pred: ^bb80
-    %c1_i256_122 = arith.constant 1 : i256
-    %235 = llvm.load %arg3 : !llvm.ptr -> i64
-    %236 = llvm.getelementptr %arg2[%235] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_123 = arith.constant 1 : i64
-    %237 = arith.addi %235, %c1_i64_123 : i64
-    llvm.store %237, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_122, %236 : i256, !llvm.ptr
+    %c1_i256_98 = arith.constant 1 : i256
+    %210 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_98, %210 : i256, !llvm.ptr
+    %211 = llvm.getelementptr %210[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %211, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb85
   ^bb80:  // pred: ^bb82
-    %c1024_i64_124 = arith.constant 1024 : i64
-    %238 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_125 = arith.constant 1 : i64
-    %239 = arith.addi %238, %c1_i64_125 : i64
-    %240 = arith.cmpi ult, %c1024_i64_124, %239 : i64
-    %c92_i8_126 = arith.constant 92 : i8
-    cf.cond_br %240, ^bb1(%c92_i8_126 : i8), ^bb79
+    %c1024_i64_99 = arith.constant 1024 : i64
+    %212 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_100 = arith.constant 1 : i64
+    %213 = arith.addi %212, %c1_i64_100 : i64
+    llvm.store %213, %arg3 : i64, !llvm.ptr
+    %214 = arith.cmpi ult, %c1024_i64_99, %213 : i64
+    %c92_i8_101 = arith.constant 92 : i8
+    cf.cond_br %214, ^bb1(%c92_i8_101 : i8), ^bb79
   ^bb81:  // pred: ^bb75
-    %241 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_127 = arith.constant 3 : i64
+    %215 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_102 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %242 = arith.cmpi uge, %241, %c3_i64_127 : i64
-    %c80_i8_128 = arith.constant 80 : i8
-    cf.cond_br %242, ^bb82, ^bb1(%c80_i8_128 : i8)
+    %216 = arith.cmpi uge, %215, %c3_i64_102 : i64
+    %c80_i8_103 = arith.constant 80 : i8
+    cf.cond_br %216, ^bb82, ^bb1(%c80_i8_103 : i8)
   ^bb82:  // pred: ^bb81
-    %243 = arith.subi %241, %c3_i64_127 : i64
-    llvm.store %243, %arg1 : i64, !llvm.ptr
+    %217 = arith.subi %215, %c3_i64_102 : i64
+    llvm.store %217, %arg1 : i64, !llvm.ptr
     cf.br ^bb80
   ^bb83:  // pred: ^bb84
-    %c0_i256_129 = arith.constant 0 : i256
-    %244 = llvm.load %arg3 : !llvm.ptr -> i64
-    %245 = llvm.getelementptr %arg2[%244] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_130 = arith.constant 1 : i64
-    %246 = arith.addi %244, %c1_i64_130 : i64
-    llvm.store %246, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_129, %245 : i256, !llvm.ptr
+    %c0_i256_104 = arith.constant 0 : i256
+    %218 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_104, %218 : i256, !llvm.ptr
+    %219 = llvm.getelementptr %218[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %219, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb91
   ^bb84:  // pred: ^bb86
-    %c1024_i64_131 = arith.constant 1024 : i64
-    %247 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_132 = arith.constant 1 : i64
-    %248 = arith.addi %247, %c1_i64_132 : i64
-    %249 = arith.cmpi ult, %c1024_i64_131, %248 : i64
-    %c92_i8_133 = arith.constant 92 : i8
-    cf.cond_br %249, ^bb1(%c92_i8_133 : i8), ^bb83
+    %c1024_i64_105 = arith.constant 1024 : i64
+    %220 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_106 = arith.constant 1 : i64
+    %221 = arith.addi %220, %c1_i64_106 : i64
+    llvm.store %221, %arg3 : i64, !llvm.ptr
+    %222 = arith.cmpi ult, %c1024_i64_105, %221 : i64
+    %c92_i8_107 = arith.constant 92 : i8
+    cf.cond_br %222, ^bb1(%c92_i8_107 : i8), ^bb83
   ^bb85:  // pred: ^bb79
-    %250 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_134 = arith.constant 3 : i64
+    %223 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_108 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %251 = arith.cmpi uge, %250, %c3_i64_134 : i64
-    %c80_i8_135 = arith.constant 80 : i8
-    cf.cond_br %251, ^bb86, ^bb1(%c80_i8_135 : i8)
+    %224 = arith.cmpi uge, %223, %c3_i64_108 : i64
+    %c80_i8_109 = arith.constant 80 : i8
+    cf.cond_br %224, ^bb86, ^bb1(%c80_i8_109 : i8)
   ^bb86:  // pred: ^bb85
-    %252 = arith.subi %250, %c3_i64_134 : i64
-    llvm.store %252, %arg1 : i64, !llvm.ptr
+    %225 = arith.subi %223, %c3_i64_108 : i64
+    llvm.store %225, %arg1 : i64, !llvm.ptr
     cf.br ^bb84
   ^bb87:  // pred: ^bb90
-    %253 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_136 = arith.constant 1 : i64
-    %254 = arith.subi %253, %c1_i64_136 : i64
-    %255 = llvm.getelementptr %arg2[%254] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %254, %arg3 : i64, !llvm.ptr
-    %256 = llvm.load %255 : !llvm.ptr -> i256
-    %257 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_137 = arith.constant 1 : i64
-    %258 = arith.subi %257, %c1_i64_137 : i64
-    %259 = llvm.getelementptr %arg2[%258] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %258, %arg3 : i64, !llvm.ptr
-    %260 = llvm.load %259 : !llvm.ptr -> i256
-    %c1_i256_138 = arith.constant 1 : i256
-    %261 = llvm.alloca %c1_i256_138 x i256 : (i256) -> !llvm.ptr
-    llvm.store %256, %261 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_139 = arith.constant 1 : i256
-    %262 = llvm.alloca %c1_i256_139 x i256 : (i256) -> !llvm.ptr
-    llvm.store %260, %262 {alignment = 1 : i64} : i256, !llvm.ptr
-    %263 = llvm.load %arg1 : !llvm.ptr -> i64
-    %264 = call @dora_fn_sstore(%arg0, %261, %262, %263) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %265 = llvm.getelementptr %264[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %266 = llvm.load %265 : !llvm.ptr -> i8
-    %c0_i8_140 = arith.constant 0 : i8
-    %267 = arith.cmpi ne, %266, %c0_i8_140 : i8
-    cf.cond_br %267, ^bb1(%266 : i8), ^bb88
+    %226 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %227 = llvm.getelementptr %226[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %228 = llvm.load %227 : !llvm.ptr -> i256
+    llvm.store %227, %0 : !llvm.ptr, !llvm.ptr
+    %229 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    llvm.store %230, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_110 = arith.constant 1 : i256
+    %232 = llvm.alloca %c1_i256_110 x i256 : (i256) -> !llvm.ptr
+    llvm.store %228, %232 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_111 = arith.constant 1 : i256
+    %233 = llvm.alloca %c1_i256_111 x i256 : (i256) -> !llvm.ptr
+    llvm.store %231, %233 {alignment = 1 : i64} : i256, !llvm.ptr
+    %234 = llvm.load %arg1 : !llvm.ptr -> i64
+    %235 = call @dora_fn_sstore(%arg0, %232, %233, %234) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %236 = llvm.getelementptr %235[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %237 = llvm.load %236 : !llvm.ptr -> i8
+    %c0_i8_112 = arith.constant 0 : i8
+    %238 = arith.cmpi ne, %237, %c0_i8_112 : i8
+    cf.cond_br %238, ^bb1(%237 : i8), ^bb88
   ^bb88:  // pred: ^bb87
-    %268 = llvm.getelementptr %264[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %269 = llvm.load %268 : !llvm.ptr -> i64
-    %270 = llvm.load %arg1 : !llvm.ptr -> i64
-    %271 = arith.cmpi ult, %270, %269 : i64
-    scf.if %271 {
+    %239 = llvm.getelementptr %235[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %240 = llvm.load %239 : !llvm.ptr -> i64
+    %241 = llvm.load %arg1 : !llvm.ptr -> i64
+    %242 = arith.cmpi ult, %241, %240 : i64
+    scf.if %242 {
     } else {
-      %571 = arith.subi %270, %269 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %241, %240 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_141 = arith.constant 80 : i8
-    cf.cond_br %271, ^bb1(%c80_i8_141 : i8), ^bb89
+    %c80_i8_113 = arith.constant 80 : i8
+    cf.cond_br %242, ^bb1(%c80_i8_113 : i8), ^bb89
   ^bb89:  // pred: ^bb88
     cf.br ^bb95
   ^bb90:  // pred: ^bb92
-    %c1024_i64_142 = arith.constant 1024 : i64
-    %272 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_143 = arith.constant -2 : i64
-    %273 = arith.addi %272, %c-2_i64_143 : i64
-    %c2_i64_144 = arith.constant 2 : i64
-    %274 = arith.cmpi ult, %272, %c2_i64_144 : i64
-    %c91_i8_145 = arith.constant 91 : i8
-    cf.cond_br %274, ^bb1(%c91_i8_145 : i8), ^bb87
+    %c1024_i64_114 = arith.constant 1024 : i64
+    %243 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_115 = arith.constant -2 : i64
+    %244 = arith.addi %243, %c-2_i64_115 : i64
+    llvm.store %244, %arg3 : i64, !llvm.ptr
+    %c2_i64_116 = arith.constant 2 : i64
+    %245 = arith.cmpi ult, %243, %c2_i64_116 : i64
+    %c91_i8_117 = arith.constant 91 : i8
+    cf.cond_br %245, ^bb1(%c91_i8_117 : i8), ^bb87
   ^bb91:  // pred: ^bb83
-    %275 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_146 = arith.constant 0 : i64
+    %246 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_118 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %276 = arith.cmpi uge, %275, %c0_i64_146 : i64
-    %c80_i8_147 = arith.constant 80 : i8
-    cf.cond_br %276, ^bb92, ^bb1(%c80_i8_147 : i8)
+    %247 = arith.cmpi uge, %246, %c0_i64_118 : i64
+    %c80_i8_119 = arith.constant 80 : i8
+    cf.cond_br %247, ^bb92, ^bb1(%c80_i8_119 : i8)
   ^bb92:  // pred: ^bb91
-    %277 = arith.subi %275, %c0_i64_146 : i64
-    llvm.store %277, %arg1 : i64, !llvm.ptr
+    %248 = arith.subi %246, %c0_i64_118 : i64
+    llvm.store %248, %arg1 : i64, !llvm.ptr
     cf.br ^bb90
   ^bb93:  // pred: ^bb94
-    %c0_i256_148 = arith.constant 0 : i256
-    %278 = llvm.load %arg3 : !llvm.ptr -> i64
-    %279 = llvm.getelementptr %arg2[%278] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_149 = arith.constant 1 : i64
-    %280 = arith.addi %278, %c1_i64_149 : i64
-    llvm.store %280, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_148, %279 : i256, !llvm.ptr
+    %c0_i256_120 = arith.constant 0 : i256
+    %249 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_120, %249 : i256, !llvm.ptr
+    %250 = llvm.getelementptr %249[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %250, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb99
   ^bb94:  // pred: ^bb96
-    %c1024_i64_150 = arith.constant 1024 : i64
-    %281 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_151 = arith.constant 1 : i64
-    %282 = arith.addi %281, %c1_i64_151 : i64
-    %283 = arith.cmpi ult, %c1024_i64_150, %282 : i64
-    %c92_i8_152 = arith.constant 92 : i8
-    cf.cond_br %283, ^bb1(%c92_i8_152 : i8), ^bb93
+    %c1024_i64_121 = arith.constant 1024 : i64
+    %251 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_122 = arith.constant 1 : i64
+    %252 = arith.addi %251, %c1_i64_122 : i64
+    llvm.store %252, %arg3 : i64, !llvm.ptr
+    %253 = arith.cmpi ult, %c1024_i64_121, %252 : i64
+    %c92_i8_123 = arith.constant 92 : i8
+    cf.cond_br %253, ^bb1(%c92_i8_123 : i8), ^bb93
   ^bb95:  // pred: ^bb89
-    %284 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_153 = arith.constant 3 : i64
+    %254 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_124 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %285 = arith.cmpi uge, %284, %c3_i64_153 : i64
-    %c80_i8_154 = arith.constant 80 : i8
-    cf.cond_br %285, ^bb96, ^bb1(%c80_i8_154 : i8)
+    %255 = arith.cmpi uge, %254, %c3_i64_124 : i64
+    %c80_i8_125 = arith.constant 80 : i8
+    cf.cond_br %255, ^bb96, ^bb1(%c80_i8_125 : i8)
   ^bb96:  // pred: ^bb95
-    %286 = arith.subi %284, %c3_i64_153 : i64
-    llvm.store %286, %arg1 : i64, !llvm.ptr
+    %256 = arith.subi %254, %c3_i64_124 : i64
+    llvm.store %256, %arg1 : i64, !llvm.ptr
     cf.br ^bb94
   ^bb97:  // pred: ^bb98
-    %c0_i256_155 = arith.constant 0 : i256
-    %287 = llvm.load %arg3 : !llvm.ptr -> i64
-    %288 = llvm.getelementptr %arg2[%287] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_156 = arith.constant 1 : i64
-    %289 = arith.addi %287, %c1_i64_156 : i64
-    llvm.store %289, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_155, %288 : i256, !llvm.ptr
+    %c0_i256_126 = arith.constant 0 : i256
+    %257 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_126, %257 : i256, !llvm.ptr
+    %258 = llvm.getelementptr %257[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %258, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb103
   ^bb98:  // pred: ^bb100
-    %c1024_i64_157 = arith.constant 1024 : i64
-    %290 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_158 = arith.constant 1 : i64
-    %291 = arith.addi %290, %c1_i64_158 : i64
-    %292 = arith.cmpi ult, %c1024_i64_157, %291 : i64
-    %c92_i8_159 = arith.constant 92 : i8
-    cf.cond_br %292, ^bb1(%c92_i8_159 : i8), ^bb97
+    %c1024_i64_127 = arith.constant 1024 : i64
+    %259 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_128 = arith.constant 1 : i64
+    %260 = arith.addi %259, %c1_i64_128 : i64
+    llvm.store %260, %arg3 : i64, !llvm.ptr
+    %261 = arith.cmpi ult, %c1024_i64_127, %260 : i64
+    %c92_i8_129 = arith.constant 92 : i8
+    cf.cond_br %261, ^bb1(%c92_i8_129 : i8), ^bb97
   ^bb99:  // pred: ^bb93
-    %293 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_160 = arith.constant 3 : i64
+    %262 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_130 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %294 = arith.cmpi uge, %293, %c3_i64_160 : i64
-    %c80_i8_161 = arith.constant 80 : i8
-    cf.cond_br %294, ^bb100, ^bb1(%c80_i8_161 : i8)
+    %263 = arith.cmpi uge, %262, %c3_i64_130 : i64
+    %c80_i8_131 = arith.constant 80 : i8
+    cf.cond_br %263, ^bb100, ^bb1(%c80_i8_131 : i8)
   ^bb100:  // pred: ^bb99
-    %295 = arith.subi %293, %c3_i64_160 : i64
-    llvm.store %295, %arg1 : i64, !llvm.ptr
+    %264 = arith.subi %262, %c3_i64_130 : i64
+    llvm.store %264, %arg1 : i64, !llvm.ptr
     cf.br ^bb98
   ^bb101:  // pred: ^bb102
     %c32_i256 = arith.constant 32 : i256
-    %296 = llvm.load %arg3 : !llvm.ptr -> i64
-    %297 = llvm.getelementptr %arg2[%296] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_162 = arith.constant 1 : i64
-    %298 = arith.addi %296, %c1_i64_162 : i64
-    llvm.store %298, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %297 : i256, !llvm.ptr
+    %265 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %265 : i256, !llvm.ptr
+    %266 = llvm.getelementptr %265[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %266, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb107
   ^bb102:  // pred: ^bb104
-    %c1024_i64_163 = arith.constant 1024 : i64
-    %299 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_164 = arith.constant 1 : i64
-    %300 = arith.addi %299, %c1_i64_164 : i64
-    %301 = arith.cmpi ult, %c1024_i64_163, %300 : i64
-    %c92_i8_165 = arith.constant 92 : i8
-    cf.cond_br %301, ^bb1(%c92_i8_165 : i8), ^bb101
+    %c1024_i64_132 = arith.constant 1024 : i64
+    %267 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_133 = arith.constant 1 : i64
+    %268 = arith.addi %267, %c1_i64_133 : i64
+    llvm.store %268, %arg3 : i64, !llvm.ptr
+    %269 = arith.cmpi ult, %c1024_i64_132, %268 : i64
+    %c92_i8_134 = arith.constant 92 : i8
+    cf.cond_br %269, ^bb1(%c92_i8_134 : i8), ^bb101
   ^bb103:  // pred: ^bb97
-    %302 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_166 = arith.constant 3 : i64
+    %270 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_135 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %303 = arith.cmpi uge, %302, %c3_i64_166 : i64
-    %c80_i8_167 = arith.constant 80 : i8
-    cf.cond_br %303, ^bb104, ^bb1(%c80_i8_167 : i8)
+    %271 = arith.cmpi uge, %270, %c3_i64_135 : i64
+    %c80_i8_136 = arith.constant 80 : i8
+    cf.cond_br %271, ^bb104, ^bb1(%c80_i8_136 : i8)
   ^bb104:  // pred: ^bb103
-    %304 = arith.subi %302, %c3_i64_166 : i64
-    llvm.store %304, %arg1 : i64, !llvm.ptr
+    %272 = arith.subi %270, %c3_i64_135 : i64
+    llvm.store %272, %arg1 : i64, !llvm.ptr
     cf.br ^bb102
   ^bb105:  // pred: ^bb106
-    %c0_i256_168 = arith.constant 0 : i256
-    %305 = llvm.load %arg3 : !llvm.ptr -> i64
-    %306 = llvm.getelementptr %arg2[%305] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_169 = arith.constant 1 : i64
-    %307 = arith.addi %305, %c1_i64_169 : i64
-    llvm.store %307, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_168, %306 : i256, !llvm.ptr
+    %c0_i256_137 = arith.constant 0 : i256
+    %273 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_137, %273 : i256, !llvm.ptr
+    %274 = llvm.getelementptr %273[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %274, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb111
   ^bb106:  // pred: ^bb108
-    %c1024_i64_170 = arith.constant 1024 : i64
-    %308 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_171 = arith.constant 1 : i64
-    %309 = arith.addi %308, %c1_i64_171 : i64
-    %310 = arith.cmpi ult, %c1024_i64_170, %309 : i64
-    %c92_i8_172 = arith.constant 92 : i8
-    cf.cond_br %310, ^bb1(%c92_i8_172 : i8), ^bb105
+    %c1024_i64_138 = arith.constant 1024 : i64
+    %275 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_139 = arith.constant 1 : i64
+    %276 = arith.addi %275, %c1_i64_139 : i64
+    llvm.store %276, %arg3 : i64, !llvm.ptr
+    %277 = arith.cmpi ult, %c1024_i64_138, %276 : i64
+    %c92_i8_140 = arith.constant 92 : i8
+    cf.cond_br %277, ^bb1(%c92_i8_140 : i8), ^bb105
   ^bb107:  // pred: ^bb101
-    %311 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_173 = arith.constant 3 : i64
+    %278 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_141 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %312 = arith.cmpi uge, %311, %c3_i64_173 : i64
-    %c80_i8_174 = arith.constant 80 : i8
-    cf.cond_br %312, ^bb108, ^bb1(%c80_i8_174 : i8)
+    %279 = arith.cmpi uge, %278, %c3_i64_141 : i64
+    %c80_i8_142 = arith.constant 80 : i8
+    cf.cond_br %279, ^bb108, ^bb1(%c80_i8_142 : i8)
   ^bb108:  // pred: ^bb107
-    %313 = arith.subi %311, %c3_i64_173 : i64
-    llvm.store %313, %arg1 : i64, !llvm.ptr
+    %280 = arith.subi %278, %c3_i64_141 : i64
+    llvm.store %280, %arg1 : i64, !llvm.ptr
     cf.br ^bb106
   ^bb109:  // pred: ^bb110
-    %314 = llvm.load %arg3 : !llvm.ptr -> i64
-    %315 = llvm.getelementptr %arg2[%314] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %316 = llvm.getelementptr %315[-6] : (!llvm.ptr) -> !llvm.ptr, i256
-    %317 = llvm.load %316 : !llvm.ptr -> i256
-    %318 = llvm.load %arg3 : !llvm.ptr -> i64
-    %319 = llvm.getelementptr %arg2[%318] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_175 = arith.constant 1 : i64
-    %320 = arith.addi %318, %c1_i64_175 : i64
-    llvm.store %320, %arg3 : i64, !llvm.ptr
-    llvm.store %317, %319 : i256, !llvm.ptr
+    %281 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %282 = llvm.getelementptr %281[-6] : (!llvm.ptr) -> !llvm.ptr, i256
+    %283 = llvm.load %282 : !llvm.ptr -> i256
+    %284 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %283, %284 : i256, !llvm.ptr
+    %285 = llvm.getelementptr %284[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %285, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb115
   ^bb110:  // pred: ^bb112
-    %c1024_i64_176 = arith.constant 1024 : i64
-    %321 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_177 = arith.constant 1 : i64
-    %322 = arith.addi %321, %c1_i64_177 : i64
-    %c6_i64_178 = arith.constant 6 : i64
-    %323 = arith.cmpi ult, %321, %c6_i64_178 : i64
-    %324 = arith.cmpi ult, %c1024_i64_176, %322 : i64
-    %325 = arith.xori %323, %324 : i1
-    %c92_i8_179 = arith.constant 92 : i8
-    cf.cond_br %325, ^bb1(%c92_i8_179 : i8), ^bb109
+    %c1024_i64_143 = arith.constant 1024 : i64
+    %286 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_144 = arith.constant 1 : i64
+    %287 = arith.addi %286, %c1_i64_144 : i64
+    llvm.store %287, %arg3 : i64, !llvm.ptr
+    %c6_i64_145 = arith.constant 6 : i64
+    %288 = arith.cmpi ult, %286, %c6_i64_145 : i64
+    %289 = arith.cmpi ult, %c1024_i64_143, %287 : i64
+    %290 = arith.xori %288, %289 : i1
+    %c92_i8_146 = arith.constant 92 : i8
+    cf.cond_br %290, ^bb1(%c92_i8_146 : i8), ^bb109
   ^bb111:  // pred: ^bb105
-    %326 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_180 = arith.constant 3 : i64
+    %291 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_147 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %327 = arith.cmpi uge, %326, %c3_i64_180 : i64
-    %c80_i8_181 = arith.constant 80 : i8
-    cf.cond_br %327, ^bb112, ^bb1(%c80_i8_181 : i8)
+    %292 = arith.cmpi uge, %291, %c3_i64_147 : i64
+    %c80_i8_148 = arith.constant 80 : i8
+    cf.cond_br %292, ^bb112, ^bb1(%c80_i8_148 : i8)
   ^bb112:  // pred: ^bb111
-    %328 = arith.subi %326, %c3_i64_180 : i64
-    llvm.store %328, %arg1 : i64, !llvm.ptr
+    %293 = arith.subi %291, %c3_i64_147 : i64
+    llvm.store %293, %arg1 : i64, !llvm.ptr
     cf.br ^bb110
   ^bb113:  // pred: ^bb114
-    %c65535_i256_182 = arith.constant 65535 : i256
-    %329 = llvm.load %arg3 : !llvm.ptr -> i64
-    %330 = llvm.getelementptr %arg2[%329] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_183 = arith.constant 1 : i64
-    %331 = arith.addi %329, %c1_i64_183 : i64
-    llvm.store %331, %arg3 : i64, !llvm.ptr
-    llvm.store %c65535_i256_182, %330 : i256, !llvm.ptr
+    %c65535_i256_149 = arith.constant 65535 : i256
+    %294 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c65535_i256_149, %294 : i256, !llvm.ptr
+    %295 = llvm.getelementptr %294[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %295, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb127
   ^bb114:  // pred: ^bb116
-    %c1024_i64_184 = arith.constant 1024 : i64
-    %332 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_185 = arith.constant 1 : i64
-    %333 = arith.addi %332, %c1_i64_185 : i64
-    %334 = arith.cmpi ult, %c1024_i64_184, %333 : i64
-    %c92_i8_186 = arith.constant 92 : i8
-    cf.cond_br %334, ^bb1(%c92_i8_186 : i8), ^bb113
+    %c1024_i64_150 = arith.constant 1024 : i64
+    %296 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_151 = arith.constant 1 : i64
+    %297 = arith.addi %296, %c1_i64_151 : i64
+    llvm.store %297, %arg3 : i64, !llvm.ptr
+    %298 = arith.cmpi ult, %c1024_i64_150, %297 : i64
+    %c92_i8_152 = arith.constant 92 : i8
+    cf.cond_br %298, ^bb1(%c92_i8_152 : i8), ^bb113
   ^bb115:  // pred: ^bb109
-    %335 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_187 = arith.constant 3 : i64
+    %299 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_153 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %336 = arith.cmpi uge, %335, %c3_i64_187 : i64
-    %c80_i8_188 = arith.constant 80 : i8
-    cf.cond_br %336, ^bb116, ^bb1(%c80_i8_188 : i8)
+    %300 = arith.cmpi uge, %299, %c3_i64_153 : i64
+    %c80_i8_154 = arith.constant 80 : i8
+    cf.cond_br %300, ^bb116, ^bb1(%c80_i8_154 : i8)
   ^bb116:  // pred: ^bb115
-    %337 = arith.subi %335, %c3_i64_187 : i64
-    llvm.store %337, %arg1 : i64, !llvm.ptr
+    %301 = arith.subi %299, %c3_i64_153 : i64
+    llvm.store %301, %arg1 : i64, !llvm.ptr
     cf.br ^bb114
   ^bb117:  // pred: ^bb126
-    %338 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_189 = arith.constant 1 : i64
-    %339 = arith.subi %338, %c1_i64_189 : i64
-    %340 = llvm.getelementptr %arg2[%339] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %339, %arg3 : i64, !llvm.ptr
-    %341 = llvm.load %340 : !llvm.ptr -> i256
-    %342 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_190 = arith.constant 1 : i64
-    %343 = arith.subi %342, %c1_i64_190 : i64
-    %344 = llvm.getelementptr %arg2[%343] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %343, %arg3 : i64, !llvm.ptr
-    %345 = llvm.load %344 : !llvm.ptr -> i256
-    %346 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_191 = arith.constant 1 : i64
-    %347 = arith.subi %346, %c1_i64_191 : i64
-    %348 = llvm.getelementptr %arg2[%347] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %347, %arg3 : i64, !llvm.ptr
-    %349 = llvm.load %348 : !llvm.ptr -> i256
-    %350 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_192 = arith.constant 1 : i64
-    %351 = arith.subi %350, %c1_i64_192 : i64
-    %352 = llvm.getelementptr %arg2[%351] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %351, %arg3 : i64, !llvm.ptr
-    %353 = llvm.load %352 : !llvm.ptr -> i256
-    %354 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_193 = arith.constant 1 : i64
-    %355 = arith.subi %354, %c1_i64_193 : i64
-    %356 = llvm.getelementptr %arg2[%355] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %355, %arg3 : i64, !llvm.ptr
-    %357 = llvm.load %356 : !llvm.ptr -> i256
-    %358 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_194 = arith.constant 1 : i64
-    %359 = arith.subi %358, %c1_i64_194 : i64
-    %360 = llvm.getelementptr %arg2[%359] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %359, %arg3 : i64, !llvm.ptr
-    %361 = llvm.load %360 : !llvm.ptr -> i256
-    %c0_i256_195 = arith.constant 0 : i256
-    %c18446744073709551615_i256_196 = arith.constant 18446744073709551615 : i256
-    %362 = arith.cmpi sgt, %353, %c18446744073709551615_i256_196 : i256
-    %c84_i8_197 = arith.constant 84 : i8
-    cf.cond_br %362, ^bb1(%c84_i8_197 : i8), ^bb118
+    %302 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %303 = llvm.getelementptr %302[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %304 = llvm.load %303 : !llvm.ptr -> i256
+    llvm.store %303, %0 : !llvm.ptr, !llvm.ptr
+    %305 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %306 = llvm.getelementptr %305[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %307 = llvm.load %306 : !llvm.ptr -> i256
+    llvm.store %306, %0 : !llvm.ptr, !llvm.ptr
+    %308 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %309 = llvm.getelementptr %308[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %310 = llvm.load %309 : !llvm.ptr -> i256
+    llvm.store %309, %0 : !llvm.ptr, !llvm.ptr
+    %311 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %312 = llvm.getelementptr %311[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %313 = llvm.load %312 : !llvm.ptr -> i256
+    llvm.store %312, %0 : !llvm.ptr, !llvm.ptr
+    %314 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %315 = llvm.getelementptr %314[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %316 = llvm.load %315 : !llvm.ptr -> i256
+    llvm.store %315, %0 : !llvm.ptr, !llvm.ptr
+    %317 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %318 = llvm.getelementptr %317[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %319 = llvm.load %318 : !llvm.ptr -> i256
+    llvm.store %318, %0 : !llvm.ptr, !llvm.ptr
+    %c0_i256_155 = arith.constant 0 : i256
+    %c18446744073709551615_i256_156 = arith.constant 18446744073709551615 : i256
+    %320 = arith.cmpi sgt, %313, %c18446744073709551615_i256_156 : i256
+    %c84_i8_157 = arith.constant 84 : i8
+    cf.cond_br %320, ^bb1(%c84_i8_157 : i8), ^bb118
   ^bb118:  // pred: ^bb117
-    %363 = arith.trunci %353 : i256 to i64
-    %c0_i64_198 = arith.constant 0 : i64
-    %364 = arith.cmpi slt, %363, %c0_i64_198 : i64
-    %c84_i8_199 = arith.constant 84 : i8
-    cf.cond_br %364, ^bb1(%c84_i8_199 : i8), ^bb119
+    %321 = arith.trunci %313 : i256 to i64
+    %c0_i64_158 = arith.constant 0 : i64
+    %322 = arith.cmpi slt, %321, %c0_i64_158 : i64
+    %c84_i8_159 = arith.constant 84 : i8
+    cf.cond_br %322, ^bb1(%c84_i8_159 : i8), ^bb119
   ^bb119:  // pred: ^bb118
-    %c0_i64_200 = arith.constant 0 : i64
-    %365 = arith.cmpi ne, %363, %c0_i64_200 : i64
-    cf.cond_br %365, ^bb164, ^bb120
+    %c0_i64_160 = arith.constant 0 : i64
+    %323 = arith.cmpi ne, %321, %c0_i64_160 : i64
+    cf.cond_br %323, ^bb164, ^bb120
   ^bb120:  // 2 preds: ^bb119, ^bb168
-    %c18446744073709551615_i256_201 = arith.constant 18446744073709551615 : i256
-    %366 = arith.cmpi sgt, %361, %c18446744073709551615_i256_201 : i256
-    %c84_i8_202 = arith.constant 84 : i8
-    cf.cond_br %366, ^bb1(%c84_i8_202 : i8), ^bb121
+    %c18446744073709551615_i256_161 = arith.constant 18446744073709551615 : i256
+    %324 = arith.cmpi sgt, %319, %c18446744073709551615_i256_161 : i256
+    %c84_i8_162 = arith.constant 84 : i8
+    cf.cond_br %324, ^bb1(%c84_i8_162 : i8), ^bb121
   ^bb121:  // pred: ^bb120
-    %367 = arith.trunci %361 : i256 to i64
-    %c0_i64_203 = arith.constant 0 : i64
-    %368 = arith.cmpi slt, %367, %c0_i64_203 : i64
-    %c84_i8_204 = arith.constant 84 : i8
-    cf.cond_br %368, ^bb1(%c84_i8_204 : i8), ^bb122
+    %325 = arith.trunci %319 : i256 to i64
+    %c0_i64_163 = arith.constant 0 : i64
+    %326 = arith.cmpi slt, %325, %c0_i64_163 : i64
+    %c84_i8_164 = arith.constant 84 : i8
+    cf.cond_br %326, ^bb1(%c84_i8_164 : i8), ^bb122
   ^bb122:  // pred: ^bb121
-    %c0_i64_205 = arith.constant 0 : i64
-    %369 = arith.cmpi ne, %367, %c0_i64_205 : i64
-    cf.cond_br %369, ^bb172, ^bb123
+    %c0_i64_165 = arith.constant 0 : i64
+    %327 = arith.cmpi ne, %325, %c0_i64_165 : i64
+    cf.cond_br %327, ^bb172, ^bb123
   ^bb123:  // 2 preds: ^bb122, ^bb176
-    %370 = arith.trunci %349 : i256 to i64
-    %371 = arith.trunci %357 : i256 to i64
-    %372 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_206 = arith.constant 1 : i256
-    %373 = llvm.alloca %c1_i256_206 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_195, %373 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_207 = arith.constant 1 : i256
-    %374 = llvm.alloca %c1_i256_207 x i256 : (i256) -> !llvm.ptr
-    llvm.store %341, %374 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_208 = arith.constant 1 : i256
-    %375 = llvm.alloca %c1_i256_208 x i256 : (i256) -> !llvm.ptr
-    llvm.store %345, %375 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c2_i8_209 = arith.constant 2 : i8
-    %376 = call @dora_fn_call(%arg0, %374, %375, %373, %370, %363, %371, %367, %372, %c2_i8_209) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %377 = llvm.getelementptr %376[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %378 = llvm.load %377 : !llvm.ptr -> i8
-    %379 = llvm.getelementptr %376[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %380 = llvm.load %379 : !llvm.ptr -> i8
-    %c0_i8_210 = arith.constant 0 : i8
-    %381 = arith.cmpi ne, %380, %c0_i8_210 : i8
-    cf.cond_br %381, ^bb1(%380 : i8), ^bb124
+    %328 = arith.trunci %310 : i256 to i64
+    %329 = arith.trunci %316 : i256 to i64
+    %330 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_166 = arith.constant 1 : i256
+    %331 = llvm.alloca %c1_i256_166 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_155, %331 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_167 = arith.constant 1 : i256
+    %332 = llvm.alloca %c1_i256_167 x i256 : (i256) -> !llvm.ptr
+    llvm.store %304, %332 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_168 = arith.constant 1 : i256
+    %333 = llvm.alloca %c1_i256_168 x i256 : (i256) -> !llvm.ptr
+    llvm.store %307, %333 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c2_i8_169 = arith.constant 2 : i8
+    %334 = call @dora_fn_call(%arg0, %332, %333, %331, %328, %321, %329, %325, %330, %c2_i8_169) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %335 = llvm.getelementptr %334[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %336 = llvm.load %335 : !llvm.ptr -> i8
+    %337 = llvm.getelementptr %334[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %338 = llvm.load %337 : !llvm.ptr -> i8
+    %c0_i8_170 = arith.constant 0 : i8
+    %339 = arith.cmpi ne, %338, %c0_i8_170 : i8
+    cf.cond_br %339, ^bb1(%338 : i8), ^bb124
   ^bb124:  // pred: ^bb123
-    %382 = llvm.getelementptr %376[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %383 = llvm.load %382 : !llvm.ptr -> i64
-    %384 = llvm.load %arg1 : !llvm.ptr -> i64
-    %385 = arith.cmpi ult, %384, %383 : i64
-    scf.if %385 {
+    %340 = llvm.getelementptr %334[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %341 = llvm.load %340 : !llvm.ptr -> i64
+    %342 = llvm.load %arg1 : !llvm.ptr -> i64
+    %343 = arith.cmpi ult, %342, %341 : i64
+    scf.if %343 {
     } else {
-      %571 = arith.subi %384, %383 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %342, %341 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_211 = arith.constant 80 : i8
-    cf.cond_br %385, ^bb1(%c80_i8_211 : i8), ^bb125
+    %c80_i8_171 = arith.constant 80 : i8
+    cf.cond_br %343, ^bb1(%c80_i8_171 : i8), ^bb125
   ^bb125:  // pred: ^bb124
-    %386 = arith.extui %378 : i8 to i256
-    %387 = llvm.load %arg3 : !llvm.ptr -> i64
-    %388 = llvm.getelementptr %arg2[%387] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_212 = arith.constant 1 : i64
-    %389 = arith.addi %387, %c1_i64_212 : i64
-    llvm.store %389, %arg3 : i64, !llvm.ptr
-    llvm.store %386, %388 : i256, !llvm.ptr
+    %344 = arith.extui %336 : i8 to i256
+    %345 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %344, %345 : i256, !llvm.ptr
+    %346 = llvm.getelementptr %345[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %346, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb129
   ^bb126:  // pred: ^bb128
-    %c1024_i64_213 = arith.constant 1024 : i64
-    %390 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-5_i64_214 = arith.constant -5 : i64
-    %391 = arith.addi %390, %c-5_i64_214 : i64
-    %c6_i64_215 = arith.constant 6 : i64
-    %392 = arith.cmpi ult, %390, %c6_i64_215 : i64
-    %c91_i8_216 = arith.constant 91 : i8
-    cf.cond_br %392, ^bb1(%c91_i8_216 : i8), ^bb117
+    %c1024_i64_172 = arith.constant 1024 : i64
+    %347 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-5_i64_173 = arith.constant -5 : i64
+    %348 = arith.addi %347, %c-5_i64_173 : i64
+    llvm.store %348, %arg3 : i64, !llvm.ptr
+    %c6_i64_174 = arith.constant 6 : i64
+    %349 = arith.cmpi ult, %347, %c6_i64_174 : i64
+    %c91_i8_175 = arith.constant 91 : i8
+    cf.cond_br %349, ^bb1(%c91_i8_175 : i8), ^bb117
   ^bb127:  // pred: ^bb113
-    %393 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_217 = arith.constant 0 : i64
+    %350 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_176 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %394 = arith.cmpi uge, %393, %c0_i64_217 : i64
-    %c80_i8_218 = arith.constant 80 : i8
-    cf.cond_br %394, ^bb128, ^bb1(%c80_i8_218 : i8)
+    %351 = arith.cmpi uge, %350, %c0_i64_176 : i64
+    %c80_i8_177 = arith.constant 80 : i8
+    cf.cond_br %351, ^bb128, ^bb1(%c80_i8_177 : i8)
   ^bb128:  // pred: ^bb127
-    %395 = arith.subi %393, %c0_i64_217 : i64
-    llvm.store %395, %arg1 : i64, !llvm.ptr
+    %352 = arith.subi %350, %c0_i64_176 : i64
+    llvm.store %352, %arg1 : i64, !llvm.ptr
     cf.br ^bb126
   ^bb129:  // pred: ^bb125
-    %c0_i64_219 = arith.constant 0 : i64
+    %c0_i64_178 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %396 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_219, %c0_i64_219, %396, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %353 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_178, %c0_i64_178, %353, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb130:  // pred: ^bb11
-    %c18446744073709551615_i256_220 = arith.constant 18446744073709551615 : i256
-    %397 = arith.cmpi sgt, %24, %c18446744073709551615_i256_220 : i256
-    %c84_i8_221 = arith.constant 84 : i8
-    cf.cond_br %397, ^bb1(%c84_i8_221 : i8), ^bb131
+    %c18446744073709551615_i256_179 = arith.constant 18446744073709551615 : i256
+    %354 = arith.cmpi sgt, %22, %c18446744073709551615_i256_179 : i256
+    %c84_i8_180 = arith.constant 84 : i8
+    cf.cond_br %354, ^bb1(%c84_i8_180 : i8), ^bb131
   ^bb131:  // pred: ^bb130
-    %398 = arith.trunci %24 : i256 to i64
-    %c0_i64_222 = arith.constant 0 : i64
-    %399 = arith.cmpi slt, %398, %c0_i64_222 : i64
-    %c84_i8_223 = arith.constant 84 : i8
-    cf.cond_br %399, ^bb1(%c84_i8_223 : i8), ^bb132
+    %355 = arith.trunci %22 : i256 to i64
+    %c0_i64_181 = arith.constant 0 : i64
+    %356 = arith.cmpi slt, %355, %c0_i64_181 : i64
+    %c84_i8_182 = arith.constant 84 : i8
+    cf.cond_br %356, ^bb1(%c84_i8_182 : i8), ^bb132
   ^bb132:  // pred: ^bb131
-    %400 = arith.addi %398, %c32_i64 : i64
-    %c0_i64_224 = arith.constant 0 : i64
-    %401 = arith.cmpi slt, %400, %c0_i64_224 : i64
-    %c84_i8_225 = arith.constant 84 : i8
-    cf.cond_br %401, ^bb1(%c84_i8_225 : i8), ^bb133
+    %357 = arith.addi %355, %c32_i64 : i64
+    %c0_i64_183 = arith.constant 0 : i64
+    %358 = arith.cmpi slt, %357, %c0_i64_183 : i64
+    %c84_i8_184 = arith.constant 84 : i8
+    cf.cond_br %358, ^bb1(%c84_i8_184 : i8), ^bb133
   ^bb133:  // pred: ^bb132
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_226 = arith.constant 32 : i64
-    %402 = arith.addi %400, %c31_i64 : i64
-    %403 = arith.divui %402, %c32_i64_226 : i64
-    %c32_i64_227 = arith.constant 32 : i64
-    %404 = arith.muli %403, %c32_i64_227 : i64
-    %405 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_228 = arith.constant 31 : i64
-    %c32_i64_229 = arith.constant 32 : i64
-    %406 = arith.addi %405, %c31_i64_228 : i64
-    %407 = arith.divui %406, %c32_i64_229 : i64
-    %408 = arith.muli %407, %c32_i64_227 : i64
-    %409 = arith.cmpi ult, %408, %404 : i64
-    cf.cond_br %409, ^bb135, ^bb134
+    %c32_i64_185 = arith.constant 32 : i64
+    %359 = arith.addi %357, %c31_i64 : i64
+    %360 = arith.divui %359, %c32_i64_185 : i64
+    %c32_i64_186 = arith.constant 32 : i64
+    %361 = arith.muli %360, %c32_i64_186 : i64
+    %362 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_187 = arith.constant 31 : i64
+    %c32_i64_188 = arith.constant 32 : i64
+    %363 = arith.addi %362, %c31_i64_187 : i64
+    %364 = arith.divui %363, %c32_i64_188 : i64
+    %365 = arith.muli %364, %c32_i64_186 : i64
+    %366 = arith.cmpi ult, %365, %361 : i64
+    cf.cond_br %366, ^bb135, ^bb134
   ^bb134:  // 2 preds: ^bb133, ^bb137
     cf.br ^bb12
   ^bb135:  // pred: ^bb133
-    %c3_i64_230 = arith.constant 3 : i64
+    %c3_i64_189 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %410 = arith.muli %407, %407 : i64
-    %411 = arith.divui %410, %c512_i64 : i64
-    %412 = arith.muli %407, %c3_i64_230 : i64
-    %413 = arith.addi %411, %412 : i64
-    %c3_i64_231 = arith.constant 3 : i64
-    %c512_i64_232 = arith.constant 512 : i64
-    %414 = arith.muli %403, %403 : i64
-    %415 = arith.divui %414, %c512_i64_232 : i64
-    %416 = arith.muli %403, %c3_i64_231 : i64
-    %417 = arith.addi %415, %416 : i64
-    %418 = arith.subi %417, %413 : i64
-    %419 = llvm.load %arg1 : !llvm.ptr -> i64
-    %420 = arith.cmpi ult, %419, %418 : i64
-    scf.if %420 {
+    %367 = arith.muli %364, %364 : i64
+    %368 = arith.divui %367, %c512_i64 : i64
+    %369 = arith.muli %364, %c3_i64_189 : i64
+    %370 = arith.addi %368, %369 : i64
+    %c3_i64_190 = arith.constant 3 : i64
+    %c512_i64_191 = arith.constant 512 : i64
+    %371 = arith.muli %360, %360 : i64
+    %372 = arith.divui %371, %c512_i64_191 : i64
+    %373 = arith.muli %360, %c3_i64_190 : i64
+    %374 = arith.addi %372, %373 : i64
+    %375 = arith.subi %374, %370 : i64
+    %376 = llvm.load %arg1 : !llvm.ptr -> i64
+    %377 = arith.cmpi ult, %376, %375 : i64
+    scf.if %377 {
     } else {
-      %571 = arith.subi %419, %418 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %376, %375 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_233 = arith.constant 80 : i8
-    cf.cond_br %420, ^bb1(%c80_i8_233 : i8), ^bb136
+    %c80_i8_192 = arith.constant 80 : i8
+    cf.cond_br %377, ^bb1(%c80_i8_192 : i8), ^bb136
   ^bb136:  // pred: ^bb135
-    %421 = call @dora_fn_extend_memory(%arg0, %404) : (!llvm.ptr, i64) -> !llvm.ptr
-    %422 = llvm.getelementptr %421[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %423 = llvm.load %422 : !llvm.ptr -> i8
-    %c0_i8_234 = arith.constant 0 : i8
-    %424 = arith.cmpi ne, %423, %c0_i8_234 : i8
-    cf.cond_br %424, ^bb1(%423 : i8), ^bb137
+    %378 = call @dora_fn_extend_memory(%arg0, %361) : (!llvm.ptr, i64) -> !llvm.ptr
+    %379 = llvm.getelementptr %378[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %380 = llvm.load %379 : !llvm.ptr -> i8
+    %c0_i8_193 = arith.constant 0 : i8
+    %381 = arith.cmpi ne, %380, %c0_i8_193 : i8
+    cf.cond_br %381, ^bb1(%380 : i8), ^bb137
   ^bb137:  // pred: ^bb136
     cf.br ^bb134
   ^bb138:  // pred: ^bb31
     %c49152_i64 = arith.constant 49152 : i64
-    %425 = arith.cmpi ugt, %82, %c49152_i64 : i64
+    %382 = arith.cmpi ugt, %73, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %425, ^bb1(%c100_i8 : i8), ^bb139
+    cf.cond_br %382, ^bb1(%c100_i8 : i8), ^bb139
   ^bb139:  // pred: ^bb138
-    %c31_i64_235 = arith.constant 31 : i64
-    %c32_i64_236 = arith.constant 32 : i64
-    %426 = arith.addi %82, %c31_i64_235 : i64
-    %427 = arith.divui %426, %c32_i64_236 : i64
-    %c2_i64_237 = arith.constant 2 : i64
-    %428 = arith.muli %427, %c2_i64_237 : i64
-    %429 = llvm.load %arg1 : !llvm.ptr -> i64
-    %430 = arith.cmpi ult, %429, %428 : i64
-    scf.if %430 {
+    %c31_i64_194 = arith.constant 31 : i64
+    %c32_i64_195 = arith.constant 32 : i64
+    %383 = arith.addi %73, %c31_i64_194 : i64
+    %384 = arith.divui %383, %c32_i64_195 : i64
+    %c2_i64_196 = arith.constant 2 : i64
+    %385 = arith.muli %384, %c2_i64_196 : i64
+    %386 = llvm.load %arg1 : !llvm.ptr -> i64
+    %387 = arith.cmpi ult, %386, %385 : i64
+    scf.if %387 {
     } else {
-      %571 = arith.subi %429, %428 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %386, %385 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_238 = arith.constant 80 : i8
-    cf.cond_br %430, ^bb1(%c80_i8_238 : i8), ^bb140
+    %c80_i8_197 = arith.constant 80 : i8
+    cf.cond_br %387, ^bb1(%c80_i8_197 : i8), ^bb140
   ^bb140:  // pred: ^bb139
-    %c18446744073709551615_i256_239 = arith.constant 18446744073709551615 : i256
-    %431 = arith.cmpi sgt, %74, %c18446744073709551615_i256_239 : i256
-    %c84_i8_240 = arith.constant 84 : i8
-    cf.cond_br %431, ^bb1(%c84_i8_240 : i8), ^bb141
+    %c18446744073709551615_i256_198 = arith.constant 18446744073709551615 : i256
+    %388 = arith.cmpi sgt, %66, %c18446744073709551615_i256_198 : i256
+    %c84_i8_199 = arith.constant 84 : i8
+    cf.cond_br %388, ^bb1(%c84_i8_199 : i8), ^bb141
   ^bb141:  // pred: ^bb140
-    %432 = arith.trunci %74 : i256 to i64
-    %c0_i64_241 = arith.constant 0 : i64
-    %433 = arith.cmpi slt, %432, %c0_i64_241 : i64
-    %c84_i8_242 = arith.constant 84 : i8
-    cf.cond_br %433, ^bb1(%c84_i8_242 : i8), ^bb142
+    %389 = arith.trunci %66 : i256 to i64
+    %c0_i64_200 = arith.constant 0 : i64
+    %390 = arith.cmpi slt, %389, %c0_i64_200 : i64
+    %c84_i8_201 = arith.constant 84 : i8
+    cf.cond_br %390, ^bb1(%c84_i8_201 : i8), ^bb142
   ^bb142:  // pred: ^bb141
-    %434 = arith.addi %432, %82 : i64
-    %c0_i64_243 = arith.constant 0 : i64
-    %435 = arith.cmpi slt, %434, %c0_i64_243 : i64
-    %c84_i8_244 = arith.constant 84 : i8
-    cf.cond_br %435, ^bb1(%c84_i8_244 : i8), ^bb143
+    %391 = arith.addi %389, %73 : i64
+    %c0_i64_202 = arith.constant 0 : i64
+    %392 = arith.cmpi slt, %391, %c0_i64_202 : i64
+    %c84_i8_203 = arith.constant 84 : i8
+    cf.cond_br %392, ^bb1(%c84_i8_203 : i8), ^bb143
   ^bb143:  // pred: ^bb142
-    %c31_i64_245 = arith.constant 31 : i64
-    %c32_i64_246 = arith.constant 32 : i64
-    %436 = arith.addi %434, %c31_i64_245 : i64
-    %437 = arith.divui %436, %c32_i64_246 : i64
-    %c32_i64_247 = arith.constant 32 : i64
-    %438 = arith.muli %437, %c32_i64_247 : i64
-    %439 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_248 = arith.constant 31 : i64
-    %c32_i64_249 = arith.constant 32 : i64
-    %440 = arith.addi %439, %c31_i64_248 : i64
-    %441 = arith.divui %440, %c32_i64_249 : i64
-    %442 = arith.muli %441, %c32_i64_247 : i64
-    %443 = arith.cmpi ult, %442, %438 : i64
-    cf.cond_br %443, ^bb145, ^bb144
+    %c31_i64_204 = arith.constant 31 : i64
+    %c32_i64_205 = arith.constant 32 : i64
+    %393 = arith.addi %391, %c31_i64_204 : i64
+    %394 = arith.divui %393, %c32_i64_205 : i64
+    %c32_i64_206 = arith.constant 32 : i64
+    %395 = arith.muli %394, %c32_i64_206 : i64
+    %396 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_207 = arith.constant 31 : i64
+    %c32_i64_208 = arith.constant 32 : i64
+    %397 = arith.addi %396, %c31_i64_207 : i64
+    %398 = arith.divui %397, %c32_i64_208 : i64
+    %399 = arith.muli %398, %c32_i64_206 : i64
+    %400 = arith.cmpi ult, %399, %395 : i64
+    cf.cond_br %400, ^bb145, ^bb144
   ^bb144:  // 2 preds: ^bb143, ^bb147
     cf.br ^bb32
   ^bb145:  // pred: ^bb143
-    %c3_i64_250 = arith.constant 3 : i64
-    %c512_i64_251 = arith.constant 512 : i64
-    %444 = arith.muli %441, %441 : i64
-    %445 = arith.divui %444, %c512_i64_251 : i64
-    %446 = arith.muli %441, %c3_i64_250 : i64
-    %447 = arith.addi %445, %446 : i64
-    %c3_i64_252 = arith.constant 3 : i64
-    %c512_i64_253 = arith.constant 512 : i64
-    %448 = arith.muli %437, %437 : i64
-    %449 = arith.divui %448, %c512_i64_253 : i64
-    %450 = arith.muli %437, %c3_i64_252 : i64
-    %451 = arith.addi %449, %450 : i64
-    %452 = arith.subi %451, %447 : i64
-    %453 = llvm.load %arg1 : !llvm.ptr -> i64
-    %454 = arith.cmpi ult, %453, %452 : i64
-    scf.if %454 {
+    %c3_i64_209 = arith.constant 3 : i64
+    %c512_i64_210 = arith.constant 512 : i64
+    %401 = arith.muli %398, %398 : i64
+    %402 = arith.divui %401, %c512_i64_210 : i64
+    %403 = arith.muli %398, %c3_i64_209 : i64
+    %404 = arith.addi %402, %403 : i64
+    %c3_i64_211 = arith.constant 3 : i64
+    %c512_i64_212 = arith.constant 512 : i64
+    %405 = arith.muli %394, %394 : i64
+    %406 = arith.divui %405, %c512_i64_212 : i64
+    %407 = arith.muli %394, %c3_i64_211 : i64
+    %408 = arith.addi %406, %407 : i64
+    %409 = arith.subi %408, %404 : i64
+    %410 = llvm.load %arg1 : !llvm.ptr -> i64
+    %411 = arith.cmpi ult, %410, %409 : i64
+    scf.if %411 {
     } else {
-      %571 = arith.subi %453, %452 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %410, %409 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_254 = arith.constant 80 : i8
-    cf.cond_br %454, ^bb1(%c80_i8_254 : i8), ^bb146
+    %c80_i8_213 = arith.constant 80 : i8
+    cf.cond_br %411, ^bb1(%c80_i8_213 : i8), ^bb146
   ^bb146:  // pred: ^bb145
-    %455 = call @dora_fn_extend_memory(%arg0, %438) : (!llvm.ptr, i64) -> !llvm.ptr
-    %456 = llvm.getelementptr %455[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %457 = llvm.load %456 : !llvm.ptr -> i8
-    %c0_i8_255 = arith.constant 0 : i8
-    %458 = arith.cmpi ne, %457, %c0_i8_255 : i8
-    cf.cond_br %458, ^bb1(%457 : i8), ^bb147
+    %412 = call @dora_fn_extend_memory(%arg0, %395) : (!llvm.ptr, i64) -> !llvm.ptr
+    %413 = llvm.getelementptr %412[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %414 = llvm.load %413 : !llvm.ptr -> i8
+    %c0_i8_214 = arith.constant 0 : i8
+    %415 = arith.cmpi ne, %414, %c0_i8_214 : i8
+    cf.cond_br %415, ^bb1(%414 : i8), ^bb147
   ^bb147:  // pred: ^bb146
     cf.br ^bb144
   ^bb148:  // pred: ^bb69
-    %c18446744073709551615_i256_256 = arith.constant 18446744073709551615 : i256
-    %459 = arith.cmpi sgt, %188, %c18446744073709551615_i256_256 : i256
-    %c84_i8_257 = arith.constant 84 : i8
-    cf.cond_br %459, ^bb1(%c84_i8_257 : i8), ^bb149
+    %c18446744073709551615_i256_215 = arith.constant 18446744073709551615 : i256
+    %416 = arith.cmpi sgt, %167, %c18446744073709551615_i256_215 : i256
+    %c84_i8_216 = arith.constant 84 : i8
+    cf.cond_br %416, ^bb1(%c84_i8_216 : i8), ^bb149
   ^bb149:  // pred: ^bb148
-    %460 = arith.trunci %188 : i256 to i64
-    %c0_i64_258 = arith.constant 0 : i64
-    %461 = arith.cmpi slt, %460, %c0_i64_258 : i64
-    %c84_i8_259 = arith.constant 84 : i8
-    cf.cond_br %461, ^bb1(%c84_i8_259 : i8), ^bb150
+    %417 = arith.trunci %167 : i256 to i64
+    %c0_i64_217 = arith.constant 0 : i64
+    %418 = arith.cmpi slt, %417, %c0_i64_217 : i64
+    %c84_i8_218 = arith.constant 84 : i8
+    cf.cond_br %418, ^bb1(%c84_i8_218 : i8), ^bb150
   ^bb150:  // pred: ^bb149
-    %462 = arith.addi %460, %202 : i64
-    %c0_i64_260 = arith.constant 0 : i64
-    %463 = arith.cmpi slt, %462, %c0_i64_260 : i64
-    %c84_i8_261 = arith.constant 84 : i8
-    cf.cond_br %463, ^bb1(%c84_i8_261 : i8), ^bb151
+    %419 = arith.addi %417, %178 : i64
+    %c0_i64_219 = arith.constant 0 : i64
+    %420 = arith.cmpi slt, %419, %c0_i64_219 : i64
+    %c84_i8_220 = arith.constant 84 : i8
+    cf.cond_br %420, ^bb1(%c84_i8_220 : i8), ^bb151
   ^bb151:  // pred: ^bb150
-    %c31_i64_262 = arith.constant 31 : i64
-    %c32_i64_263 = arith.constant 32 : i64
-    %464 = arith.addi %462, %c31_i64_262 : i64
-    %465 = arith.divui %464, %c32_i64_263 : i64
-    %c32_i64_264 = arith.constant 32 : i64
-    %466 = arith.muli %465, %c32_i64_264 : i64
-    %467 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_265 = arith.constant 31 : i64
-    %c32_i64_266 = arith.constant 32 : i64
-    %468 = arith.addi %467, %c31_i64_265 : i64
-    %469 = arith.divui %468, %c32_i64_266 : i64
-    %470 = arith.muli %469, %c32_i64_264 : i64
-    %471 = arith.cmpi ult, %470, %466 : i64
-    cf.cond_br %471, ^bb153, ^bb152
+    %c31_i64_221 = arith.constant 31 : i64
+    %c32_i64_222 = arith.constant 32 : i64
+    %421 = arith.addi %419, %c31_i64_221 : i64
+    %422 = arith.divui %421, %c32_i64_222 : i64
+    %c32_i64_223 = arith.constant 32 : i64
+    %423 = arith.muli %422, %c32_i64_223 : i64
+    %424 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_224 = arith.constant 31 : i64
+    %c32_i64_225 = arith.constant 32 : i64
+    %425 = arith.addi %424, %c31_i64_224 : i64
+    %426 = arith.divui %425, %c32_i64_225 : i64
+    %427 = arith.muli %426, %c32_i64_223 : i64
+    %428 = arith.cmpi ult, %427, %423 : i64
+    cf.cond_br %428, ^bb153, ^bb152
   ^bb152:  // 2 preds: ^bb151, ^bb155
     cf.br ^bb70
   ^bb153:  // pred: ^bb151
-    %c3_i64_267 = arith.constant 3 : i64
-    %c512_i64_268 = arith.constant 512 : i64
-    %472 = arith.muli %469, %469 : i64
-    %473 = arith.divui %472, %c512_i64_268 : i64
-    %474 = arith.muli %469, %c3_i64_267 : i64
-    %475 = arith.addi %473, %474 : i64
-    %c3_i64_269 = arith.constant 3 : i64
-    %c512_i64_270 = arith.constant 512 : i64
-    %476 = arith.muli %465, %465 : i64
-    %477 = arith.divui %476, %c512_i64_270 : i64
-    %478 = arith.muli %465, %c3_i64_269 : i64
-    %479 = arith.addi %477, %478 : i64
-    %480 = arith.subi %479, %475 : i64
-    %481 = llvm.load %arg1 : !llvm.ptr -> i64
-    %482 = arith.cmpi ult, %481, %480 : i64
-    scf.if %482 {
+    %c3_i64_226 = arith.constant 3 : i64
+    %c512_i64_227 = arith.constant 512 : i64
+    %429 = arith.muli %426, %426 : i64
+    %430 = arith.divui %429, %c512_i64_227 : i64
+    %431 = arith.muli %426, %c3_i64_226 : i64
+    %432 = arith.addi %430, %431 : i64
+    %c3_i64_228 = arith.constant 3 : i64
+    %c512_i64_229 = arith.constant 512 : i64
+    %433 = arith.muli %422, %422 : i64
+    %434 = arith.divui %433, %c512_i64_229 : i64
+    %435 = arith.muli %422, %c3_i64_228 : i64
+    %436 = arith.addi %434, %435 : i64
+    %437 = arith.subi %436, %432 : i64
+    %438 = llvm.load %arg1 : !llvm.ptr -> i64
+    %439 = arith.cmpi ult, %438, %437 : i64
+    scf.if %439 {
     } else {
-      %571 = arith.subi %481, %480 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %438, %437 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_271 = arith.constant 80 : i8
-    cf.cond_br %482, ^bb1(%c80_i8_271 : i8), ^bb154
+    %c80_i8_230 = arith.constant 80 : i8
+    cf.cond_br %439, ^bb1(%c80_i8_230 : i8), ^bb154
   ^bb154:  // pred: ^bb153
-    %483 = call @dora_fn_extend_memory(%arg0, %466) : (!llvm.ptr, i64) -> !llvm.ptr
-    %484 = llvm.getelementptr %483[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %485 = llvm.load %484 : !llvm.ptr -> i8
-    %c0_i8_272 = arith.constant 0 : i8
-    %486 = arith.cmpi ne, %485, %c0_i8_272 : i8
-    cf.cond_br %486, ^bb1(%485 : i8), ^bb155
+    %440 = call @dora_fn_extend_memory(%arg0, %423) : (!llvm.ptr, i64) -> !llvm.ptr
+    %441 = llvm.getelementptr %440[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %442 = llvm.load %441 : !llvm.ptr -> i8
+    %c0_i8_231 = arith.constant 0 : i8
+    %443 = arith.cmpi ne, %442, %c0_i8_231 : i8
+    cf.cond_br %443, ^bb1(%442 : i8), ^bb155
   ^bb155:  // pred: ^bb154
     cf.br ^bb152
   ^bb156:  // pred: ^bb72
-    %c18446744073709551615_i256_273 = arith.constant 18446744073709551615 : i256
-    %487 = arith.cmpi sgt, %196, %c18446744073709551615_i256_273 : i256
-    %c84_i8_274 = arith.constant 84 : i8
-    cf.cond_br %487, ^bb1(%c84_i8_274 : i8), ^bb157
+    %c18446744073709551615_i256_232 = arith.constant 18446744073709551615 : i256
+    %444 = arith.cmpi sgt, %173, %c18446744073709551615_i256_232 : i256
+    %c84_i8_233 = arith.constant 84 : i8
+    cf.cond_br %444, ^bb1(%c84_i8_233 : i8), ^bb157
   ^bb157:  // pred: ^bb156
-    %488 = arith.trunci %196 : i256 to i64
-    %c0_i64_275 = arith.constant 0 : i64
-    %489 = arith.cmpi slt, %488, %c0_i64_275 : i64
-    %c84_i8_276 = arith.constant 84 : i8
-    cf.cond_br %489, ^bb1(%c84_i8_276 : i8), ^bb158
+    %445 = arith.trunci %173 : i256 to i64
+    %c0_i64_234 = arith.constant 0 : i64
+    %446 = arith.cmpi slt, %445, %c0_i64_234 : i64
+    %c84_i8_235 = arith.constant 84 : i8
+    cf.cond_br %446, ^bb1(%c84_i8_235 : i8), ^bb158
   ^bb158:  // pred: ^bb157
-    %490 = arith.addi %488, %206 : i64
-    %c0_i64_277 = arith.constant 0 : i64
-    %491 = arith.cmpi slt, %490, %c0_i64_277 : i64
-    %c84_i8_278 = arith.constant 84 : i8
-    cf.cond_br %491, ^bb1(%c84_i8_278 : i8), ^bb159
+    %447 = arith.addi %445, %182 : i64
+    %c0_i64_236 = arith.constant 0 : i64
+    %448 = arith.cmpi slt, %447, %c0_i64_236 : i64
+    %c84_i8_237 = arith.constant 84 : i8
+    cf.cond_br %448, ^bb1(%c84_i8_237 : i8), ^bb159
   ^bb159:  // pred: ^bb158
-    %c31_i64_279 = arith.constant 31 : i64
-    %c32_i64_280 = arith.constant 32 : i64
-    %492 = arith.addi %490, %c31_i64_279 : i64
-    %493 = arith.divui %492, %c32_i64_280 : i64
-    %c32_i64_281 = arith.constant 32 : i64
-    %494 = arith.muli %493, %c32_i64_281 : i64
-    %495 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_282 = arith.constant 31 : i64
-    %c32_i64_283 = arith.constant 32 : i64
-    %496 = arith.addi %495, %c31_i64_282 : i64
-    %497 = arith.divui %496, %c32_i64_283 : i64
-    %498 = arith.muli %497, %c32_i64_281 : i64
-    %499 = arith.cmpi ult, %498, %494 : i64
-    cf.cond_br %499, ^bb161, ^bb160
+    %c31_i64_238 = arith.constant 31 : i64
+    %c32_i64_239 = arith.constant 32 : i64
+    %449 = arith.addi %447, %c31_i64_238 : i64
+    %450 = arith.divui %449, %c32_i64_239 : i64
+    %c32_i64_240 = arith.constant 32 : i64
+    %451 = arith.muli %450, %c32_i64_240 : i64
+    %452 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_241 = arith.constant 31 : i64
+    %c32_i64_242 = arith.constant 32 : i64
+    %453 = arith.addi %452, %c31_i64_241 : i64
+    %454 = arith.divui %453, %c32_i64_242 : i64
+    %455 = arith.muli %454, %c32_i64_240 : i64
+    %456 = arith.cmpi ult, %455, %451 : i64
+    cf.cond_br %456, ^bb161, ^bb160
   ^bb160:  // 2 preds: ^bb159, ^bb163
     cf.br ^bb73
   ^bb161:  // pred: ^bb159
-    %c3_i64_284 = arith.constant 3 : i64
-    %c512_i64_285 = arith.constant 512 : i64
-    %500 = arith.muli %497, %497 : i64
-    %501 = arith.divui %500, %c512_i64_285 : i64
-    %502 = arith.muli %497, %c3_i64_284 : i64
-    %503 = arith.addi %501, %502 : i64
-    %c3_i64_286 = arith.constant 3 : i64
-    %c512_i64_287 = arith.constant 512 : i64
-    %504 = arith.muli %493, %493 : i64
-    %505 = arith.divui %504, %c512_i64_287 : i64
-    %506 = arith.muli %493, %c3_i64_286 : i64
-    %507 = arith.addi %505, %506 : i64
-    %508 = arith.subi %507, %503 : i64
-    %509 = llvm.load %arg1 : !llvm.ptr -> i64
-    %510 = arith.cmpi ult, %509, %508 : i64
-    scf.if %510 {
+    %c3_i64_243 = arith.constant 3 : i64
+    %c512_i64_244 = arith.constant 512 : i64
+    %457 = arith.muli %454, %454 : i64
+    %458 = arith.divui %457, %c512_i64_244 : i64
+    %459 = arith.muli %454, %c3_i64_243 : i64
+    %460 = arith.addi %458, %459 : i64
+    %c3_i64_245 = arith.constant 3 : i64
+    %c512_i64_246 = arith.constant 512 : i64
+    %461 = arith.muli %450, %450 : i64
+    %462 = arith.divui %461, %c512_i64_246 : i64
+    %463 = arith.muli %450, %c3_i64_245 : i64
+    %464 = arith.addi %462, %463 : i64
+    %465 = arith.subi %464, %460 : i64
+    %466 = llvm.load %arg1 : !llvm.ptr -> i64
+    %467 = arith.cmpi ult, %466, %465 : i64
+    scf.if %467 {
     } else {
-      %571 = arith.subi %509, %508 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %466, %465 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_288 = arith.constant 80 : i8
-    cf.cond_br %510, ^bb1(%c80_i8_288 : i8), ^bb162
+    %c80_i8_247 = arith.constant 80 : i8
+    cf.cond_br %467, ^bb1(%c80_i8_247 : i8), ^bb162
   ^bb162:  // pred: ^bb161
-    %511 = call @dora_fn_extend_memory(%arg0, %494) : (!llvm.ptr, i64) -> !llvm.ptr
-    %512 = llvm.getelementptr %511[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %513 = llvm.load %512 : !llvm.ptr -> i8
-    %c0_i8_289 = arith.constant 0 : i8
-    %514 = arith.cmpi ne, %513, %c0_i8_289 : i8
-    cf.cond_br %514, ^bb1(%513 : i8), ^bb163
+    %468 = call @dora_fn_extend_memory(%arg0, %451) : (!llvm.ptr, i64) -> !llvm.ptr
+    %469 = llvm.getelementptr %468[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %470 = llvm.load %469 : !llvm.ptr -> i8
+    %c0_i8_248 = arith.constant 0 : i8
+    %471 = arith.cmpi ne, %470, %c0_i8_248 : i8
+    cf.cond_br %471, ^bb1(%470 : i8), ^bb163
   ^bb163:  // pred: ^bb162
     cf.br ^bb160
   ^bb164:  // pred: ^bb119
-    %c18446744073709551615_i256_290 = arith.constant 18446744073709551615 : i256
-    %515 = arith.cmpi sgt, %349, %c18446744073709551615_i256_290 : i256
-    %c84_i8_291 = arith.constant 84 : i8
-    cf.cond_br %515, ^bb1(%c84_i8_291 : i8), ^bb165
+    %c18446744073709551615_i256_249 = arith.constant 18446744073709551615 : i256
+    %472 = arith.cmpi sgt, %310, %c18446744073709551615_i256_249 : i256
+    %c84_i8_250 = arith.constant 84 : i8
+    cf.cond_br %472, ^bb1(%c84_i8_250 : i8), ^bb165
   ^bb165:  // pred: ^bb164
-    %516 = arith.trunci %349 : i256 to i64
-    %c0_i64_292 = arith.constant 0 : i64
-    %517 = arith.cmpi slt, %516, %c0_i64_292 : i64
-    %c84_i8_293 = arith.constant 84 : i8
-    cf.cond_br %517, ^bb1(%c84_i8_293 : i8), ^bb166
+    %473 = arith.trunci %310 : i256 to i64
+    %c0_i64_251 = arith.constant 0 : i64
+    %474 = arith.cmpi slt, %473, %c0_i64_251 : i64
+    %c84_i8_252 = arith.constant 84 : i8
+    cf.cond_br %474, ^bb1(%c84_i8_252 : i8), ^bb166
   ^bb166:  // pred: ^bb165
-    %518 = arith.addi %516, %363 : i64
-    %c0_i64_294 = arith.constant 0 : i64
-    %519 = arith.cmpi slt, %518, %c0_i64_294 : i64
-    %c84_i8_295 = arith.constant 84 : i8
-    cf.cond_br %519, ^bb1(%c84_i8_295 : i8), ^bb167
+    %475 = arith.addi %473, %321 : i64
+    %c0_i64_253 = arith.constant 0 : i64
+    %476 = arith.cmpi slt, %475, %c0_i64_253 : i64
+    %c84_i8_254 = arith.constant 84 : i8
+    cf.cond_br %476, ^bb1(%c84_i8_254 : i8), ^bb167
   ^bb167:  // pred: ^bb166
-    %c31_i64_296 = arith.constant 31 : i64
-    %c32_i64_297 = arith.constant 32 : i64
-    %520 = arith.addi %518, %c31_i64_296 : i64
-    %521 = arith.divui %520, %c32_i64_297 : i64
-    %c32_i64_298 = arith.constant 32 : i64
-    %522 = arith.muli %521, %c32_i64_298 : i64
-    %523 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_299 = arith.constant 31 : i64
-    %c32_i64_300 = arith.constant 32 : i64
-    %524 = arith.addi %523, %c31_i64_299 : i64
-    %525 = arith.divui %524, %c32_i64_300 : i64
-    %526 = arith.muli %525, %c32_i64_298 : i64
-    %527 = arith.cmpi ult, %526, %522 : i64
-    cf.cond_br %527, ^bb169, ^bb168
+    %c31_i64_255 = arith.constant 31 : i64
+    %c32_i64_256 = arith.constant 32 : i64
+    %477 = arith.addi %475, %c31_i64_255 : i64
+    %478 = arith.divui %477, %c32_i64_256 : i64
+    %c32_i64_257 = arith.constant 32 : i64
+    %479 = arith.muli %478, %c32_i64_257 : i64
+    %480 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_258 = arith.constant 31 : i64
+    %c32_i64_259 = arith.constant 32 : i64
+    %481 = arith.addi %480, %c31_i64_258 : i64
+    %482 = arith.divui %481, %c32_i64_259 : i64
+    %483 = arith.muli %482, %c32_i64_257 : i64
+    %484 = arith.cmpi ult, %483, %479 : i64
+    cf.cond_br %484, ^bb169, ^bb168
   ^bb168:  // 2 preds: ^bb167, ^bb171
     cf.br ^bb120
   ^bb169:  // pred: ^bb167
-    %c3_i64_301 = arith.constant 3 : i64
-    %c512_i64_302 = arith.constant 512 : i64
-    %528 = arith.muli %525, %525 : i64
-    %529 = arith.divui %528, %c512_i64_302 : i64
-    %530 = arith.muli %525, %c3_i64_301 : i64
-    %531 = arith.addi %529, %530 : i64
-    %c3_i64_303 = arith.constant 3 : i64
-    %c512_i64_304 = arith.constant 512 : i64
-    %532 = arith.muli %521, %521 : i64
-    %533 = arith.divui %532, %c512_i64_304 : i64
-    %534 = arith.muli %521, %c3_i64_303 : i64
-    %535 = arith.addi %533, %534 : i64
-    %536 = arith.subi %535, %531 : i64
-    %537 = llvm.load %arg1 : !llvm.ptr -> i64
-    %538 = arith.cmpi ult, %537, %536 : i64
-    scf.if %538 {
+    %c3_i64_260 = arith.constant 3 : i64
+    %c512_i64_261 = arith.constant 512 : i64
+    %485 = arith.muli %482, %482 : i64
+    %486 = arith.divui %485, %c512_i64_261 : i64
+    %487 = arith.muli %482, %c3_i64_260 : i64
+    %488 = arith.addi %486, %487 : i64
+    %c3_i64_262 = arith.constant 3 : i64
+    %c512_i64_263 = arith.constant 512 : i64
+    %489 = arith.muli %478, %478 : i64
+    %490 = arith.divui %489, %c512_i64_263 : i64
+    %491 = arith.muli %478, %c3_i64_262 : i64
+    %492 = arith.addi %490, %491 : i64
+    %493 = arith.subi %492, %488 : i64
+    %494 = llvm.load %arg1 : !llvm.ptr -> i64
+    %495 = arith.cmpi ult, %494, %493 : i64
+    scf.if %495 {
     } else {
-      %571 = arith.subi %537, %536 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %494, %493 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_305 = arith.constant 80 : i8
-    cf.cond_br %538, ^bb1(%c80_i8_305 : i8), ^bb170
+    %c80_i8_264 = arith.constant 80 : i8
+    cf.cond_br %495, ^bb1(%c80_i8_264 : i8), ^bb170
   ^bb170:  // pred: ^bb169
-    %539 = call @dora_fn_extend_memory(%arg0, %522) : (!llvm.ptr, i64) -> !llvm.ptr
-    %540 = llvm.getelementptr %539[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %541 = llvm.load %540 : !llvm.ptr -> i8
-    %c0_i8_306 = arith.constant 0 : i8
-    %542 = arith.cmpi ne, %541, %c0_i8_306 : i8
-    cf.cond_br %542, ^bb1(%541 : i8), ^bb171
+    %496 = call @dora_fn_extend_memory(%arg0, %479) : (!llvm.ptr, i64) -> !llvm.ptr
+    %497 = llvm.getelementptr %496[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %498 = llvm.load %497 : !llvm.ptr -> i8
+    %c0_i8_265 = arith.constant 0 : i8
+    %499 = arith.cmpi ne, %498, %c0_i8_265 : i8
+    cf.cond_br %499, ^bb1(%498 : i8), ^bb171
   ^bb171:  // pred: ^bb170
     cf.br ^bb168
   ^bb172:  // pred: ^bb122
-    %c18446744073709551615_i256_307 = arith.constant 18446744073709551615 : i256
-    %543 = arith.cmpi sgt, %357, %c18446744073709551615_i256_307 : i256
-    %c84_i8_308 = arith.constant 84 : i8
-    cf.cond_br %543, ^bb1(%c84_i8_308 : i8), ^bb173
+    %c18446744073709551615_i256_266 = arith.constant 18446744073709551615 : i256
+    %500 = arith.cmpi sgt, %316, %c18446744073709551615_i256_266 : i256
+    %c84_i8_267 = arith.constant 84 : i8
+    cf.cond_br %500, ^bb1(%c84_i8_267 : i8), ^bb173
   ^bb173:  // pred: ^bb172
-    %544 = arith.trunci %357 : i256 to i64
-    %c0_i64_309 = arith.constant 0 : i64
-    %545 = arith.cmpi slt, %544, %c0_i64_309 : i64
-    %c84_i8_310 = arith.constant 84 : i8
-    cf.cond_br %545, ^bb1(%c84_i8_310 : i8), ^bb174
+    %501 = arith.trunci %316 : i256 to i64
+    %c0_i64_268 = arith.constant 0 : i64
+    %502 = arith.cmpi slt, %501, %c0_i64_268 : i64
+    %c84_i8_269 = arith.constant 84 : i8
+    cf.cond_br %502, ^bb1(%c84_i8_269 : i8), ^bb174
   ^bb174:  // pred: ^bb173
-    %546 = arith.addi %544, %367 : i64
-    %c0_i64_311 = arith.constant 0 : i64
-    %547 = arith.cmpi slt, %546, %c0_i64_311 : i64
-    %c84_i8_312 = arith.constant 84 : i8
-    cf.cond_br %547, ^bb1(%c84_i8_312 : i8), ^bb175
+    %503 = arith.addi %501, %325 : i64
+    %c0_i64_270 = arith.constant 0 : i64
+    %504 = arith.cmpi slt, %503, %c0_i64_270 : i64
+    %c84_i8_271 = arith.constant 84 : i8
+    cf.cond_br %504, ^bb1(%c84_i8_271 : i8), ^bb175
   ^bb175:  // pred: ^bb174
-    %c31_i64_313 = arith.constant 31 : i64
-    %c32_i64_314 = arith.constant 32 : i64
-    %548 = arith.addi %546, %c31_i64_313 : i64
-    %549 = arith.divui %548, %c32_i64_314 : i64
-    %c32_i64_315 = arith.constant 32 : i64
-    %550 = arith.muli %549, %c32_i64_315 : i64
-    %551 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_316 = arith.constant 31 : i64
-    %c32_i64_317 = arith.constant 32 : i64
-    %552 = arith.addi %551, %c31_i64_316 : i64
-    %553 = arith.divui %552, %c32_i64_317 : i64
-    %554 = arith.muli %553, %c32_i64_315 : i64
-    %555 = arith.cmpi ult, %554, %550 : i64
-    cf.cond_br %555, ^bb177, ^bb176
+    %c31_i64_272 = arith.constant 31 : i64
+    %c32_i64_273 = arith.constant 32 : i64
+    %505 = arith.addi %503, %c31_i64_272 : i64
+    %506 = arith.divui %505, %c32_i64_273 : i64
+    %c32_i64_274 = arith.constant 32 : i64
+    %507 = arith.muli %506, %c32_i64_274 : i64
+    %508 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_275 = arith.constant 31 : i64
+    %c32_i64_276 = arith.constant 32 : i64
+    %509 = arith.addi %508, %c31_i64_275 : i64
+    %510 = arith.divui %509, %c32_i64_276 : i64
+    %511 = arith.muli %510, %c32_i64_274 : i64
+    %512 = arith.cmpi ult, %511, %507 : i64
+    cf.cond_br %512, ^bb177, ^bb176
   ^bb176:  // 2 preds: ^bb175, ^bb179
     cf.br ^bb123
   ^bb177:  // pred: ^bb175
-    %c3_i64_318 = arith.constant 3 : i64
-    %c512_i64_319 = arith.constant 512 : i64
-    %556 = arith.muli %553, %553 : i64
-    %557 = arith.divui %556, %c512_i64_319 : i64
-    %558 = arith.muli %553, %c3_i64_318 : i64
-    %559 = arith.addi %557, %558 : i64
-    %c3_i64_320 = arith.constant 3 : i64
-    %c512_i64_321 = arith.constant 512 : i64
-    %560 = arith.muli %549, %549 : i64
-    %561 = arith.divui %560, %c512_i64_321 : i64
-    %562 = arith.muli %549, %c3_i64_320 : i64
-    %563 = arith.addi %561, %562 : i64
-    %564 = arith.subi %563, %559 : i64
-    %565 = llvm.load %arg1 : !llvm.ptr -> i64
-    %566 = arith.cmpi ult, %565, %564 : i64
-    scf.if %566 {
+    %c3_i64_277 = arith.constant 3 : i64
+    %c512_i64_278 = arith.constant 512 : i64
+    %513 = arith.muli %510, %510 : i64
+    %514 = arith.divui %513, %c512_i64_278 : i64
+    %515 = arith.muli %510, %c3_i64_277 : i64
+    %516 = arith.addi %514, %515 : i64
+    %c3_i64_279 = arith.constant 3 : i64
+    %c512_i64_280 = arith.constant 512 : i64
+    %517 = arith.muli %506, %506 : i64
+    %518 = arith.divui %517, %c512_i64_280 : i64
+    %519 = arith.muli %506, %c3_i64_279 : i64
+    %520 = arith.addi %518, %519 : i64
+    %521 = arith.subi %520, %516 : i64
+    %522 = llvm.load %arg1 : !llvm.ptr -> i64
+    %523 = arith.cmpi ult, %522, %521 : i64
+    scf.if %523 {
     } else {
-      %571 = arith.subi %565, %564 : i64
-      llvm.store %571, %arg1 : i64, !llvm.ptr
+      %528 = arith.subi %522, %521 : i64
+      llvm.store %528, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_322 = arith.constant 80 : i8
-    cf.cond_br %566, ^bb1(%c80_i8_322 : i8), ^bb178
+    %c80_i8_281 = arith.constant 80 : i8
+    cf.cond_br %523, ^bb1(%c80_i8_281 : i8), ^bb178
   ^bb178:  // pred: ^bb177
-    %567 = call @dora_fn_extend_memory(%arg0, %550) : (!llvm.ptr, i64) -> !llvm.ptr
-    %568 = llvm.getelementptr %567[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %569 = llvm.load %568 : !llvm.ptr -> i8
-    %c0_i8_323 = arith.constant 0 : i8
-    %570 = arith.cmpi ne, %569, %c0_i8_323 : i8
-    cf.cond_br %570, ^bb1(%569 : i8), ^bb179
+    %524 = call @dora_fn_extend_memory(%arg0, %507) : (!llvm.ptr, i64) -> !llvm.ptr
+    %525 = llvm.getelementptr %524[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %526 = llvm.load %525 : !llvm.ptr -> i8
+    %c0_i8_282 = arith.constant 0 : i8
+    %527 = arith.cmpi ne, %526, %c0_i8_282 : i8
+    cf.cond_br %527, ^bb1(%526 : i8), ^bb179
   ^bb179:  // pred: ^bb178
     cf.br ^bb176
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodecopy.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 85 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb49, ^bb50, ^bb53, ^bb54, ^bb57, ^bb58, ^bb62, ^bb63, ^bb66, ^bb67, ^bb70, ^bb71, ^bb75, ^bb76, ^bb79, ^bb80, ^bb83, ^bb84, ^bb87, ^bb88, ^bb91, ^bb92, ^bb94, ^bb95, ^bb96, ^bb98, ^bb100, ^bb101, ^bb104, ^bb105, ^bb106, ^bb109, ^bb110, ^bb112, ^bb113, ^bb114, ^bb117, ^bb118, ^bb120, ^bb121, ^bb122, ^bb123, ^bb124, ^bb127, ^bb128, ^bb130, ^bb131, ^bb132, ^bb135, ^bb136, ^bb138, ^bb139, ^bb140, ^bb143, ^bb144, ^bb146, ^bb147, ^bb148, ^bb151, ^bb152
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 85 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb49, ^bb50, ^bb53, ^bb54, ^bb57, ^bb58, ^bb62, ^bb63, ^bb66, ^bb67, ^bb70, ^bb71, ^bb75, ^bb76, ^bb79, ^bb80, ^bb83, ^bb84, ^bb87, ^bb88, ^bb91, ^bb92, ^bb94, ^bb95, ^bb96, ^bb98, ^bb100, ^bb101, ^bb104, ^bb105, ^bb106, ^bb109, ^bb110, ^bb112, ^bb113, ^bb114, ^bb117, ^bb118, ^bb120, ^bb121, ^bb122, ^bb123, ^bb124, ^bb127, ^bb128, ^bb130, ^bb131, ^bb132, ^bb135, ^bb136, ^bb138, ^bb139, ^bb140, ^bb143, ^bb144, ^bb146, ^bb147, ^bb148, ^bb151, ^bb152
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c170141183460469231731687303715884105727_i256 = arith.constant 170141183460469231731687303715884105727 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c170141183460469231731687303715884105727_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,1199 +96,1158 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb104, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb104, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb108
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c170141183460469231731687303715884105727_i256_13 = arith.constant 170141183460469231731687303715884105727 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c170141183460469231731687303715884105727_i256_13, %41 : i256, !llvm.ptr
+    %c170141183460469231731687303715884105727_i256_10 = arith.constant 170141183460469231731687303715884105727 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c170141183460469231731687303715884105727_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c32_i256 = arith.constant 32 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
-    %c32_i64_28 = arith.constant 32 : i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %66 = arith.cmpi ne, %c32_i64_28, %c0_i64_29 : i64
-    cf.cond_br %66, ^bb112, ^bb25
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_21 = arith.constant 32 : i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %59 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
+    cf.cond_br %59, ^bb112, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb116
-    %67 = arith.trunci %61 : i256 to i64
-    %68 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %69 = llvm.getelementptr %68[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %70 = llvm.intr.bswap(%65)  : (i256) -> i256
-    llvm.store %70, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = arith.trunci %55 : i256 to i64
+    %61 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %63 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %63, %62 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb31
   ^bb26:  // pred: ^bb28
-    %c1024_i64_30 = arith.constant 1024 : i64
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_31 = arith.constant -2 : i64
-    %72 = arith.addi %71, %c-2_i64_31 : i64
-    %c2_i64_32 = arith.constant 2 : i64
-    %73 = arith.cmpi ult, %71, %c2_i64_32 : i64
-    %c91_i8_33 = arith.constant 91 : i8
-    cf.cond_br %73, ^bb1(%c91_i8_33 : i8), ^bb24
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_24 = arith.constant -2 : i64
+    %65 = arith.addi %64, %c-2_i64_24 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c2_i64_25 = arith.constant 2 : i64
+    %66 = arith.cmpi ult, %64, %c2_i64_25 : i64
+    %c91_i8_26 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_26 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_34 = arith.constant 3 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_27 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %75 = arith.cmpi uge, %74, %c3_i64_34 : i64
-    %c80_i8_35 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb28, ^bb1(%c80_i8_35 : i8)
+    %68 = arith.cmpi uge, %67, %c3_i64_27 : i64
+    %c80_i8_28 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb28, ^bb1(%c80_i8_28 : i8)
   ^bb28:  // pred: ^bb27
-    %76 = arith.subi %74, %c3_i64_34 : i64
-    llvm.store %76, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c3_i64_27 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb30
     %c41_i256 = arith.constant 41 : i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %78 = llvm.getelementptr %arg2[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_36 = arith.constant 1 : i64
-    %79 = arith.addi %77, %c1_i64_36 : i64
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    llvm.store %c41_i256, %78 : i256, !llvm.ptr
+    %70 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c41_i256, %70 : i256, !llvm.ptr
+    %71 = llvm.getelementptr %70[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %71, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_37 = arith.constant 1024 : i64
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %81 = arith.addi %80, %c1_i64_38 : i64
-    %82 = arith.cmpi ult, %c1024_i64_37, %81 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %82, ^bb1(%c92_i8_39 : i8), ^bb29
+    %c1024_i64_29 = arith.constant 1024 : i64
+    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_30 = arith.constant 1 : i64
+    %73 = arith.addi %72, %c1_i64_30 : i64
+    llvm.store %73, %arg3 : i64, !llvm.ptr
+    %74 = arith.cmpi ult, %c1024_i64_29, %73 : i64
+    %c92_i8_31 = arith.constant 92 : i8
+    cf.cond_br %74, ^bb1(%c92_i8_31 : i8), ^bb29
   ^bb31:  // pred: ^bb25
-    %83 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_40 = arith.constant 3 : i64
+    %75 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_32 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %84 = arith.cmpi uge, %83, %c3_i64_40 : i64
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %84, ^bb32, ^bb1(%c80_i8_41 : i8)
+    %76 = arith.cmpi uge, %75, %c3_i64_32 : i64
+    %c80_i8_33 = arith.constant 80 : i8
+    cf.cond_br %76, ^bb32, ^bb1(%c80_i8_33 : i8)
   ^bb32:  // pred: ^bb31
-    %85 = arith.subi %83, %c3_i64_40 : i64
-    llvm.store %85, %arg1 : i64, !llvm.ptr
+    %77 = arith.subi %75, %c3_i64_32 : i64
+    llvm.store %77, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
-    %c0_i256_42 = arith.constant 0 : i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %87 = llvm.getelementptr %arg2[%86] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_43 = arith.constant 1 : i64
-    %88 = arith.addi %86, %c1_i64_43 : i64
-    llvm.store %88, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_42, %87 : i256, !llvm.ptr
+    %c0_i256_34 = arith.constant 0 : i256
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_34, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb34:  // pred: ^bb36
-    %c1024_i64_44 = arith.constant 1024 : i64
-    %89 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_45 = arith.constant 1 : i64
-    %90 = arith.addi %89, %c1_i64_45 : i64
-    %91 = arith.cmpi ult, %c1024_i64_44, %90 : i64
-    %c92_i8_46 = arith.constant 92 : i8
-    cf.cond_br %91, ^bb1(%c92_i8_46 : i8), ^bb33
+    %c1024_i64_35 = arith.constant 1024 : i64
+    %80 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_36 = arith.constant 1 : i64
+    %81 = arith.addi %80, %c1_i64_36 : i64
+    llvm.store %81, %arg3 : i64, !llvm.ptr
+    %82 = arith.cmpi ult, %c1024_i64_35, %81 : i64
+    %c92_i8_37 = arith.constant 92 : i8
+    cf.cond_br %82, ^bb1(%c92_i8_37 : i8), ^bb33
   ^bb35:  // pred: ^bb29
-    %92 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_47 = arith.constant 3 : i64
+    %83 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_38 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %93 = arith.cmpi uge, %92, %c3_i64_47 : i64
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %93, ^bb36, ^bb1(%c80_i8_48 : i8)
+    %84 = arith.cmpi uge, %83, %c3_i64_38 : i64
+    %c80_i8_39 = arith.constant 80 : i8
+    cf.cond_br %84, ^bb36, ^bb1(%c80_i8_39 : i8)
   ^bb36:  // pred: ^bb35
-    %94 = arith.subi %92, %c3_i64_47 : i64
-    llvm.store %94, %arg1 : i64, !llvm.ptr
+    %85 = arith.subi %83, %c3_i64_38 : i64
+    llvm.store %85, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb38
-    %c0_i256_49 = arith.constant 0 : i256
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
-    %96 = llvm.getelementptr %arg2[%95] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_50 = arith.constant 1 : i64
-    %97 = arith.addi %95, %c1_i64_50 : i64
-    llvm.store %97, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_49, %96 : i256, !llvm.ptr
+    %c0_i256_40 = arith.constant 0 : i256
+    %86 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_40, %86 : i256, !llvm.ptr
+    %87 = llvm.getelementptr %86[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %87, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb50
   ^bb38:  // pred: ^bb40
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %98 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_52 = arith.constant 1 : i64
-    %99 = arith.addi %98, %c1_i64_52 : i64
-    %100 = arith.cmpi ult, %c1024_i64_51, %99 : i64
-    %c92_i8_53 = arith.constant 92 : i8
-    cf.cond_br %100, ^bb1(%c92_i8_53 : i8), ^bb37
+    %c1024_i64_41 = arith.constant 1024 : i64
+    %88 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_42 = arith.constant 1 : i64
+    %89 = arith.addi %88, %c1_i64_42 : i64
+    llvm.store %89, %arg3 : i64, !llvm.ptr
+    %90 = arith.cmpi ult, %c1024_i64_41, %89 : i64
+    %c92_i8_43 = arith.constant 92 : i8
+    cf.cond_br %90, ^bb1(%c92_i8_43 : i8), ^bb37
   ^bb39:  // pred: ^bb33
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_54 = arith.constant 3 : i64
+    %91 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_44 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %102 = arith.cmpi uge, %101, %c3_i64_54 : i64
-    %c80_i8_55 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb40, ^bb1(%c80_i8_55 : i8)
+    %92 = arith.cmpi uge, %91, %c3_i64_44 : i64
+    %c80_i8_45 = arith.constant 80 : i8
+    cf.cond_br %92, ^bb40, ^bb1(%c80_i8_45 : i8)
   ^bb40:  // pred: ^bb39
-    %103 = arith.subi %101, %c3_i64_54 : i64
-    llvm.store %103, %arg1 : i64, !llvm.ptr
+    %93 = arith.subi %91, %c3_i64_44 : i64
+    llvm.store %93, %arg1 : i64, !llvm.ptr
     cf.br ^bb38
   ^bb41:  // pred: ^bb49
-    %104 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_56 = arith.constant 1 : i64
-    %105 = arith.subi %104, %c1_i64_56 : i64
-    %106 = llvm.getelementptr %arg2[%105] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %105, %arg3 : i64, !llvm.ptr
-    %107 = llvm.load %106 : !llvm.ptr -> i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_57 = arith.constant 1 : i64
-    %109 = arith.subi %108, %c1_i64_57 : i64
-    %110 = llvm.getelementptr %arg2[%109] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %109, %arg3 : i64, !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> i256
-    %112 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %113 = arith.subi %112, %c1_i64_58 : i64
-    %114 = llvm.getelementptr %arg2[%113] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %113, %arg3 : i64, !llvm.ptr
-    %115 = llvm.load %114 : !llvm.ptr -> i256
-    %116 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %94 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %95 = llvm.getelementptr %94[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %96 = llvm.load %95 : !llvm.ptr -> i256
+    llvm.store %95, %0 : !llvm.ptr, !llvm.ptr
+    %97 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %98 = llvm.getelementptr %97[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %99 = llvm.load %98 : !llvm.ptr -> i256
+    llvm.store %98, %0 : !llvm.ptr, !llvm.ptr
+    %100 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %101 = llvm.getelementptr %100[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %102 = llvm.load %101 : !llvm.ptr -> i256
+    llvm.store %101, %0 : !llvm.ptr, !llvm.ptr
+    %103 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %117 = arith.cmpi ne, %116, %c0_i8 : i8
+    %104 = arith.cmpi ne, %103, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %117, ^bb1(%c87_i8 : i8), ^bb42
+    cf.cond_br %104, ^bb1(%c87_i8 : i8), ^bb42
   ^bb42:  // pred: ^bb41
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %118 = arith.cmpi sgt, %115, %c18446744073709551615_i256 : i256
+    %105 = arith.cmpi sgt, %102, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8 : i8), ^bb43
+    cf.cond_br %105, ^bb1(%c84_i8 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %119 = arith.trunci %115 : i256 to i64
-    %c0_i64_59 = arith.constant 0 : i64
-    %120 = arith.cmpi slt, %119, %c0_i64_59 : i64
-    %c84_i8_60 = arith.constant 84 : i8
-    cf.cond_br %120, ^bb1(%c84_i8_60 : i8), ^bb44
+    %106 = arith.trunci %102 : i256 to i64
+    %c0_i64_46 = arith.constant 0 : i64
+    %107 = arith.cmpi slt, %106, %c0_i64_46 : i64
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %107, ^bb1(%c84_i8_47 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c0_i64_61 = arith.constant 0 : i64
-    %121 = arith.cmpi ne, %119, %c0_i64_61 : i64
-    cf.cond_br %121, ^bb120, ^bb45
+    %c0_i64_48 = arith.constant 0 : i64
+    %108 = arith.cmpi ne, %106, %c0_i64_48 : i64
+    cf.cond_br %108, ^bb120, ^bb45
   ^bb45:  // 2 preds: ^bb44, ^bb126
     %c32000_i64 = arith.constant 32000 : i64
-    %122 = llvm.load %arg1 : !llvm.ptr -> i64
-    %123 = arith.cmpi ult, %122, %c32000_i64 : i64
-    scf.if %123 {
+    %109 = llvm.load %arg1 : !llvm.ptr -> i64
+    %110 = arith.cmpi ult, %109, %c32000_i64 : i64
+    scf.if %110 {
     } else {
-      %475 = arith.subi %122, %c32000_i64 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %109, %c32000_i64 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %123, ^bb1(%c80_i8_62 : i8), ^bb46
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %110, ^bb1(%c80_i8_49 : i8), ^bb46
   ^bb46:  // pred: ^bb45
     %c1_i256 = arith.constant 1 : i256
-    %124 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %107, %124 {alignment = 1 : i64} : i256, !llvm.ptr
-    %125 = llvm.load %arg1 : !llvm.ptr -> i64
-    %126 = arith.trunci %111 : i256 to i64
-    %127 = call @dora_fn_create(%arg0, %119, %126, %124, %125) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %128 = llvm.getelementptr %127[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %129 = llvm.load %128 : !llvm.ptr -> i8
-    %c0_i8_63 = arith.constant 0 : i8
-    %130 = arith.cmpi ne, %129, %c0_i8_63 : i8
-    cf.cond_br %130, ^bb1(%129 : i8), ^bb47
+    %111 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %96, %111 {alignment = 1 : i64} : i256, !llvm.ptr
+    %112 = llvm.load %arg1 : !llvm.ptr -> i64
+    %113 = arith.trunci %99 : i256 to i64
+    %114 = call @dora_fn_create(%arg0, %106, %113, %111, %112) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %115 = llvm.getelementptr %114[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %116 = llvm.load %115 : !llvm.ptr -> i8
+    %c0_i8_50 = arith.constant 0 : i8
+    %117 = arith.cmpi ne, %116, %c0_i8_50 : i8
+    cf.cond_br %117, ^bb1(%116 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %131 = llvm.getelementptr %127[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %132 = llvm.load %131 : !llvm.ptr -> i64
-    %133 = llvm.load %arg1 : !llvm.ptr -> i64
-    %134 = arith.cmpi ult, %133, %132 : i64
-    scf.if %134 {
+    %118 = llvm.getelementptr %114[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %119 = llvm.load %118 : !llvm.ptr -> i64
+    %120 = llvm.load %arg1 : !llvm.ptr -> i64
+    %121 = arith.cmpi ult, %120, %119 : i64
+    scf.if %121 {
     } else {
-      %475 = arith.subi %133, %132 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %120, %119 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_64 = arith.constant 80 : i8
-    cf.cond_br %134, ^bb1(%c80_i8_64 : i8), ^bb48
+    %c80_i8_51 = arith.constant 80 : i8
+    cf.cond_br %121, ^bb1(%c80_i8_51 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %135 = llvm.load %124 : !llvm.ptr -> i256
-    %136 = llvm.load %arg3 : !llvm.ptr -> i64
-    %137 = llvm.getelementptr %arg2[%136] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_65 = arith.constant 1 : i64
-    %138 = arith.addi %136, %c1_i64_65 : i64
-    llvm.store %138, %arg3 : i64, !llvm.ptr
-    llvm.store %135, %137 : i256, !llvm.ptr
+    %122 = llvm.load %111 : !llvm.ptr -> i256
+    %123 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %122, %123 : i256, !llvm.ptr
+    %124 = llvm.getelementptr %123[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %124, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb54
   ^bb49:  // pred: ^bb51
-    %c1024_i64_66 = arith.constant 1024 : i64
-    %139 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_67 = arith.constant -2 : i64
-    %140 = arith.addi %139, %c-2_i64_67 : i64
-    %c3_i64_68 = arith.constant 3 : i64
-    %141 = arith.cmpi ult, %139, %c3_i64_68 : i64
-    %c91_i8_69 = arith.constant 91 : i8
-    cf.cond_br %141, ^bb1(%c91_i8_69 : i8), ^bb41
+    %c1024_i64_52 = arith.constant 1024 : i64
+    %125 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_53 = arith.constant -2 : i64
+    %126 = arith.addi %125, %c-2_i64_53 : i64
+    llvm.store %126, %arg3 : i64, !llvm.ptr
+    %c3_i64_54 = arith.constant 3 : i64
+    %127 = arith.cmpi ult, %125, %c3_i64_54 : i64
+    %c91_i8_55 = arith.constant 91 : i8
+    cf.cond_br %127, ^bb1(%c91_i8_55 : i8), ^bb41
   ^bb50:  // pred: ^bb37
-    %142 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_70 = arith.constant 0 : i64
+    %128 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_56 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %143 = arith.cmpi uge, %142, %c0_i64_70 : i64
-    %c80_i8_71 = arith.constant 80 : i8
-    cf.cond_br %143, ^bb51, ^bb1(%c80_i8_71 : i8)
+    %129 = arith.cmpi uge, %128, %c0_i64_56 : i64
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %129, ^bb51, ^bb1(%c80_i8_57 : i8)
   ^bb51:  // pred: ^bb50
-    %144 = arith.subi %142, %c0_i64_70 : i64
-    llvm.store %144, %arg1 : i64, !llvm.ptr
+    %130 = arith.subi %128, %c0_i64_56 : i64
+    llvm.store %130, %arg1 : i64, !llvm.ptr
     cf.br ^bb49
   ^bb52:  // pred: ^bb53
-    %c0_i256_72 = arith.constant 0 : i256
-    %145 = llvm.load %arg3 : !llvm.ptr -> i64
-    %146 = llvm.getelementptr %arg2[%145] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_73 = arith.constant 1 : i64
-    %147 = arith.addi %145, %c1_i64_73 : i64
-    llvm.store %147, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_72, %146 : i256, !llvm.ptr
+    %c0_i256_58 = arith.constant 0 : i256
+    %131 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_58, %131 : i256, !llvm.ptr
+    %132 = llvm.getelementptr %131[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %132, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb58
   ^bb53:  // pred: ^bb55
-    %c1024_i64_74 = arith.constant 1024 : i64
-    %148 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_75 = arith.constant 1 : i64
-    %149 = arith.addi %148, %c1_i64_75 : i64
-    %150 = arith.cmpi ult, %c1024_i64_74, %149 : i64
-    %c92_i8_76 = arith.constant 92 : i8
-    cf.cond_br %150, ^bb1(%c92_i8_76 : i8), ^bb52
+    %c1024_i64_59 = arith.constant 1024 : i64
+    %133 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_60 = arith.constant 1 : i64
+    %134 = arith.addi %133, %c1_i64_60 : i64
+    llvm.store %134, %arg3 : i64, !llvm.ptr
+    %135 = arith.cmpi ult, %c1024_i64_59, %134 : i64
+    %c92_i8_61 = arith.constant 92 : i8
+    cf.cond_br %135, ^bb1(%c92_i8_61 : i8), ^bb52
   ^bb54:  // pred: ^bb48
-    %151 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_77 = arith.constant 3 : i64
+    %136 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_62 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %152 = arith.cmpi uge, %151, %c3_i64_77 : i64
-    %c80_i8_78 = arith.constant 80 : i8
-    cf.cond_br %152, ^bb55, ^bb1(%c80_i8_78 : i8)
+    %137 = arith.cmpi uge, %136, %c3_i64_62 : i64
+    %c80_i8_63 = arith.constant 80 : i8
+    cf.cond_br %137, ^bb55, ^bb1(%c80_i8_63 : i8)
   ^bb55:  // pred: ^bb54
-    %153 = arith.subi %151, %c3_i64_77 : i64
-    llvm.store %153, %arg1 : i64, !llvm.ptr
+    %138 = arith.subi %136, %c3_i64_62 : i64
+    llvm.store %138, %arg1 : i64, !llvm.ptr
     cf.br ^bb53
   ^bb56:  // pred: ^bb57
-    %c0_i256_79 = arith.constant 0 : i256
-    %154 = llvm.load %arg3 : !llvm.ptr -> i64
-    %155 = llvm.getelementptr %arg2[%154] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_80 = arith.constant 1 : i64
-    %156 = arith.addi %154, %c1_i64_80 : i64
-    llvm.store %156, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_79, %155 : i256, !llvm.ptr
+    %c0_i256_64 = arith.constant 0 : i256
+    %139 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_64, %139 : i256, !llvm.ptr
+    %140 = llvm.getelementptr %139[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %140, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb63
   ^bb57:  // pred: ^bb59
-    %c1024_i64_81 = arith.constant 1024 : i64
-    %157 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_82 = arith.constant 1 : i64
-    %158 = arith.addi %157, %c1_i64_82 : i64
-    %159 = arith.cmpi ult, %c1024_i64_81, %158 : i64
-    %c92_i8_83 = arith.constant 92 : i8
-    cf.cond_br %159, ^bb1(%c92_i8_83 : i8), ^bb56
+    %c1024_i64_65 = arith.constant 1024 : i64
+    %141 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_66 = arith.constant 1 : i64
+    %142 = arith.addi %141, %c1_i64_66 : i64
+    llvm.store %142, %arg3 : i64, !llvm.ptr
+    %143 = arith.cmpi ult, %c1024_i64_65, %142 : i64
+    %c92_i8_67 = arith.constant 92 : i8
+    cf.cond_br %143, ^bb1(%c92_i8_67 : i8), ^bb56
   ^bb58:  // pred: ^bb52
-    %160 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_84 = arith.constant 3 : i64
+    %144 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_68 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %161 = arith.cmpi uge, %160, %c3_i64_84 : i64
-    %c80_i8_85 = arith.constant 80 : i8
-    cf.cond_br %161, ^bb59, ^bb1(%c80_i8_85 : i8)
+    %145 = arith.cmpi uge, %144, %c3_i64_68 : i64
+    %c80_i8_69 = arith.constant 80 : i8
+    cf.cond_br %145, ^bb59, ^bb1(%c80_i8_69 : i8)
   ^bb59:  // pred: ^bb58
-    %162 = arith.subi %160, %c3_i64_84 : i64
-    llvm.store %162, %arg1 : i64, !llvm.ptr
+    %146 = arith.subi %144, %c3_i64_68 : i64
+    llvm.store %146, %arg1 : i64, !llvm.ptr
     cf.br ^bb57
   ^bb60:  // pred: ^bb62
-    %163 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_86 = arith.constant 1 : i64
-    %164 = arith.subi %163, %c1_i64_86 : i64
-    %165 = llvm.getelementptr %arg2[%164] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %164, %arg3 : i64, !llvm.ptr
-    %166 = llvm.load %165 : !llvm.ptr -> i256
-    %167 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_87 = arith.constant 1 : i64
-    %168 = arith.subi %167, %c1_i64_87 : i64
-    %169 = llvm.getelementptr %arg2[%168] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %168, %arg3 : i64, !llvm.ptr
-    %170 = llvm.load %169 : !llvm.ptr -> i256
-    %c32_i64_88 = arith.constant 32 : i64
-    %c0_i64_89 = arith.constant 0 : i64
-    %171 = arith.cmpi ne, %c32_i64_88, %c0_i64_89 : i64
-    cf.cond_br %171, ^bb130, ^bb61
+    %147 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %148 = llvm.getelementptr %147[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %149 = llvm.load %148 : !llvm.ptr -> i256
+    llvm.store %148, %0 : !llvm.ptr, !llvm.ptr
+    %150 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %151 = llvm.getelementptr %150[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %152 = llvm.load %151 : !llvm.ptr -> i256
+    llvm.store %151, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_70 = arith.constant 32 : i64
+    %c0_i64_71 = arith.constant 0 : i64
+    %153 = arith.cmpi ne, %c32_i64_70, %c0_i64_71 : i64
+    cf.cond_br %153, ^bb130, ^bb61
   ^bb61:  // 2 preds: ^bb60, ^bb134
-    %172 = arith.trunci %166 : i256 to i64
-    %173 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %174 = llvm.getelementptr %173[%172] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %175 = llvm.intr.bswap(%170)  : (i256) -> i256
-    llvm.store %175, %174 {alignment = 1 : i64} : i256, !llvm.ptr
+    %154 = arith.trunci %149 : i256 to i64
+    %155 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %156 = llvm.getelementptr %155[%154] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %157 = llvm.intr.bswap(%152)  : (i256) -> i256
+    llvm.store %157, %156 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb67
   ^bb62:  // pred: ^bb64
-    %c1024_i64_90 = arith.constant 1024 : i64
-    %176 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_91 = arith.constant -2 : i64
-    %177 = arith.addi %176, %c-2_i64_91 : i64
-    %c2_i64_92 = arith.constant 2 : i64
-    %178 = arith.cmpi ult, %176, %c2_i64_92 : i64
-    %c91_i8_93 = arith.constant 91 : i8
-    cf.cond_br %178, ^bb1(%c91_i8_93 : i8), ^bb60
+    %c1024_i64_72 = arith.constant 1024 : i64
+    %158 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_73 = arith.constant -2 : i64
+    %159 = arith.addi %158, %c-2_i64_73 : i64
+    llvm.store %159, %arg3 : i64, !llvm.ptr
+    %c2_i64_74 = arith.constant 2 : i64
+    %160 = arith.cmpi ult, %158, %c2_i64_74 : i64
+    %c91_i8_75 = arith.constant 91 : i8
+    cf.cond_br %160, ^bb1(%c91_i8_75 : i8), ^bb60
   ^bb63:  // pred: ^bb56
-    %179 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_94 = arith.constant 3 : i64
+    %161 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_76 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %180 = arith.cmpi uge, %179, %c3_i64_94 : i64
-    %c80_i8_95 = arith.constant 80 : i8
-    cf.cond_br %180, ^bb64, ^bb1(%c80_i8_95 : i8)
+    %162 = arith.cmpi uge, %161, %c3_i64_76 : i64
+    %c80_i8_77 = arith.constant 80 : i8
+    cf.cond_br %162, ^bb64, ^bb1(%c80_i8_77 : i8)
   ^bb64:  // pred: ^bb63
-    %181 = arith.subi %179, %c3_i64_94 : i64
-    llvm.store %181, %arg1 : i64, !llvm.ptr
+    %163 = arith.subi %161, %c3_i64_76 : i64
+    llvm.store %163, %arg1 : i64, !llvm.ptr
     cf.br ^bb62
   ^bb65:  // pred: ^bb66
-    %c0_i256_96 = arith.constant 0 : i256
-    %182 = llvm.load %arg3 : !llvm.ptr -> i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_97 = arith.constant 1 : i64
-    %184 = arith.addi %182, %c1_i64_97 : i64
-    llvm.store %184, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_96, %183 : i256, !llvm.ptr
+    %c0_i256_78 = arith.constant 0 : i256
+    %164 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_78, %164 : i256, !llvm.ptr
+    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %165, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb71
   ^bb66:  // pred: ^bb68
-    %c1024_i64_98 = arith.constant 1024 : i64
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_99 = arith.constant 1 : i64
-    %186 = arith.addi %185, %c1_i64_99 : i64
-    %187 = arith.cmpi ult, %c1024_i64_98, %186 : i64
-    %c92_i8_100 = arith.constant 92 : i8
-    cf.cond_br %187, ^bb1(%c92_i8_100 : i8), ^bb65
+    %c1024_i64_79 = arith.constant 1024 : i64
+    %166 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_80 = arith.constant 1 : i64
+    %167 = arith.addi %166, %c1_i64_80 : i64
+    llvm.store %167, %arg3 : i64, !llvm.ptr
+    %168 = arith.cmpi ult, %c1024_i64_79, %167 : i64
+    %c92_i8_81 = arith.constant 92 : i8
+    cf.cond_br %168, ^bb1(%c92_i8_81 : i8), ^bb65
   ^bb67:  // pred: ^bb61
-    %188 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_101 = arith.constant 3 : i64
+    %169 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_82 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %189 = arith.cmpi uge, %188, %c3_i64_101 : i64
-    %c80_i8_102 = arith.constant 80 : i8
-    cf.cond_br %189, ^bb68, ^bb1(%c80_i8_102 : i8)
+    %170 = arith.cmpi uge, %169, %c3_i64_82 : i64
+    %c80_i8_83 = arith.constant 80 : i8
+    cf.cond_br %170, ^bb68, ^bb1(%c80_i8_83 : i8)
   ^bb68:  // pred: ^bb67
-    %190 = arith.subi %188, %c3_i64_101 : i64
-    llvm.store %190, %arg1 : i64, !llvm.ptr
+    %171 = arith.subi %169, %c3_i64_82 : i64
+    llvm.store %171, %arg1 : i64, !llvm.ptr
     cf.br ^bb66
   ^bb69:  // pred: ^bb70
-    %c32_i256_103 = arith.constant 32 : i256
-    %191 = llvm.load %arg3 : !llvm.ptr -> i64
-    %192 = llvm.getelementptr %arg2[%191] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_104 = arith.constant 1 : i64
-    %193 = arith.addi %191, %c1_i64_104 : i64
-    llvm.store %193, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_103, %192 : i256, !llvm.ptr
+    %c32_i256_84 = arith.constant 32 : i256
+    %172 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_84, %172 : i256, !llvm.ptr
+    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %173, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb76
   ^bb70:  // pred: ^bb72
-    %c1024_i64_105 = arith.constant 1024 : i64
-    %194 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_106 = arith.constant 1 : i64
-    %195 = arith.addi %194, %c1_i64_106 : i64
-    %196 = arith.cmpi ult, %c1024_i64_105, %195 : i64
-    %c92_i8_107 = arith.constant 92 : i8
-    cf.cond_br %196, ^bb1(%c92_i8_107 : i8), ^bb69
+    %c1024_i64_85 = arith.constant 1024 : i64
+    %174 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_86 = arith.constant 1 : i64
+    %175 = arith.addi %174, %c1_i64_86 : i64
+    llvm.store %175, %arg3 : i64, !llvm.ptr
+    %176 = arith.cmpi ult, %c1024_i64_85, %175 : i64
+    %c92_i8_87 = arith.constant 92 : i8
+    cf.cond_br %176, ^bb1(%c92_i8_87 : i8), ^bb69
   ^bb71:  // pred: ^bb65
-    %197 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_108 = arith.constant 3 : i64
+    %177 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_88 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %198 = arith.cmpi uge, %197, %c3_i64_108 : i64
-    %c80_i8_109 = arith.constant 80 : i8
-    cf.cond_br %198, ^bb72, ^bb1(%c80_i8_109 : i8)
+    %178 = arith.cmpi uge, %177, %c3_i64_88 : i64
+    %c80_i8_89 = arith.constant 80 : i8
+    cf.cond_br %178, ^bb72, ^bb1(%c80_i8_89 : i8)
   ^bb72:  // pred: ^bb71
-    %199 = arith.subi %197, %c3_i64_108 : i64
-    llvm.store %199, %arg1 : i64, !llvm.ptr
+    %179 = arith.subi %177, %c3_i64_88 : i64
+    llvm.store %179, %arg1 : i64, !llvm.ptr
     cf.br ^bb70
   ^bb73:  // pred: ^bb75
-    %200 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_110 = arith.constant 1 : i64
-    %201 = arith.subi %200, %c1_i64_110 : i64
-    %202 = llvm.getelementptr %arg2[%201] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %201, %arg3 : i64, !llvm.ptr
-    %203 = llvm.load %202 : !llvm.ptr -> i256
-    %204 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_111 = arith.constant 1 : i64
-    %205 = arith.subi %204, %c1_i64_111 : i64
-    %206 = llvm.getelementptr %arg2[%205] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %205, %arg3 : i64, !llvm.ptr
-    %207 = llvm.load %206 : !llvm.ptr -> i256
-    %c32_i64_112 = arith.constant 32 : i64
-    %c0_i64_113 = arith.constant 0 : i64
-    %208 = arith.cmpi ne, %c32_i64_112, %c0_i64_113 : i64
-    cf.cond_br %208, ^bb138, ^bb74
+    %180 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %181 = llvm.getelementptr %180[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %182 = llvm.load %181 : !llvm.ptr -> i256
+    llvm.store %181, %0 : !llvm.ptr, !llvm.ptr
+    %183 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %184 = llvm.getelementptr %183[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %185 = llvm.load %184 : !llvm.ptr -> i256
+    llvm.store %184, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_90 = arith.constant 32 : i64
+    %c0_i64_91 = arith.constant 0 : i64
+    %186 = arith.cmpi ne, %c32_i64_90, %c0_i64_91 : i64
+    cf.cond_br %186, ^bb138, ^bb74
   ^bb74:  // 2 preds: ^bb73, ^bb142
-    %209 = arith.trunci %203 : i256 to i64
-    %210 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %211 = llvm.getelementptr %210[%209] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %212 = llvm.intr.bswap(%207)  : (i256) -> i256
-    llvm.store %212, %211 {alignment = 1 : i64} : i256, !llvm.ptr
+    %187 = arith.trunci %182 : i256 to i64
+    %188 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %189 = llvm.getelementptr %188[%187] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %190 = llvm.intr.bswap(%185)  : (i256) -> i256
+    llvm.store %190, %189 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb80
   ^bb75:  // pred: ^bb77
-    %c1024_i64_114 = arith.constant 1024 : i64
-    %213 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_115 = arith.constant -2 : i64
-    %214 = arith.addi %213, %c-2_i64_115 : i64
-    %c2_i64_116 = arith.constant 2 : i64
-    %215 = arith.cmpi ult, %213, %c2_i64_116 : i64
-    %c91_i8_117 = arith.constant 91 : i8
-    cf.cond_br %215, ^bb1(%c91_i8_117 : i8), ^bb73
+    %c1024_i64_92 = arith.constant 1024 : i64
+    %191 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_93 = arith.constant -2 : i64
+    %192 = arith.addi %191, %c-2_i64_93 : i64
+    llvm.store %192, %arg3 : i64, !llvm.ptr
+    %c2_i64_94 = arith.constant 2 : i64
+    %193 = arith.cmpi ult, %191, %c2_i64_94 : i64
+    %c91_i8_95 = arith.constant 91 : i8
+    cf.cond_br %193, ^bb1(%c91_i8_95 : i8), ^bb73
   ^bb76:  // pred: ^bb69
-    %216 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_118 = arith.constant 3 : i64
+    %194 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_96 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %217 = arith.cmpi uge, %216, %c3_i64_118 : i64
-    %c80_i8_119 = arith.constant 80 : i8
-    cf.cond_br %217, ^bb77, ^bb1(%c80_i8_119 : i8)
+    %195 = arith.cmpi uge, %194, %c3_i64_96 : i64
+    %c80_i8_97 = arith.constant 80 : i8
+    cf.cond_br %195, ^bb77, ^bb1(%c80_i8_97 : i8)
   ^bb77:  // pred: ^bb76
-    %218 = arith.subi %216, %c3_i64_118 : i64
-    llvm.store %218, %arg1 : i64, !llvm.ptr
+    %196 = arith.subi %194, %c3_i64_96 : i64
+    llvm.store %196, %arg1 : i64, !llvm.ptr
     cf.br ^bb75
   ^bb78:  // pred: ^bb79
-    %c32_i256_120 = arith.constant 32 : i256
-    %219 = llvm.load %arg3 : !llvm.ptr -> i64
-    %220 = llvm.getelementptr %arg2[%219] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_121 = arith.constant 1 : i64
-    %221 = arith.addi %219, %c1_i64_121 : i64
-    llvm.store %221, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_120, %220 : i256, !llvm.ptr
+    %c32_i256_98 = arith.constant 32 : i256
+    %197 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_98, %197 : i256, !llvm.ptr
+    %198 = llvm.getelementptr %197[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %198, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb84
   ^bb79:  // pred: ^bb81
-    %c1024_i64_122 = arith.constant 1024 : i64
-    %222 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_123 = arith.constant 1 : i64
-    %223 = arith.addi %222, %c1_i64_123 : i64
-    %224 = arith.cmpi ult, %c1024_i64_122, %223 : i64
-    %c92_i8_124 = arith.constant 92 : i8
-    cf.cond_br %224, ^bb1(%c92_i8_124 : i8), ^bb78
+    %c1024_i64_99 = arith.constant 1024 : i64
+    %199 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_100 = arith.constant 1 : i64
+    %200 = arith.addi %199, %c1_i64_100 : i64
+    llvm.store %200, %arg3 : i64, !llvm.ptr
+    %201 = arith.cmpi ult, %c1024_i64_99, %200 : i64
+    %c92_i8_101 = arith.constant 92 : i8
+    cf.cond_br %201, ^bb1(%c92_i8_101 : i8), ^bb78
   ^bb80:  // pred: ^bb74
-    %225 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_125 = arith.constant 3 : i64
+    %202 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_102 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %226 = arith.cmpi uge, %225, %c3_i64_125 : i64
-    %c80_i8_126 = arith.constant 80 : i8
-    cf.cond_br %226, ^bb81, ^bb1(%c80_i8_126 : i8)
+    %203 = arith.cmpi uge, %202, %c3_i64_102 : i64
+    %c80_i8_103 = arith.constant 80 : i8
+    cf.cond_br %203, ^bb81, ^bb1(%c80_i8_103 : i8)
   ^bb81:  // pred: ^bb80
-    %227 = arith.subi %225, %c3_i64_125 : i64
-    llvm.store %227, %arg1 : i64, !llvm.ptr
+    %204 = arith.subi %202, %c3_i64_102 : i64
+    llvm.store %204, %arg1 : i64, !llvm.ptr
     cf.br ^bb79
   ^bb82:  // pred: ^bb83
-    %c0_i256_127 = arith.constant 0 : i256
-    %228 = llvm.load %arg3 : !llvm.ptr -> i64
-    %229 = llvm.getelementptr %arg2[%228] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_128 = arith.constant 1 : i64
-    %230 = arith.addi %228, %c1_i64_128 : i64
-    llvm.store %230, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_127, %229 : i256, !llvm.ptr
+    %c0_i256_104 = arith.constant 0 : i256
+    %205 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_104, %205 : i256, !llvm.ptr
+    %206 = llvm.getelementptr %205[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %206, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb88
   ^bb83:  // pred: ^bb85
-    %c1024_i64_129 = arith.constant 1024 : i64
-    %231 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_130 = arith.constant 1 : i64
-    %232 = arith.addi %231, %c1_i64_130 : i64
-    %233 = arith.cmpi ult, %c1024_i64_129, %232 : i64
-    %c92_i8_131 = arith.constant 92 : i8
-    cf.cond_br %233, ^bb1(%c92_i8_131 : i8), ^bb82
+    %c1024_i64_105 = arith.constant 1024 : i64
+    %207 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_106 = arith.constant 1 : i64
+    %208 = arith.addi %207, %c1_i64_106 : i64
+    llvm.store %208, %arg3 : i64, !llvm.ptr
+    %209 = arith.cmpi ult, %c1024_i64_105, %208 : i64
+    %c92_i8_107 = arith.constant 92 : i8
+    cf.cond_br %209, ^bb1(%c92_i8_107 : i8), ^bb82
   ^bb84:  // pred: ^bb78
-    %234 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_132 = arith.constant 3 : i64
+    %210 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_108 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %235 = arith.cmpi uge, %234, %c3_i64_132 : i64
-    %c80_i8_133 = arith.constant 80 : i8
-    cf.cond_br %235, ^bb85, ^bb1(%c80_i8_133 : i8)
+    %211 = arith.cmpi uge, %210, %c3_i64_108 : i64
+    %c80_i8_109 = arith.constant 80 : i8
+    cf.cond_br %211, ^bb85, ^bb1(%c80_i8_109 : i8)
   ^bb85:  // pred: ^bb84
-    %236 = arith.subi %234, %c3_i64_132 : i64
-    llvm.store %236, %arg1 : i64, !llvm.ptr
+    %212 = arith.subi %210, %c3_i64_108 : i64
+    llvm.store %212, %arg1 : i64, !llvm.ptr
     cf.br ^bb83
   ^bb86:  // pred: ^bb87
-    %c0_i256_134 = arith.constant 0 : i256
-    %237 = llvm.load %arg3 : !llvm.ptr -> i64
-    %238 = llvm.getelementptr %arg2[%237] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_135 = arith.constant 1 : i64
-    %239 = arith.addi %237, %c1_i64_135 : i64
-    llvm.store %239, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_134, %238 : i256, !llvm.ptr
+    %c0_i256_110 = arith.constant 0 : i256
+    %213 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_110, %213 : i256, !llvm.ptr
+    %214 = llvm.getelementptr %213[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %214, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb92
   ^bb87:  // pred: ^bb89
-    %c1024_i64_136 = arith.constant 1024 : i64
-    %240 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_137 = arith.constant 1 : i64
-    %241 = arith.addi %240, %c1_i64_137 : i64
-    %242 = arith.cmpi ult, %c1024_i64_136, %241 : i64
-    %c92_i8_138 = arith.constant 92 : i8
-    cf.cond_br %242, ^bb1(%c92_i8_138 : i8), ^bb86
+    %c1024_i64_111 = arith.constant 1024 : i64
+    %215 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_112 = arith.constant 1 : i64
+    %216 = arith.addi %215, %c1_i64_112 : i64
+    llvm.store %216, %arg3 : i64, !llvm.ptr
+    %217 = arith.cmpi ult, %c1024_i64_111, %216 : i64
+    %c92_i8_113 = arith.constant 92 : i8
+    cf.cond_br %217, ^bb1(%c92_i8_113 : i8), ^bb86
   ^bb88:  // pred: ^bb82
-    %243 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_139 = arith.constant 3 : i64
+    %218 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_114 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %244 = arith.cmpi uge, %243, %c3_i64_139 : i64
-    %c80_i8_140 = arith.constant 80 : i8
-    cf.cond_br %244, ^bb89, ^bb1(%c80_i8_140 : i8)
+    %219 = arith.cmpi uge, %218, %c3_i64_114 : i64
+    %c80_i8_115 = arith.constant 80 : i8
+    cf.cond_br %219, ^bb89, ^bb1(%c80_i8_115 : i8)
   ^bb89:  // pred: ^bb88
-    %245 = arith.subi %243, %c3_i64_139 : i64
-    llvm.store %245, %arg1 : i64, !llvm.ptr
+    %220 = arith.subi %218, %c3_i64_114 : i64
+    llvm.store %220, %arg1 : i64, !llvm.ptr
     cf.br ^bb87
   ^bb90:  // pred: ^bb91
-    %246 = llvm.load %arg3 : !llvm.ptr -> i64
-    %247 = llvm.getelementptr %arg2[%246] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %248 = llvm.getelementptr %247[-4] : (!llvm.ptr) -> !llvm.ptr, i256
-    %249 = llvm.load %248 : !llvm.ptr -> i256
-    %250 = llvm.load %arg3 : !llvm.ptr -> i64
-    %251 = llvm.getelementptr %arg2[%250] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_141 = arith.constant 1 : i64
-    %252 = arith.addi %250, %c1_i64_141 : i64
-    llvm.store %252, %arg3 : i64, !llvm.ptr
-    llvm.store %249, %251 : i256, !llvm.ptr
+    %221 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %222 = llvm.getelementptr %221[-4] : (!llvm.ptr) -> !llvm.ptr, i256
+    %223 = llvm.load %222 : !llvm.ptr -> i256
+    %224 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %223, %224 : i256, !llvm.ptr
+    %225 = llvm.getelementptr %224[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %225, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb101
   ^bb91:  // pred: ^bb93
-    %c1024_i64_142 = arith.constant 1024 : i64
-    %253 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_143 = arith.constant 1 : i64
-    %254 = arith.addi %253, %c1_i64_143 : i64
+    %c1024_i64_116 = arith.constant 1024 : i64
+    %226 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_117 = arith.constant 1 : i64
+    %227 = arith.addi %226, %c1_i64_117 : i64
+    llvm.store %227, %arg3 : i64, !llvm.ptr
     %c4_i64 = arith.constant 4 : i64
-    %255 = arith.cmpi ult, %253, %c4_i64 : i64
-    %256 = arith.cmpi ult, %c1024_i64_142, %254 : i64
-    %257 = arith.xori %255, %256 : i1
-    %c92_i8_144 = arith.constant 92 : i8
-    cf.cond_br %257, ^bb1(%c92_i8_144 : i8), ^bb90
+    %228 = arith.cmpi ult, %226, %c4_i64 : i64
+    %229 = arith.cmpi ult, %c1024_i64_116, %227 : i64
+    %230 = arith.xori %228, %229 : i1
+    %c92_i8_118 = arith.constant 92 : i8
+    cf.cond_br %230, ^bb1(%c92_i8_118 : i8), ^bb90
   ^bb92:  // pred: ^bb86
-    %258 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_145 = arith.constant 3 : i64
+    %231 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_119 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %259 = arith.cmpi uge, %258, %c3_i64_145 : i64
-    %c80_i8_146 = arith.constant 80 : i8
-    cf.cond_br %259, ^bb93, ^bb1(%c80_i8_146 : i8)
+    %232 = arith.cmpi uge, %231, %c3_i64_119 : i64
+    %c80_i8_120 = arith.constant 80 : i8
+    cf.cond_br %232, ^bb93, ^bb1(%c80_i8_120 : i8)
   ^bb93:  // pred: ^bb92
-    %260 = arith.subi %258, %c3_i64_145 : i64
-    llvm.store %260, %arg1 : i64, !llvm.ptr
+    %233 = arith.subi %231, %c3_i64_119 : i64
+    llvm.store %233, %arg1 : i64, !llvm.ptr
     cf.br ^bb91
   ^bb94:  // pred: ^bb100
-    %261 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_147 = arith.constant 1 : i64
-    %262 = arith.subi %261, %c1_i64_147 : i64
-    %263 = llvm.getelementptr %arg2[%262] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %262, %arg3 : i64, !llvm.ptr
-    %264 = llvm.load %263 : !llvm.ptr -> i256
-    %265 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_148 = arith.constant 1 : i64
-    %266 = arith.subi %265, %c1_i64_148 : i64
-    %267 = llvm.getelementptr %arg2[%266] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %266, %arg3 : i64, !llvm.ptr
-    %268 = llvm.load %267 : !llvm.ptr -> i256
-    %269 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_149 = arith.constant 1 : i64
-    %270 = arith.subi %269, %c1_i64_149 : i64
-    %271 = llvm.getelementptr %arg2[%270] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %270, %arg3 : i64, !llvm.ptr
-    %272 = llvm.load %271 : !llvm.ptr -> i256
-    %273 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_150 = arith.constant 1 : i64
-    %274 = arith.subi %273, %c1_i64_150 : i64
-    %275 = llvm.getelementptr %arg2[%274] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %274, %arg3 : i64, !llvm.ptr
-    %276 = llvm.load %275 : !llvm.ptr -> i256
-    %c18446744073709551615_i256_151 = arith.constant 18446744073709551615 : i256
-    %277 = arith.cmpi sgt, %276, %c18446744073709551615_i256_151 : i256
-    %c84_i8_152 = arith.constant 84 : i8
-    cf.cond_br %277, ^bb1(%c84_i8_152 : i8), ^bb95
+    %234 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %235 = llvm.getelementptr %234[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %236 = llvm.load %235 : !llvm.ptr -> i256
+    llvm.store %235, %0 : !llvm.ptr, !llvm.ptr
+    %237 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %238 = llvm.getelementptr %237[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %239 = llvm.load %238 : !llvm.ptr -> i256
+    llvm.store %238, %0 : !llvm.ptr, !llvm.ptr
+    %240 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %241 = llvm.getelementptr %240[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %242 = llvm.load %241 : !llvm.ptr -> i256
+    llvm.store %241, %0 : !llvm.ptr, !llvm.ptr
+    %243 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %244 = llvm.getelementptr %243[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %245 = llvm.load %244 : !llvm.ptr -> i256
+    llvm.store %244, %0 : !llvm.ptr, !llvm.ptr
+    %c18446744073709551615_i256_121 = arith.constant 18446744073709551615 : i256
+    %246 = arith.cmpi sgt, %245, %c18446744073709551615_i256_121 : i256
+    %c84_i8_122 = arith.constant 84 : i8
+    cf.cond_br %246, ^bb1(%c84_i8_122 : i8), ^bb95
   ^bb95:  // pred: ^bb94
-    %278 = arith.trunci %276 : i256 to i64
-    %c0_i64_153 = arith.constant 0 : i64
-    %279 = arith.cmpi slt, %278, %c0_i64_153 : i64
-    %c84_i8_154 = arith.constant 84 : i8
-    cf.cond_br %279, ^bb1(%c84_i8_154 : i8), ^bb96
+    %247 = arith.trunci %245 : i256 to i64
+    %c0_i64_123 = arith.constant 0 : i64
+    %248 = arith.cmpi slt, %247, %c0_i64_123 : i64
+    %c84_i8_124 = arith.constant 84 : i8
+    cf.cond_br %248, ^bb1(%c84_i8_124 : i8), ^bb96
   ^bb96:  // pred: ^bb95
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_155 = arith.constant 32 : i64
-    %280 = arith.addi %278, %c31_i64 : i64
-    %281 = arith.divui %280, %c32_i64_155 : i64
-    %c3_i64_156 = arith.constant 3 : i64
-    %282 = arith.muli %281, %c3_i64_156 : i64
-    %283 = llvm.load %arg1 : !llvm.ptr -> i64
-    %284 = arith.cmpi ult, %283, %282 : i64
-    scf.if %284 {
+    %c32_i64_125 = arith.constant 32 : i64
+    %249 = arith.addi %247, %c31_i64 : i64
+    %250 = arith.divui %249, %c32_i64_125 : i64
+    %c3_i64_126 = arith.constant 3 : i64
+    %251 = arith.muli %250, %c3_i64_126 : i64
+    %252 = llvm.load %arg1 : !llvm.ptr -> i64
+    %253 = arith.cmpi ult, %252, %251 : i64
+    scf.if %253 {
     } else {
-      %475 = arith.subi %283, %282 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %252, %251 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_157 = arith.constant 80 : i8
-    cf.cond_br %284, ^bb1(%c80_i8_157 : i8), ^bb97
+    %c80_i8_127 = arith.constant 80 : i8
+    cf.cond_br %253, ^bb1(%c80_i8_127 : i8), ^bb97
   ^bb97:  // pred: ^bb96
-    %c0_i64_158 = arith.constant 0 : i64
-    %285 = arith.cmpi ne, %278, %c0_i64_158 : i64
-    cf.cond_br %285, ^bb146, ^bb98
+    %c0_i64_128 = arith.constant 0 : i64
+    %254 = arith.cmpi ne, %247, %c0_i64_128 : i64
+    cf.cond_br %254, ^bb146, ^bb98
   ^bb98:  // 2 preds: ^bb97, ^bb150
-    %286 = arith.trunci %268 : i256 to i64
-    %c1_i256_159 = arith.constant 1 : i256
-    %287 = llvm.alloca %c1_i256_159 x i256 : (i256) -> !llvm.ptr
-    llvm.store %264, %287 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_160 = arith.constant 1 : i256
-    %288 = llvm.alloca %c1_i256_160 x i256 : (i256) -> !llvm.ptr
-    llvm.store %272, %288 {alignment = 1 : i64} : i256, !llvm.ptr
-    %289 = call @dora_fn_ext_code_copy(%arg0, %287, %288, %278, %286) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
-    %290 = llvm.getelementptr %289[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %291 = llvm.load %290 : !llvm.ptr -> i64
+    %255 = arith.trunci %239 : i256 to i64
+    %c1_i256_129 = arith.constant 1 : i256
+    %256 = llvm.alloca %c1_i256_129 x i256 : (i256) -> !llvm.ptr
+    llvm.store %236, %256 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_130 = arith.constant 1 : i256
+    %257 = llvm.alloca %c1_i256_130 x i256 : (i256) -> !llvm.ptr
+    llvm.store %242, %257 {alignment = 1 : i64} : i256, !llvm.ptr
+    %258 = call @dora_fn_ext_code_copy(%arg0, %256, %257, %247, %255) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> !llvm.ptr
+    %259 = llvm.getelementptr %258[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %260 = llvm.load %259 : !llvm.ptr -> i64
+    %261 = llvm.load %arg1 : !llvm.ptr -> i64
+    %262 = arith.cmpi ult, %261, %260 : i64
+    scf.if %262 {
+    } else {
+      %444 = arith.subi %261, %260 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
+    }
+    %c80_i8_131 = arith.constant 80 : i8
+    cf.cond_br %262, ^bb1(%c80_i8_131 : i8), ^bb99
+  ^bb99:  // pred: ^bb98
+    cf.br ^bb103
+  ^bb100:  // pred: ^bb102
+    %c1024_i64_132 = arith.constant 1024 : i64
+    %263 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-4_i64 = arith.constant -4 : i64
+    %264 = arith.addi %263, %c-4_i64 : i64
+    llvm.store %264, %arg3 : i64, !llvm.ptr
+    %c4_i64_133 = arith.constant 4 : i64
+    %265 = arith.cmpi ult, %263, %c4_i64_133 : i64
+    %c91_i8_134 = arith.constant 91 : i8
+    cf.cond_br %265, ^bb1(%c91_i8_134 : i8), ^bb94
+  ^bb101:  // pred: ^bb90
+    %266 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_135 = arith.constant 0 : i64
+    call @dora_fn_nop() : () -> ()
+    %267 = arith.cmpi uge, %266, %c0_i64_135 : i64
+    %c80_i8_136 = arith.constant 80 : i8
+    cf.cond_br %267, ^bb102, ^bb1(%c80_i8_136 : i8)
+  ^bb102:  // pred: ^bb101
+    %268 = arith.subi %266, %c0_i64_135 : i64
+    llvm.store %268, %arg1 : i64, !llvm.ptr
+    cf.br ^bb100
+  ^bb103:  // pred: ^bb99
+    %c0_i64_137 = arith.constant 0 : i64
+    %c1_i8 = arith.constant 1 : i8
+    %269 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_137, %c0_i64_137, %269, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %c1_i8 : i8
+  ^bb104:  // pred: ^bb11
+    %c18446744073709551615_i256_138 = arith.constant 18446744073709551615 : i256
+    %270 = arith.cmpi sgt, %22, %c18446744073709551615_i256_138 : i256
+    %c84_i8_139 = arith.constant 84 : i8
+    cf.cond_br %270, ^bb1(%c84_i8_139 : i8), ^bb105
+  ^bb105:  // pred: ^bb104
+    %271 = arith.trunci %22 : i256 to i64
+    %c0_i64_140 = arith.constant 0 : i64
+    %272 = arith.cmpi slt, %271, %c0_i64_140 : i64
+    %c84_i8_141 = arith.constant 84 : i8
+    cf.cond_br %272, ^bb1(%c84_i8_141 : i8), ^bb106
+  ^bb106:  // pred: ^bb105
+    %273 = arith.addi %271, %c32_i64 : i64
+    %c0_i64_142 = arith.constant 0 : i64
+    %274 = arith.cmpi slt, %273, %c0_i64_142 : i64
+    %c84_i8_143 = arith.constant 84 : i8
+    cf.cond_br %274, ^bb1(%c84_i8_143 : i8), ^bb107
+  ^bb107:  // pred: ^bb106
+    %c31_i64_144 = arith.constant 31 : i64
+    %c32_i64_145 = arith.constant 32 : i64
+    %275 = arith.addi %273, %c31_i64_144 : i64
+    %276 = arith.divui %275, %c32_i64_145 : i64
+    %c32_i64_146 = arith.constant 32 : i64
+    %277 = arith.muli %276, %c32_i64_146 : i64
+    %278 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_147 = arith.constant 31 : i64
+    %c32_i64_148 = arith.constant 32 : i64
+    %279 = arith.addi %278, %c31_i64_147 : i64
+    %280 = arith.divui %279, %c32_i64_148 : i64
+    %281 = arith.muli %280, %c32_i64_146 : i64
+    %282 = arith.cmpi ult, %281, %277 : i64
+    cf.cond_br %282, ^bb109, ^bb108
+  ^bb108:  // 2 preds: ^bb107, ^bb111
+    cf.br ^bb12
+  ^bb109:  // pred: ^bb107
+    %c3_i64_149 = arith.constant 3 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %283 = arith.muli %280, %280 : i64
+    %284 = arith.divui %283, %c512_i64 : i64
+    %285 = arith.muli %280, %c3_i64_149 : i64
+    %286 = arith.addi %284, %285 : i64
+    %c3_i64_150 = arith.constant 3 : i64
+    %c512_i64_151 = arith.constant 512 : i64
+    %287 = arith.muli %276, %276 : i64
+    %288 = arith.divui %287, %c512_i64_151 : i64
+    %289 = arith.muli %276, %c3_i64_150 : i64
+    %290 = arith.addi %288, %289 : i64
+    %291 = arith.subi %290, %286 : i64
     %292 = llvm.load %arg1 : !llvm.ptr -> i64
     %293 = arith.cmpi ult, %292, %291 : i64
     scf.if %293 {
     } else {
-      %475 = arith.subi %292, %291 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %292, %291 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_161 = arith.constant 80 : i8
-    cf.cond_br %293, ^bb1(%c80_i8_161 : i8), ^bb99
-  ^bb99:  // pred: ^bb98
-    cf.br ^bb103
-  ^bb100:  // pred: ^bb102
-    %c1024_i64_162 = arith.constant 1024 : i64
-    %294 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-4_i64 = arith.constant -4 : i64
-    %295 = arith.addi %294, %c-4_i64 : i64
-    %c4_i64_163 = arith.constant 4 : i64
-    %296 = arith.cmpi ult, %294, %c4_i64_163 : i64
-    %c91_i8_164 = arith.constant 91 : i8
-    cf.cond_br %296, ^bb1(%c91_i8_164 : i8), ^bb94
-  ^bb101:  // pred: ^bb90
-    %297 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_165 = arith.constant 0 : i64
-    call @dora_fn_nop() : () -> ()
-    %298 = arith.cmpi uge, %297, %c0_i64_165 : i64
-    %c80_i8_166 = arith.constant 80 : i8
-    cf.cond_br %298, ^bb102, ^bb1(%c80_i8_166 : i8)
-  ^bb102:  // pred: ^bb101
-    %299 = arith.subi %297, %c0_i64_165 : i64
-    llvm.store %299, %arg1 : i64, !llvm.ptr
-    cf.br ^bb100
-  ^bb103:  // pred: ^bb99
-    %c0_i64_167 = arith.constant 0 : i64
-    %c1_i8 = arith.constant 1 : i8
-    %300 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_167, %c0_i64_167, %300, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %c1_i8 : i8
-  ^bb104:  // pred: ^bb11
-    %c18446744073709551615_i256_168 = arith.constant 18446744073709551615 : i256
-    %301 = arith.cmpi sgt, %24, %c18446744073709551615_i256_168 : i256
-    %c84_i8_169 = arith.constant 84 : i8
-    cf.cond_br %301, ^bb1(%c84_i8_169 : i8), ^bb105
-  ^bb105:  // pred: ^bb104
-    %302 = arith.trunci %24 : i256 to i64
-    %c0_i64_170 = arith.constant 0 : i64
-    %303 = arith.cmpi slt, %302, %c0_i64_170 : i64
-    %c84_i8_171 = arith.constant 84 : i8
-    cf.cond_br %303, ^bb1(%c84_i8_171 : i8), ^bb106
-  ^bb106:  // pred: ^bb105
-    %304 = arith.addi %302, %c32_i64 : i64
-    %c0_i64_172 = arith.constant 0 : i64
-    %305 = arith.cmpi slt, %304, %c0_i64_172 : i64
-    %c84_i8_173 = arith.constant 84 : i8
-    cf.cond_br %305, ^bb1(%c84_i8_173 : i8), ^bb107
-  ^bb107:  // pred: ^bb106
-    %c31_i64_174 = arith.constant 31 : i64
-    %c32_i64_175 = arith.constant 32 : i64
-    %306 = arith.addi %304, %c31_i64_174 : i64
-    %307 = arith.divui %306, %c32_i64_175 : i64
-    %c32_i64_176 = arith.constant 32 : i64
-    %308 = arith.muli %307, %c32_i64_176 : i64
-    %309 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_177 = arith.constant 31 : i64
-    %c32_i64_178 = arith.constant 32 : i64
-    %310 = arith.addi %309, %c31_i64_177 : i64
-    %311 = arith.divui %310, %c32_i64_178 : i64
-    %312 = arith.muli %311, %c32_i64_176 : i64
-    %313 = arith.cmpi ult, %312, %308 : i64
-    cf.cond_br %313, ^bb109, ^bb108
-  ^bb108:  // 2 preds: ^bb107, ^bb111
-    cf.br ^bb12
-  ^bb109:  // pred: ^bb107
-    %c3_i64_179 = arith.constant 3 : i64
-    %c512_i64 = arith.constant 512 : i64
-    %314 = arith.muli %311, %311 : i64
-    %315 = arith.divui %314, %c512_i64 : i64
-    %316 = arith.muli %311, %c3_i64_179 : i64
-    %317 = arith.addi %315, %316 : i64
-    %c3_i64_180 = arith.constant 3 : i64
-    %c512_i64_181 = arith.constant 512 : i64
-    %318 = arith.muli %307, %307 : i64
-    %319 = arith.divui %318, %c512_i64_181 : i64
-    %320 = arith.muli %307, %c3_i64_180 : i64
-    %321 = arith.addi %319, %320 : i64
-    %322 = arith.subi %321, %317 : i64
-    %323 = llvm.load %arg1 : !llvm.ptr -> i64
-    %324 = arith.cmpi ult, %323, %322 : i64
-    scf.if %324 {
-    } else {
-      %475 = arith.subi %323, %322 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
-    }
-    %c80_i8_182 = arith.constant 80 : i8
-    cf.cond_br %324, ^bb1(%c80_i8_182 : i8), ^bb110
+    %c80_i8_152 = arith.constant 80 : i8
+    cf.cond_br %293, ^bb1(%c80_i8_152 : i8), ^bb110
   ^bb110:  // pred: ^bb109
-    %325 = call @dora_fn_extend_memory(%arg0, %308) : (!llvm.ptr, i64) -> !llvm.ptr
-    %326 = llvm.getelementptr %325[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %327 = llvm.load %326 : !llvm.ptr -> i8
-    %c0_i8_183 = arith.constant 0 : i8
-    %328 = arith.cmpi ne, %327, %c0_i8_183 : i8
-    cf.cond_br %328, ^bb1(%327 : i8), ^bb111
+    %294 = call @dora_fn_extend_memory(%arg0, %277) : (!llvm.ptr, i64) -> !llvm.ptr
+    %295 = llvm.getelementptr %294[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %296 = llvm.load %295 : !llvm.ptr -> i8
+    %c0_i8_153 = arith.constant 0 : i8
+    %297 = arith.cmpi ne, %296, %c0_i8_153 : i8
+    cf.cond_br %297, ^bb1(%296 : i8), ^bb111
   ^bb111:  // pred: ^bb110
     cf.br ^bb108
   ^bb112:  // pred: ^bb24
-    %c18446744073709551615_i256_184 = arith.constant 18446744073709551615 : i256
-    %329 = arith.cmpi sgt, %61, %c18446744073709551615_i256_184 : i256
-    %c84_i8_185 = arith.constant 84 : i8
-    cf.cond_br %329, ^bb1(%c84_i8_185 : i8), ^bb113
+    %c18446744073709551615_i256_154 = arith.constant 18446744073709551615 : i256
+    %298 = arith.cmpi sgt, %55, %c18446744073709551615_i256_154 : i256
+    %c84_i8_155 = arith.constant 84 : i8
+    cf.cond_br %298, ^bb1(%c84_i8_155 : i8), ^bb113
   ^bb113:  // pred: ^bb112
-    %330 = arith.trunci %61 : i256 to i64
-    %c0_i64_186 = arith.constant 0 : i64
-    %331 = arith.cmpi slt, %330, %c0_i64_186 : i64
-    %c84_i8_187 = arith.constant 84 : i8
-    cf.cond_br %331, ^bb1(%c84_i8_187 : i8), ^bb114
+    %299 = arith.trunci %55 : i256 to i64
+    %c0_i64_156 = arith.constant 0 : i64
+    %300 = arith.cmpi slt, %299, %c0_i64_156 : i64
+    %c84_i8_157 = arith.constant 84 : i8
+    cf.cond_br %300, ^bb1(%c84_i8_157 : i8), ^bb114
   ^bb114:  // pred: ^bb113
-    %332 = arith.addi %330, %c32_i64_28 : i64
-    %c0_i64_188 = arith.constant 0 : i64
-    %333 = arith.cmpi slt, %332, %c0_i64_188 : i64
-    %c84_i8_189 = arith.constant 84 : i8
-    cf.cond_br %333, ^bb1(%c84_i8_189 : i8), ^bb115
+    %301 = arith.addi %299, %c32_i64_21 : i64
+    %c0_i64_158 = arith.constant 0 : i64
+    %302 = arith.cmpi slt, %301, %c0_i64_158 : i64
+    %c84_i8_159 = arith.constant 84 : i8
+    cf.cond_br %302, ^bb1(%c84_i8_159 : i8), ^bb115
   ^bb115:  // pred: ^bb114
-    %c31_i64_190 = arith.constant 31 : i64
-    %c32_i64_191 = arith.constant 32 : i64
-    %334 = arith.addi %332, %c31_i64_190 : i64
-    %335 = arith.divui %334, %c32_i64_191 : i64
-    %c32_i64_192 = arith.constant 32 : i64
-    %336 = arith.muli %335, %c32_i64_192 : i64
-    %337 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_193 = arith.constant 31 : i64
-    %c32_i64_194 = arith.constant 32 : i64
-    %338 = arith.addi %337, %c31_i64_193 : i64
-    %339 = arith.divui %338, %c32_i64_194 : i64
-    %340 = arith.muli %339, %c32_i64_192 : i64
-    %341 = arith.cmpi ult, %340, %336 : i64
-    cf.cond_br %341, ^bb117, ^bb116
+    %c31_i64_160 = arith.constant 31 : i64
+    %c32_i64_161 = arith.constant 32 : i64
+    %303 = arith.addi %301, %c31_i64_160 : i64
+    %304 = arith.divui %303, %c32_i64_161 : i64
+    %c32_i64_162 = arith.constant 32 : i64
+    %305 = arith.muli %304, %c32_i64_162 : i64
+    %306 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_163 = arith.constant 31 : i64
+    %c32_i64_164 = arith.constant 32 : i64
+    %307 = arith.addi %306, %c31_i64_163 : i64
+    %308 = arith.divui %307, %c32_i64_164 : i64
+    %309 = arith.muli %308, %c32_i64_162 : i64
+    %310 = arith.cmpi ult, %309, %305 : i64
+    cf.cond_br %310, ^bb117, ^bb116
   ^bb116:  // 2 preds: ^bb115, ^bb119
     cf.br ^bb25
   ^bb117:  // pred: ^bb115
-    %c3_i64_195 = arith.constant 3 : i64
-    %c512_i64_196 = arith.constant 512 : i64
-    %342 = arith.muli %339, %339 : i64
-    %343 = arith.divui %342, %c512_i64_196 : i64
-    %344 = arith.muli %339, %c3_i64_195 : i64
-    %345 = arith.addi %343, %344 : i64
-    %c3_i64_197 = arith.constant 3 : i64
-    %c512_i64_198 = arith.constant 512 : i64
-    %346 = arith.muli %335, %335 : i64
-    %347 = arith.divui %346, %c512_i64_198 : i64
-    %348 = arith.muli %335, %c3_i64_197 : i64
-    %349 = arith.addi %347, %348 : i64
-    %350 = arith.subi %349, %345 : i64
-    %351 = llvm.load %arg1 : !llvm.ptr -> i64
-    %352 = arith.cmpi ult, %351, %350 : i64
-    scf.if %352 {
+    %c3_i64_165 = arith.constant 3 : i64
+    %c512_i64_166 = arith.constant 512 : i64
+    %311 = arith.muli %308, %308 : i64
+    %312 = arith.divui %311, %c512_i64_166 : i64
+    %313 = arith.muli %308, %c3_i64_165 : i64
+    %314 = arith.addi %312, %313 : i64
+    %c3_i64_167 = arith.constant 3 : i64
+    %c512_i64_168 = arith.constant 512 : i64
+    %315 = arith.muli %304, %304 : i64
+    %316 = arith.divui %315, %c512_i64_168 : i64
+    %317 = arith.muli %304, %c3_i64_167 : i64
+    %318 = arith.addi %316, %317 : i64
+    %319 = arith.subi %318, %314 : i64
+    %320 = llvm.load %arg1 : !llvm.ptr -> i64
+    %321 = arith.cmpi ult, %320, %319 : i64
+    scf.if %321 {
     } else {
-      %475 = arith.subi %351, %350 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %320, %319 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_199 = arith.constant 80 : i8
-    cf.cond_br %352, ^bb1(%c80_i8_199 : i8), ^bb118
+    %c80_i8_169 = arith.constant 80 : i8
+    cf.cond_br %321, ^bb1(%c80_i8_169 : i8), ^bb118
   ^bb118:  // pred: ^bb117
-    %353 = call @dora_fn_extend_memory(%arg0, %336) : (!llvm.ptr, i64) -> !llvm.ptr
-    %354 = llvm.getelementptr %353[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %355 = llvm.load %354 : !llvm.ptr -> i8
-    %c0_i8_200 = arith.constant 0 : i8
-    %356 = arith.cmpi ne, %355, %c0_i8_200 : i8
-    cf.cond_br %356, ^bb1(%355 : i8), ^bb119
+    %322 = call @dora_fn_extend_memory(%arg0, %305) : (!llvm.ptr, i64) -> !llvm.ptr
+    %323 = llvm.getelementptr %322[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %324 = llvm.load %323 : !llvm.ptr -> i8
+    %c0_i8_170 = arith.constant 0 : i8
+    %325 = arith.cmpi ne, %324, %c0_i8_170 : i8
+    cf.cond_br %325, ^bb1(%324 : i8), ^bb119
   ^bb119:  // pred: ^bb118
     cf.br ^bb116
   ^bb120:  // pred: ^bb44
     %c49152_i64 = arith.constant 49152 : i64
-    %357 = arith.cmpi ugt, %119, %c49152_i64 : i64
+    %326 = arith.cmpi ugt, %106, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %357, ^bb1(%c100_i8 : i8), ^bb121
+    cf.cond_br %326, ^bb1(%c100_i8 : i8), ^bb121
   ^bb121:  // pred: ^bb120
-    %c31_i64_201 = arith.constant 31 : i64
-    %c32_i64_202 = arith.constant 32 : i64
-    %358 = arith.addi %119, %c31_i64_201 : i64
-    %359 = arith.divui %358, %c32_i64_202 : i64
-    %c2_i64_203 = arith.constant 2 : i64
-    %360 = arith.muli %359, %c2_i64_203 : i64
-    %361 = llvm.load %arg1 : !llvm.ptr -> i64
-    %362 = arith.cmpi ult, %361, %360 : i64
-    scf.if %362 {
+    %c31_i64_171 = arith.constant 31 : i64
+    %c32_i64_172 = arith.constant 32 : i64
+    %327 = arith.addi %106, %c31_i64_171 : i64
+    %328 = arith.divui %327, %c32_i64_172 : i64
+    %c2_i64_173 = arith.constant 2 : i64
+    %329 = arith.muli %328, %c2_i64_173 : i64
+    %330 = llvm.load %arg1 : !llvm.ptr -> i64
+    %331 = arith.cmpi ult, %330, %329 : i64
+    scf.if %331 {
     } else {
-      %475 = arith.subi %361, %360 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %330, %329 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_204 = arith.constant 80 : i8
-    cf.cond_br %362, ^bb1(%c80_i8_204 : i8), ^bb122
+    %c80_i8_174 = arith.constant 80 : i8
+    cf.cond_br %331, ^bb1(%c80_i8_174 : i8), ^bb122
   ^bb122:  // pred: ^bb121
-    %c18446744073709551615_i256_205 = arith.constant 18446744073709551615 : i256
-    %363 = arith.cmpi sgt, %111, %c18446744073709551615_i256_205 : i256
-    %c84_i8_206 = arith.constant 84 : i8
-    cf.cond_br %363, ^bb1(%c84_i8_206 : i8), ^bb123
+    %c18446744073709551615_i256_175 = arith.constant 18446744073709551615 : i256
+    %332 = arith.cmpi sgt, %99, %c18446744073709551615_i256_175 : i256
+    %c84_i8_176 = arith.constant 84 : i8
+    cf.cond_br %332, ^bb1(%c84_i8_176 : i8), ^bb123
   ^bb123:  // pred: ^bb122
-    %364 = arith.trunci %111 : i256 to i64
-    %c0_i64_207 = arith.constant 0 : i64
-    %365 = arith.cmpi slt, %364, %c0_i64_207 : i64
-    %c84_i8_208 = arith.constant 84 : i8
-    cf.cond_br %365, ^bb1(%c84_i8_208 : i8), ^bb124
+    %333 = arith.trunci %99 : i256 to i64
+    %c0_i64_177 = arith.constant 0 : i64
+    %334 = arith.cmpi slt, %333, %c0_i64_177 : i64
+    %c84_i8_178 = arith.constant 84 : i8
+    cf.cond_br %334, ^bb1(%c84_i8_178 : i8), ^bb124
   ^bb124:  // pred: ^bb123
-    %366 = arith.addi %364, %119 : i64
-    %c0_i64_209 = arith.constant 0 : i64
-    %367 = arith.cmpi slt, %366, %c0_i64_209 : i64
-    %c84_i8_210 = arith.constant 84 : i8
-    cf.cond_br %367, ^bb1(%c84_i8_210 : i8), ^bb125
+    %335 = arith.addi %333, %106 : i64
+    %c0_i64_179 = arith.constant 0 : i64
+    %336 = arith.cmpi slt, %335, %c0_i64_179 : i64
+    %c84_i8_180 = arith.constant 84 : i8
+    cf.cond_br %336, ^bb1(%c84_i8_180 : i8), ^bb125
   ^bb125:  // pred: ^bb124
-    %c31_i64_211 = arith.constant 31 : i64
-    %c32_i64_212 = arith.constant 32 : i64
-    %368 = arith.addi %366, %c31_i64_211 : i64
-    %369 = arith.divui %368, %c32_i64_212 : i64
-    %c32_i64_213 = arith.constant 32 : i64
-    %370 = arith.muli %369, %c32_i64_213 : i64
-    %371 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_214 = arith.constant 31 : i64
-    %c32_i64_215 = arith.constant 32 : i64
-    %372 = arith.addi %371, %c31_i64_214 : i64
-    %373 = arith.divui %372, %c32_i64_215 : i64
-    %374 = arith.muli %373, %c32_i64_213 : i64
-    %375 = arith.cmpi ult, %374, %370 : i64
-    cf.cond_br %375, ^bb127, ^bb126
+    %c31_i64_181 = arith.constant 31 : i64
+    %c32_i64_182 = arith.constant 32 : i64
+    %337 = arith.addi %335, %c31_i64_181 : i64
+    %338 = arith.divui %337, %c32_i64_182 : i64
+    %c32_i64_183 = arith.constant 32 : i64
+    %339 = arith.muli %338, %c32_i64_183 : i64
+    %340 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_184 = arith.constant 31 : i64
+    %c32_i64_185 = arith.constant 32 : i64
+    %341 = arith.addi %340, %c31_i64_184 : i64
+    %342 = arith.divui %341, %c32_i64_185 : i64
+    %343 = arith.muli %342, %c32_i64_183 : i64
+    %344 = arith.cmpi ult, %343, %339 : i64
+    cf.cond_br %344, ^bb127, ^bb126
   ^bb126:  // 2 preds: ^bb125, ^bb129
     cf.br ^bb45
   ^bb127:  // pred: ^bb125
-    %c3_i64_216 = arith.constant 3 : i64
-    %c512_i64_217 = arith.constant 512 : i64
-    %376 = arith.muli %373, %373 : i64
-    %377 = arith.divui %376, %c512_i64_217 : i64
-    %378 = arith.muli %373, %c3_i64_216 : i64
-    %379 = arith.addi %377, %378 : i64
-    %c3_i64_218 = arith.constant 3 : i64
-    %c512_i64_219 = arith.constant 512 : i64
-    %380 = arith.muli %369, %369 : i64
-    %381 = arith.divui %380, %c512_i64_219 : i64
-    %382 = arith.muli %369, %c3_i64_218 : i64
-    %383 = arith.addi %381, %382 : i64
-    %384 = arith.subi %383, %379 : i64
-    %385 = llvm.load %arg1 : !llvm.ptr -> i64
-    %386 = arith.cmpi ult, %385, %384 : i64
-    scf.if %386 {
+    %c3_i64_186 = arith.constant 3 : i64
+    %c512_i64_187 = arith.constant 512 : i64
+    %345 = arith.muli %342, %342 : i64
+    %346 = arith.divui %345, %c512_i64_187 : i64
+    %347 = arith.muli %342, %c3_i64_186 : i64
+    %348 = arith.addi %346, %347 : i64
+    %c3_i64_188 = arith.constant 3 : i64
+    %c512_i64_189 = arith.constant 512 : i64
+    %349 = arith.muli %338, %338 : i64
+    %350 = arith.divui %349, %c512_i64_189 : i64
+    %351 = arith.muli %338, %c3_i64_188 : i64
+    %352 = arith.addi %350, %351 : i64
+    %353 = arith.subi %352, %348 : i64
+    %354 = llvm.load %arg1 : !llvm.ptr -> i64
+    %355 = arith.cmpi ult, %354, %353 : i64
+    scf.if %355 {
     } else {
-      %475 = arith.subi %385, %384 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %354, %353 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_220 = arith.constant 80 : i8
-    cf.cond_br %386, ^bb1(%c80_i8_220 : i8), ^bb128
+    %c80_i8_190 = arith.constant 80 : i8
+    cf.cond_br %355, ^bb1(%c80_i8_190 : i8), ^bb128
   ^bb128:  // pred: ^bb127
-    %387 = call @dora_fn_extend_memory(%arg0, %370) : (!llvm.ptr, i64) -> !llvm.ptr
-    %388 = llvm.getelementptr %387[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %389 = llvm.load %388 : !llvm.ptr -> i8
-    %c0_i8_221 = arith.constant 0 : i8
-    %390 = arith.cmpi ne, %389, %c0_i8_221 : i8
-    cf.cond_br %390, ^bb1(%389 : i8), ^bb129
+    %356 = call @dora_fn_extend_memory(%arg0, %339) : (!llvm.ptr, i64) -> !llvm.ptr
+    %357 = llvm.getelementptr %356[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %358 = llvm.load %357 : !llvm.ptr -> i8
+    %c0_i8_191 = arith.constant 0 : i8
+    %359 = arith.cmpi ne, %358, %c0_i8_191 : i8
+    cf.cond_br %359, ^bb1(%358 : i8), ^bb129
   ^bb129:  // pred: ^bb128
     cf.br ^bb126
   ^bb130:  // pred: ^bb60
-    %c18446744073709551615_i256_222 = arith.constant 18446744073709551615 : i256
-    %391 = arith.cmpi sgt, %166, %c18446744073709551615_i256_222 : i256
-    %c84_i8_223 = arith.constant 84 : i8
-    cf.cond_br %391, ^bb1(%c84_i8_223 : i8), ^bb131
+    %c18446744073709551615_i256_192 = arith.constant 18446744073709551615 : i256
+    %360 = arith.cmpi sgt, %149, %c18446744073709551615_i256_192 : i256
+    %c84_i8_193 = arith.constant 84 : i8
+    cf.cond_br %360, ^bb1(%c84_i8_193 : i8), ^bb131
   ^bb131:  // pred: ^bb130
-    %392 = arith.trunci %166 : i256 to i64
-    %c0_i64_224 = arith.constant 0 : i64
-    %393 = arith.cmpi slt, %392, %c0_i64_224 : i64
-    %c84_i8_225 = arith.constant 84 : i8
-    cf.cond_br %393, ^bb1(%c84_i8_225 : i8), ^bb132
+    %361 = arith.trunci %149 : i256 to i64
+    %c0_i64_194 = arith.constant 0 : i64
+    %362 = arith.cmpi slt, %361, %c0_i64_194 : i64
+    %c84_i8_195 = arith.constant 84 : i8
+    cf.cond_br %362, ^bb1(%c84_i8_195 : i8), ^bb132
   ^bb132:  // pred: ^bb131
-    %394 = arith.addi %392, %c32_i64_88 : i64
-    %c0_i64_226 = arith.constant 0 : i64
-    %395 = arith.cmpi slt, %394, %c0_i64_226 : i64
-    %c84_i8_227 = arith.constant 84 : i8
-    cf.cond_br %395, ^bb1(%c84_i8_227 : i8), ^bb133
+    %363 = arith.addi %361, %c32_i64_70 : i64
+    %c0_i64_196 = arith.constant 0 : i64
+    %364 = arith.cmpi slt, %363, %c0_i64_196 : i64
+    %c84_i8_197 = arith.constant 84 : i8
+    cf.cond_br %364, ^bb1(%c84_i8_197 : i8), ^bb133
   ^bb133:  // pred: ^bb132
-    %c31_i64_228 = arith.constant 31 : i64
-    %c32_i64_229 = arith.constant 32 : i64
-    %396 = arith.addi %394, %c31_i64_228 : i64
-    %397 = arith.divui %396, %c32_i64_229 : i64
-    %c32_i64_230 = arith.constant 32 : i64
-    %398 = arith.muli %397, %c32_i64_230 : i64
-    %399 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_231 = arith.constant 31 : i64
-    %c32_i64_232 = arith.constant 32 : i64
-    %400 = arith.addi %399, %c31_i64_231 : i64
-    %401 = arith.divui %400, %c32_i64_232 : i64
-    %402 = arith.muli %401, %c32_i64_230 : i64
-    %403 = arith.cmpi ult, %402, %398 : i64
-    cf.cond_br %403, ^bb135, ^bb134
+    %c31_i64_198 = arith.constant 31 : i64
+    %c32_i64_199 = arith.constant 32 : i64
+    %365 = arith.addi %363, %c31_i64_198 : i64
+    %366 = arith.divui %365, %c32_i64_199 : i64
+    %c32_i64_200 = arith.constant 32 : i64
+    %367 = arith.muli %366, %c32_i64_200 : i64
+    %368 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_201 = arith.constant 31 : i64
+    %c32_i64_202 = arith.constant 32 : i64
+    %369 = arith.addi %368, %c31_i64_201 : i64
+    %370 = arith.divui %369, %c32_i64_202 : i64
+    %371 = arith.muli %370, %c32_i64_200 : i64
+    %372 = arith.cmpi ult, %371, %367 : i64
+    cf.cond_br %372, ^bb135, ^bb134
   ^bb134:  // 2 preds: ^bb133, ^bb137
     cf.br ^bb61
   ^bb135:  // pred: ^bb133
-    %c3_i64_233 = arith.constant 3 : i64
-    %c512_i64_234 = arith.constant 512 : i64
-    %404 = arith.muli %401, %401 : i64
-    %405 = arith.divui %404, %c512_i64_234 : i64
-    %406 = arith.muli %401, %c3_i64_233 : i64
-    %407 = arith.addi %405, %406 : i64
-    %c3_i64_235 = arith.constant 3 : i64
-    %c512_i64_236 = arith.constant 512 : i64
-    %408 = arith.muli %397, %397 : i64
-    %409 = arith.divui %408, %c512_i64_236 : i64
-    %410 = arith.muli %397, %c3_i64_235 : i64
-    %411 = arith.addi %409, %410 : i64
-    %412 = arith.subi %411, %407 : i64
-    %413 = llvm.load %arg1 : !llvm.ptr -> i64
-    %414 = arith.cmpi ult, %413, %412 : i64
-    scf.if %414 {
+    %c3_i64_203 = arith.constant 3 : i64
+    %c512_i64_204 = arith.constant 512 : i64
+    %373 = arith.muli %370, %370 : i64
+    %374 = arith.divui %373, %c512_i64_204 : i64
+    %375 = arith.muli %370, %c3_i64_203 : i64
+    %376 = arith.addi %374, %375 : i64
+    %c3_i64_205 = arith.constant 3 : i64
+    %c512_i64_206 = arith.constant 512 : i64
+    %377 = arith.muli %366, %366 : i64
+    %378 = arith.divui %377, %c512_i64_206 : i64
+    %379 = arith.muli %366, %c3_i64_205 : i64
+    %380 = arith.addi %378, %379 : i64
+    %381 = arith.subi %380, %376 : i64
+    %382 = llvm.load %arg1 : !llvm.ptr -> i64
+    %383 = arith.cmpi ult, %382, %381 : i64
+    scf.if %383 {
     } else {
-      %475 = arith.subi %413, %412 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %382, %381 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_237 = arith.constant 80 : i8
-    cf.cond_br %414, ^bb1(%c80_i8_237 : i8), ^bb136
+    %c80_i8_207 = arith.constant 80 : i8
+    cf.cond_br %383, ^bb1(%c80_i8_207 : i8), ^bb136
   ^bb136:  // pred: ^bb135
-    %415 = call @dora_fn_extend_memory(%arg0, %398) : (!llvm.ptr, i64) -> !llvm.ptr
-    %416 = llvm.getelementptr %415[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %417 = llvm.load %416 : !llvm.ptr -> i8
-    %c0_i8_238 = arith.constant 0 : i8
-    %418 = arith.cmpi ne, %417, %c0_i8_238 : i8
-    cf.cond_br %418, ^bb1(%417 : i8), ^bb137
+    %384 = call @dora_fn_extend_memory(%arg0, %367) : (!llvm.ptr, i64) -> !llvm.ptr
+    %385 = llvm.getelementptr %384[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %386 = llvm.load %385 : !llvm.ptr -> i8
+    %c0_i8_208 = arith.constant 0 : i8
+    %387 = arith.cmpi ne, %386, %c0_i8_208 : i8
+    cf.cond_br %387, ^bb1(%386 : i8), ^bb137
   ^bb137:  // pred: ^bb136
     cf.br ^bb134
   ^bb138:  // pred: ^bb73
-    %c18446744073709551615_i256_239 = arith.constant 18446744073709551615 : i256
-    %419 = arith.cmpi sgt, %203, %c18446744073709551615_i256_239 : i256
-    %c84_i8_240 = arith.constant 84 : i8
-    cf.cond_br %419, ^bb1(%c84_i8_240 : i8), ^bb139
+    %c18446744073709551615_i256_209 = arith.constant 18446744073709551615 : i256
+    %388 = arith.cmpi sgt, %182, %c18446744073709551615_i256_209 : i256
+    %c84_i8_210 = arith.constant 84 : i8
+    cf.cond_br %388, ^bb1(%c84_i8_210 : i8), ^bb139
   ^bb139:  // pred: ^bb138
-    %420 = arith.trunci %203 : i256 to i64
-    %c0_i64_241 = arith.constant 0 : i64
-    %421 = arith.cmpi slt, %420, %c0_i64_241 : i64
-    %c84_i8_242 = arith.constant 84 : i8
-    cf.cond_br %421, ^bb1(%c84_i8_242 : i8), ^bb140
+    %389 = arith.trunci %182 : i256 to i64
+    %c0_i64_211 = arith.constant 0 : i64
+    %390 = arith.cmpi slt, %389, %c0_i64_211 : i64
+    %c84_i8_212 = arith.constant 84 : i8
+    cf.cond_br %390, ^bb1(%c84_i8_212 : i8), ^bb140
   ^bb140:  // pred: ^bb139
-    %422 = arith.addi %420, %c32_i64_112 : i64
-    %c0_i64_243 = arith.constant 0 : i64
-    %423 = arith.cmpi slt, %422, %c0_i64_243 : i64
-    %c84_i8_244 = arith.constant 84 : i8
-    cf.cond_br %423, ^bb1(%c84_i8_244 : i8), ^bb141
+    %391 = arith.addi %389, %c32_i64_90 : i64
+    %c0_i64_213 = arith.constant 0 : i64
+    %392 = arith.cmpi slt, %391, %c0_i64_213 : i64
+    %c84_i8_214 = arith.constant 84 : i8
+    cf.cond_br %392, ^bb1(%c84_i8_214 : i8), ^bb141
   ^bb141:  // pred: ^bb140
-    %c31_i64_245 = arith.constant 31 : i64
-    %c32_i64_246 = arith.constant 32 : i64
-    %424 = arith.addi %422, %c31_i64_245 : i64
-    %425 = arith.divui %424, %c32_i64_246 : i64
-    %c32_i64_247 = arith.constant 32 : i64
-    %426 = arith.muli %425, %c32_i64_247 : i64
-    %427 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_248 = arith.constant 31 : i64
-    %c32_i64_249 = arith.constant 32 : i64
-    %428 = arith.addi %427, %c31_i64_248 : i64
-    %429 = arith.divui %428, %c32_i64_249 : i64
-    %430 = arith.muli %429, %c32_i64_247 : i64
-    %431 = arith.cmpi ult, %430, %426 : i64
-    cf.cond_br %431, ^bb143, ^bb142
+    %c31_i64_215 = arith.constant 31 : i64
+    %c32_i64_216 = arith.constant 32 : i64
+    %393 = arith.addi %391, %c31_i64_215 : i64
+    %394 = arith.divui %393, %c32_i64_216 : i64
+    %c32_i64_217 = arith.constant 32 : i64
+    %395 = arith.muli %394, %c32_i64_217 : i64
+    %396 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_218 = arith.constant 31 : i64
+    %c32_i64_219 = arith.constant 32 : i64
+    %397 = arith.addi %396, %c31_i64_218 : i64
+    %398 = arith.divui %397, %c32_i64_219 : i64
+    %399 = arith.muli %398, %c32_i64_217 : i64
+    %400 = arith.cmpi ult, %399, %395 : i64
+    cf.cond_br %400, ^bb143, ^bb142
   ^bb142:  // 2 preds: ^bb141, ^bb145
     cf.br ^bb74
   ^bb143:  // pred: ^bb141
-    %c3_i64_250 = arith.constant 3 : i64
-    %c512_i64_251 = arith.constant 512 : i64
-    %432 = arith.muli %429, %429 : i64
-    %433 = arith.divui %432, %c512_i64_251 : i64
-    %434 = arith.muli %429, %c3_i64_250 : i64
-    %435 = arith.addi %433, %434 : i64
-    %c3_i64_252 = arith.constant 3 : i64
-    %c512_i64_253 = arith.constant 512 : i64
-    %436 = arith.muli %425, %425 : i64
-    %437 = arith.divui %436, %c512_i64_253 : i64
-    %438 = arith.muli %425, %c3_i64_252 : i64
-    %439 = arith.addi %437, %438 : i64
-    %440 = arith.subi %439, %435 : i64
-    %441 = llvm.load %arg1 : !llvm.ptr -> i64
-    %442 = arith.cmpi ult, %441, %440 : i64
-    scf.if %442 {
+    %c3_i64_220 = arith.constant 3 : i64
+    %c512_i64_221 = arith.constant 512 : i64
+    %401 = arith.muli %398, %398 : i64
+    %402 = arith.divui %401, %c512_i64_221 : i64
+    %403 = arith.muli %398, %c3_i64_220 : i64
+    %404 = arith.addi %402, %403 : i64
+    %c3_i64_222 = arith.constant 3 : i64
+    %c512_i64_223 = arith.constant 512 : i64
+    %405 = arith.muli %394, %394 : i64
+    %406 = arith.divui %405, %c512_i64_223 : i64
+    %407 = arith.muli %394, %c3_i64_222 : i64
+    %408 = arith.addi %406, %407 : i64
+    %409 = arith.subi %408, %404 : i64
+    %410 = llvm.load %arg1 : !llvm.ptr -> i64
+    %411 = arith.cmpi ult, %410, %409 : i64
+    scf.if %411 {
     } else {
-      %475 = arith.subi %441, %440 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %410, %409 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_254 = arith.constant 80 : i8
-    cf.cond_br %442, ^bb1(%c80_i8_254 : i8), ^bb144
+    %c80_i8_224 = arith.constant 80 : i8
+    cf.cond_br %411, ^bb1(%c80_i8_224 : i8), ^bb144
   ^bb144:  // pred: ^bb143
-    %443 = call @dora_fn_extend_memory(%arg0, %426) : (!llvm.ptr, i64) -> !llvm.ptr
-    %444 = llvm.getelementptr %443[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %445 = llvm.load %444 : !llvm.ptr -> i8
-    %c0_i8_255 = arith.constant 0 : i8
-    %446 = arith.cmpi ne, %445, %c0_i8_255 : i8
-    cf.cond_br %446, ^bb1(%445 : i8), ^bb145
+    %412 = call @dora_fn_extend_memory(%arg0, %395) : (!llvm.ptr, i64) -> !llvm.ptr
+    %413 = llvm.getelementptr %412[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %414 = llvm.load %413 : !llvm.ptr -> i8
+    %c0_i8_225 = arith.constant 0 : i8
+    %415 = arith.cmpi ne, %414, %c0_i8_225 : i8
+    cf.cond_br %415, ^bb1(%414 : i8), ^bb145
   ^bb145:  // pred: ^bb144
     cf.br ^bb142
   ^bb146:  // pred: ^bb97
-    %c18446744073709551615_i256_256 = arith.constant 18446744073709551615 : i256
-    %447 = arith.cmpi sgt, %268, %c18446744073709551615_i256_256 : i256
-    %c84_i8_257 = arith.constant 84 : i8
-    cf.cond_br %447, ^bb1(%c84_i8_257 : i8), ^bb147
+    %c18446744073709551615_i256_226 = arith.constant 18446744073709551615 : i256
+    %416 = arith.cmpi sgt, %239, %c18446744073709551615_i256_226 : i256
+    %c84_i8_227 = arith.constant 84 : i8
+    cf.cond_br %416, ^bb1(%c84_i8_227 : i8), ^bb147
   ^bb147:  // pred: ^bb146
-    %448 = arith.trunci %268 : i256 to i64
-    %c0_i64_258 = arith.constant 0 : i64
-    %449 = arith.cmpi slt, %448, %c0_i64_258 : i64
-    %c84_i8_259 = arith.constant 84 : i8
-    cf.cond_br %449, ^bb1(%c84_i8_259 : i8), ^bb148
+    %417 = arith.trunci %239 : i256 to i64
+    %c0_i64_228 = arith.constant 0 : i64
+    %418 = arith.cmpi slt, %417, %c0_i64_228 : i64
+    %c84_i8_229 = arith.constant 84 : i8
+    cf.cond_br %418, ^bb1(%c84_i8_229 : i8), ^bb148
   ^bb148:  // pred: ^bb147
-    %450 = arith.addi %448, %278 : i64
-    %c0_i64_260 = arith.constant 0 : i64
-    %451 = arith.cmpi slt, %450, %c0_i64_260 : i64
-    %c84_i8_261 = arith.constant 84 : i8
-    cf.cond_br %451, ^bb1(%c84_i8_261 : i8), ^bb149
+    %419 = arith.addi %417, %247 : i64
+    %c0_i64_230 = arith.constant 0 : i64
+    %420 = arith.cmpi slt, %419, %c0_i64_230 : i64
+    %c84_i8_231 = arith.constant 84 : i8
+    cf.cond_br %420, ^bb1(%c84_i8_231 : i8), ^bb149
   ^bb149:  // pred: ^bb148
-    %c31_i64_262 = arith.constant 31 : i64
-    %c32_i64_263 = arith.constant 32 : i64
-    %452 = arith.addi %450, %c31_i64_262 : i64
-    %453 = arith.divui %452, %c32_i64_263 : i64
-    %c32_i64_264 = arith.constant 32 : i64
-    %454 = arith.muli %453, %c32_i64_264 : i64
-    %455 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_265 = arith.constant 31 : i64
-    %c32_i64_266 = arith.constant 32 : i64
-    %456 = arith.addi %455, %c31_i64_265 : i64
-    %457 = arith.divui %456, %c32_i64_266 : i64
-    %458 = arith.muli %457, %c32_i64_264 : i64
-    %459 = arith.cmpi ult, %458, %454 : i64
-    cf.cond_br %459, ^bb151, ^bb150
+    %c31_i64_232 = arith.constant 31 : i64
+    %c32_i64_233 = arith.constant 32 : i64
+    %421 = arith.addi %419, %c31_i64_232 : i64
+    %422 = arith.divui %421, %c32_i64_233 : i64
+    %c32_i64_234 = arith.constant 32 : i64
+    %423 = arith.muli %422, %c32_i64_234 : i64
+    %424 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_235 = arith.constant 31 : i64
+    %c32_i64_236 = arith.constant 32 : i64
+    %425 = arith.addi %424, %c31_i64_235 : i64
+    %426 = arith.divui %425, %c32_i64_236 : i64
+    %427 = arith.muli %426, %c32_i64_234 : i64
+    %428 = arith.cmpi ult, %427, %423 : i64
+    cf.cond_br %428, ^bb151, ^bb150
   ^bb150:  // 2 preds: ^bb149, ^bb153
     cf.br ^bb98
   ^bb151:  // pred: ^bb149
-    %c3_i64_267 = arith.constant 3 : i64
-    %c512_i64_268 = arith.constant 512 : i64
-    %460 = arith.muli %457, %457 : i64
-    %461 = arith.divui %460, %c512_i64_268 : i64
-    %462 = arith.muli %457, %c3_i64_267 : i64
-    %463 = arith.addi %461, %462 : i64
-    %c3_i64_269 = arith.constant 3 : i64
-    %c512_i64_270 = arith.constant 512 : i64
-    %464 = arith.muli %453, %453 : i64
-    %465 = arith.divui %464, %c512_i64_270 : i64
-    %466 = arith.muli %453, %c3_i64_269 : i64
-    %467 = arith.addi %465, %466 : i64
-    %468 = arith.subi %467, %463 : i64
-    %469 = llvm.load %arg1 : !llvm.ptr -> i64
-    %470 = arith.cmpi ult, %469, %468 : i64
-    scf.if %470 {
+    %c3_i64_237 = arith.constant 3 : i64
+    %c512_i64_238 = arith.constant 512 : i64
+    %429 = arith.muli %426, %426 : i64
+    %430 = arith.divui %429, %c512_i64_238 : i64
+    %431 = arith.muli %426, %c3_i64_237 : i64
+    %432 = arith.addi %430, %431 : i64
+    %c3_i64_239 = arith.constant 3 : i64
+    %c512_i64_240 = arith.constant 512 : i64
+    %433 = arith.muli %422, %422 : i64
+    %434 = arith.divui %433, %c512_i64_240 : i64
+    %435 = arith.muli %422, %c3_i64_239 : i64
+    %436 = arith.addi %434, %435 : i64
+    %437 = arith.subi %436, %432 : i64
+    %438 = llvm.load %arg1 : !llvm.ptr -> i64
+    %439 = arith.cmpi ult, %438, %437 : i64
+    scf.if %439 {
     } else {
-      %475 = arith.subi %469, %468 : i64
-      llvm.store %475, %arg1 : i64, !llvm.ptr
+      %444 = arith.subi %438, %437 : i64
+      llvm.store %444, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_271 = arith.constant 80 : i8
-    cf.cond_br %470, ^bb1(%c80_i8_271 : i8), ^bb152
+    %c80_i8_241 = arith.constant 80 : i8
+    cf.cond_br %439, ^bb1(%c80_i8_241 : i8), ^bb152
   ^bb152:  // pred: ^bb151
-    %471 = call @dora_fn_extend_memory(%arg0, %454) : (!llvm.ptr, i64) -> !llvm.ptr
-    %472 = llvm.getelementptr %471[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %473 = llvm.load %472 : !llvm.ptr -> i8
-    %c0_i8_272 = arith.constant 0 : i8
-    %474 = arith.cmpi ne, %473, %c0_i8_272 : i8
-    cf.cond_br %474, ^bb1(%473 : i8), ^bb153
+    %440 = call @dora_fn_extend_memory(%arg0, %423) : (!llvm.ptr, i64) -> !llvm.ptr
+    %441 = llvm.getelementptr %440[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %442 = llvm.load %441 : !llvm.ptr -> i8
+    %c0_i8_242 = arith.constant 0 : i8
+    %443 = arith.cmpi ne, %442, %c0_i8_242 : i8
+    cf.cond_br %443, ^bb1(%442 : i8), ^bb153
   ^bb153:  // pred: ^bb152
     cf.br ^bb150
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodehash.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 36 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb39, ^bb41, ^bb42, ^bb45, ^bb46, ^bb47, ^bb50, ^bb51, ^bb53, ^bb54, ^bb55, ^bb56, ^bb57, ^bb60, ^bb61
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 36 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb32, ^bb33, ^bb34, ^bb36, ^bb37, ^bb39, ^bb41, ^bb42, ^bb45, ^bb46, ^bb47, ^bb50, ^bb51, ^bb53, ^bb54, ^bb55, ^bb56, ^bb57, ^bb60, ^bb61
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c7922816251414904634880670302451_i256 = arith.constant 7922816251414904634880670302451 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c7922816251414904634880670302451_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,471 +96,454 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb45, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb45, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb49
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c13_i256 = arith.constant 13 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c13_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c13_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %c0_i256_19 = arith.constant 0 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_19, %50 : i256, !llvm.ptr
+    %c0_i256_15 = arith.constant 0 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_15, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %c0_i256_26 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_27 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_27 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_26, %59 : i256, !llvm.ptr
+    %c0_i256_21 = arith.constant 0 : i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_21, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb25:  // pred: ^bb27
-    %c1024_i64_28 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_29 : i64
-    %63 = arith.cmpi ult, %c1024_i64_28, %62 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_30 : i8), ^bb24
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_23 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_23 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_22, %56 : i64
+    %c92_i8_24 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_24 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_31 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_25 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_31 : i64
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_32 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_26 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_31 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_25 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb36
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_33 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_34 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_35 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
-    %79 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
+    %70 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %80 = arith.cmpi ne, %79, %c0_i8 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %80, ^bb1(%c87_i8 : i8), ^bb29
+    cf.cond_br %71, ^bb1(%c87_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %72 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb30
+    cf.cond_br %72, ^bb1(%c84_i8 : i8), ^bb30
   ^bb30:  // pred: ^bb29
-    %82 = arith.trunci %78 : i256 to i64
-    %c0_i64_36 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_36 : i64
-    %c84_i8_37 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_37 : i8), ^bb31
+    %73 = arith.trunci %69 : i256 to i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_28 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %c0_i64_38 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_38 : i64
-    cf.cond_br %84, ^bb53, ^bb32
+    %c0_i64_29 = arith.constant 0 : i64
+    %75 = arith.cmpi ne, %73, %c0_i64_29 : i64
+    cf.cond_br %75, ^bb53, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb59
     %c32000_i64 = arith.constant 32000 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %c32000_i64 : i64
-    scf.if %86 {
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %c32000_i64 : i64
+    scf.if %77 {
     } else {
-      %191 = arith.subi %85, %c32000_i64 : i64
-      llvm.store %191, %arg1 : i64, !llvm.ptr
+      %179 = arith.subi %76, %c32000_i64 : i64
+      llvm.store %179, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_39 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_39 : i8), ^bb33
+    %c80_i8_30 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_30 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     %c1_i256 = arith.constant 1 : i256
-    %87 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %70, %87 {alignment = 1 : i64} : i256, !llvm.ptr
-    %88 = llvm.load %arg1 : !llvm.ptr -> i64
-    %89 = arith.trunci %74 : i256 to i64
-    %90 = call @dora_fn_create(%arg0, %82, %89, %87, %88) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %91 = llvm.getelementptr %90[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %92 = llvm.load %91 : !llvm.ptr -> i8
-    %c0_i8_40 = arith.constant 0 : i8
-    %93 = arith.cmpi ne, %92, %c0_i8_40 : i8
-    cf.cond_br %93, ^bb1(%92 : i8), ^bb34
+    %78 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %63, %78 {alignment = 1 : i64} : i256, !llvm.ptr
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %80 = arith.trunci %66 : i256 to i64
+    %81 = call @dora_fn_create(%arg0, %73, %80, %78, %79) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %82 = llvm.getelementptr %81[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %83 = llvm.load %82 : !llvm.ptr -> i8
+    %c0_i8_31 = arith.constant 0 : i8
+    %84 = arith.cmpi ne, %83, %c0_i8_31 : i8
+    cf.cond_br %84, ^bb1(%83 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %94 = llvm.getelementptr %90[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i64
-    %96 = llvm.load %arg1 : !llvm.ptr -> i64
-    %97 = arith.cmpi ult, %96, %95 : i64
-    scf.if %97 {
+    %85 = llvm.getelementptr %81[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %88 = arith.cmpi ult, %87, %86 : i64
+    scf.if %88 {
     } else {
-      %191 = arith.subi %96, %95 : i64
-      llvm.store %191, %arg1 : i64, !llvm.ptr
+      %179 = arith.subi %87, %86 : i64
+      llvm.store %179, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %97, ^bb1(%c80_i8_41 : i8), ^bb35
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb1(%c80_i8_32 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = llvm.load %87 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_42 = arith.constant 1 : i64
-    %101 = arith.addi %99, %c1_i64_42 : i64
-    llvm.store %101, %arg3 : i64, !llvm.ptr
-    llvm.store %98, %100 : i256, !llvm.ptr
+    %89 = llvm.load %78 : !llvm.ptr -> i256
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %89, %90 : i256, !llvm.ptr
+    %91 = llvm.getelementptr %90[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb42
   ^bb36:  // pred: ^bb38
-    %c1024_i64_43 = arith.constant 1024 : i64
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_44 = arith.constant -2 : i64
-    %103 = arith.addi %102, %c-2_i64_44 : i64
-    %c3_i64_45 = arith.constant 3 : i64
-    %104 = arith.cmpi ult, %102, %c3_i64_45 : i64
-    %c91_i8_46 = arith.constant 91 : i8
-    cf.cond_br %104, ^bb1(%c91_i8_46 : i8), ^bb28
+    %c1024_i64_33 = arith.constant 1024 : i64
+    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_34 = arith.constant -2 : i64
+    %93 = arith.addi %92, %c-2_i64_34 : i64
+    llvm.store %93, %arg3 : i64, !llvm.ptr
+    %c3_i64_35 = arith.constant 3 : i64
+    %94 = arith.cmpi ult, %92, %c3_i64_35 : i64
+    %c91_i8_36 = arith.constant 91 : i8
+    cf.cond_br %94, ^bb1(%c91_i8_36 : i8), ^bb28
   ^bb37:  // pred: ^bb24
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_47 = arith.constant 0 : i64
+    %95 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_37 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %106 = arith.cmpi uge, %105, %c0_i64_47 : i64
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb38, ^bb1(%c80_i8_48 : i8)
+    %96 = arith.cmpi uge, %95, %c0_i64_37 : i64
+    %c80_i8_38 = arith.constant 80 : i8
+    cf.cond_br %96, ^bb38, ^bb1(%c80_i8_38 : i8)
   ^bb38:  // pred: ^bb37
-    %107 = arith.subi %105, %c0_i64_47 : i64
-    llvm.store %107, %arg1 : i64, !llvm.ptr
+    %97 = arith.subi %95, %c0_i64_37 : i64
+    llvm.store %97, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb41
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_49 = arith.constant 1 : i64
-    %109 = arith.subi %108, %c1_i64_49 : i64
-    %110 = llvm.getelementptr %arg2[%109] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %109, %arg3 : i64, !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> i256
-    %c1_i256_50 = arith.constant 1 : i256
-    %112 = llvm.alloca %c1_i256_50 x i256 : (i256) -> !llvm.ptr
-    llvm.store %111, %112 {alignment = 1 : i64} : i256, !llvm.ptr
-    %113 = call @dora_fn_ext_code_hash(%arg0, %112) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %114 = llvm.getelementptr %113[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %115 = llvm.load %114 : !llvm.ptr -> i64
-    %116 = llvm.load %arg1 : !llvm.ptr -> i64
-    %117 = arith.cmpi ult, %116, %115 : i64
-    scf.if %117 {
+    %98 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %99 = llvm.getelementptr %98[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %100 = llvm.load %99 : !llvm.ptr -> i256
+    llvm.store %99, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_39 = arith.constant 1 : i256
+    %101 = llvm.alloca %c1_i256_39 x i256 : (i256) -> !llvm.ptr
+    llvm.store %100, %101 {alignment = 1 : i64} : i256, !llvm.ptr
+    %102 = call @dora_fn_ext_code_hash(%arg0, %101) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %103 = llvm.getelementptr %102[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %104 = llvm.load %103 : !llvm.ptr -> i64
+    %105 = llvm.load %arg1 : !llvm.ptr -> i64
+    %106 = arith.cmpi ult, %105, %104 : i64
+    scf.if %106 {
     } else {
-      %191 = arith.subi %116, %115 : i64
-      llvm.store %191, %arg1 : i64, !llvm.ptr
+      %179 = arith.subi %105, %104 : i64
+      llvm.store %179, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_51 = arith.constant 80 : i8
-    cf.cond_br %117, ^bb1(%c80_i8_51 : i8), ^bb40
+    %c80_i8_40 = arith.constant 80 : i8
+    cf.cond_br %106, ^bb1(%c80_i8_40 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %118 = llvm.load %112 : !llvm.ptr -> i256
-    %119 = llvm.load %arg3 : !llvm.ptr -> i64
-    %120 = llvm.getelementptr %arg2[%119] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_52 = arith.constant 1 : i64
-    %121 = arith.addi %119, %c1_i64_52 : i64
-    llvm.store %121, %arg3 : i64, !llvm.ptr
-    llvm.store %118, %120 : i256, !llvm.ptr
+    %107 = llvm.load %101 : !llvm.ptr -> i256
+    %108 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %107, %108 : i256, !llvm.ptr
+    %109 = llvm.getelementptr %108[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %109, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb44
   ^bb41:  // pred: ^bb43
-    %c1024_i64_53 = arith.constant 1024 : i64
-    %122 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %123 = arith.addi %122, %c0_i64_54 : i64
-    %c1_i64_55 = arith.constant 1 : i64
-    %124 = arith.cmpi ult, %122, %c1_i64_55 : i64
-    %c91_i8_56 = arith.constant 91 : i8
-    cf.cond_br %124, ^bb1(%c91_i8_56 : i8), ^bb39
+    %c1024_i64_41 = arith.constant 1024 : i64
+    %110 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_42 = arith.constant 0 : i64
+    %111 = arith.addi %110, %c0_i64_42 : i64
+    llvm.store %111, %arg3 : i64, !llvm.ptr
+    %c1_i64_43 = arith.constant 1 : i64
+    %112 = arith.cmpi ult, %110, %c1_i64_43 : i64
+    %c91_i8_44 = arith.constant 91 : i8
+    cf.cond_br %112, ^bb1(%c91_i8_44 : i8), ^bb39
   ^bb42:  // pred: ^bb35
-    %125 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_57 = arith.constant 0 : i64
+    %113 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_45 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %126 = arith.cmpi uge, %125, %c0_i64_57 : i64
-    %c80_i8_58 = arith.constant 80 : i8
-    cf.cond_br %126, ^bb43, ^bb1(%c80_i8_58 : i8)
+    %114 = arith.cmpi uge, %113, %c0_i64_45 : i64
+    %c80_i8_46 = arith.constant 80 : i8
+    cf.cond_br %114, ^bb43, ^bb1(%c80_i8_46 : i8)
   ^bb43:  // pred: ^bb42
-    %127 = arith.subi %125, %c0_i64_57 : i64
-    llvm.store %127, %arg1 : i64, !llvm.ptr
+    %115 = arith.subi %113, %c0_i64_45 : i64
+    llvm.store %115, %arg1 : i64, !llvm.ptr
     cf.br ^bb41
   ^bb44:  // pred: ^bb40
-    %c0_i64_59 = arith.constant 0 : i64
+    %c0_i64_47 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %128 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_59, %c0_i64_59, %128, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %116 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_47, %c0_i64_47, %116, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb45:  // pred: ^bb11
-    %c18446744073709551615_i256_60 = arith.constant 18446744073709551615 : i256
-    %129 = arith.cmpi sgt, %24, %c18446744073709551615_i256_60 : i256
-    %c84_i8_61 = arith.constant 84 : i8
-    cf.cond_br %129, ^bb1(%c84_i8_61 : i8), ^bb46
+    %c18446744073709551615_i256_48 = arith.constant 18446744073709551615 : i256
+    %117 = arith.cmpi sgt, %22, %c18446744073709551615_i256_48 : i256
+    %c84_i8_49 = arith.constant 84 : i8
+    cf.cond_br %117, ^bb1(%c84_i8_49 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %130 = arith.trunci %24 : i256 to i64
-    %c0_i64_62 = arith.constant 0 : i64
-    %131 = arith.cmpi slt, %130, %c0_i64_62 : i64
-    %c84_i8_63 = arith.constant 84 : i8
-    cf.cond_br %131, ^bb1(%c84_i8_63 : i8), ^bb47
+    %118 = arith.trunci %22 : i256 to i64
+    %c0_i64_50 = arith.constant 0 : i64
+    %119 = arith.cmpi slt, %118, %c0_i64_50 : i64
+    %c84_i8_51 = arith.constant 84 : i8
+    cf.cond_br %119, ^bb1(%c84_i8_51 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %132 = arith.addi %130, %c32_i64 : i64
-    %c0_i64_64 = arith.constant 0 : i64
-    %133 = arith.cmpi slt, %132, %c0_i64_64 : i64
-    %c84_i8_65 = arith.constant 84 : i8
-    cf.cond_br %133, ^bb1(%c84_i8_65 : i8), ^bb48
+    %120 = arith.addi %118, %c32_i64 : i64
+    %c0_i64_52 = arith.constant 0 : i64
+    %121 = arith.cmpi slt, %120, %c0_i64_52 : i64
+    %c84_i8_53 = arith.constant 84 : i8
+    cf.cond_br %121, ^bb1(%c84_i8_53 : i8), ^bb48
   ^bb48:  // pred: ^bb47
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_66 = arith.constant 32 : i64
-    %134 = arith.addi %132, %c31_i64 : i64
-    %135 = arith.divui %134, %c32_i64_66 : i64
-    %c32_i64_67 = arith.constant 32 : i64
-    %136 = arith.muli %135, %c32_i64_67 : i64
-    %137 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_68 = arith.constant 31 : i64
-    %c32_i64_69 = arith.constant 32 : i64
-    %138 = arith.addi %137, %c31_i64_68 : i64
-    %139 = arith.divui %138, %c32_i64_69 : i64
-    %140 = arith.muli %139, %c32_i64_67 : i64
-    %141 = arith.cmpi ult, %140, %136 : i64
-    cf.cond_br %141, ^bb50, ^bb49
+    %c32_i64_54 = arith.constant 32 : i64
+    %122 = arith.addi %120, %c31_i64 : i64
+    %123 = arith.divui %122, %c32_i64_54 : i64
+    %c32_i64_55 = arith.constant 32 : i64
+    %124 = arith.muli %123, %c32_i64_55 : i64
+    %125 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_56 = arith.constant 31 : i64
+    %c32_i64_57 = arith.constant 32 : i64
+    %126 = arith.addi %125, %c31_i64_56 : i64
+    %127 = arith.divui %126, %c32_i64_57 : i64
+    %128 = arith.muli %127, %c32_i64_55 : i64
+    %129 = arith.cmpi ult, %128, %124 : i64
+    cf.cond_br %129, ^bb50, ^bb49
   ^bb49:  // 2 preds: ^bb48, ^bb52
     cf.br ^bb12
   ^bb50:  // pred: ^bb48
-    %c3_i64_70 = arith.constant 3 : i64
+    %c3_i64_58 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %142 = arith.muli %139, %139 : i64
-    %143 = arith.divui %142, %c512_i64 : i64
-    %144 = arith.muli %139, %c3_i64_70 : i64
-    %145 = arith.addi %143, %144 : i64
-    %c3_i64_71 = arith.constant 3 : i64
-    %c512_i64_72 = arith.constant 512 : i64
-    %146 = arith.muli %135, %135 : i64
-    %147 = arith.divui %146, %c512_i64_72 : i64
-    %148 = arith.muli %135, %c3_i64_71 : i64
-    %149 = arith.addi %147, %148 : i64
-    %150 = arith.subi %149, %145 : i64
-    %151 = llvm.load %arg1 : !llvm.ptr -> i64
-    %152 = arith.cmpi ult, %151, %150 : i64
-    scf.if %152 {
+    %130 = arith.muli %127, %127 : i64
+    %131 = arith.divui %130, %c512_i64 : i64
+    %132 = arith.muli %127, %c3_i64_58 : i64
+    %133 = arith.addi %131, %132 : i64
+    %c3_i64_59 = arith.constant 3 : i64
+    %c512_i64_60 = arith.constant 512 : i64
+    %134 = arith.muli %123, %123 : i64
+    %135 = arith.divui %134, %c512_i64_60 : i64
+    %136 = arith.muli %123, %c3_i64_59 : i64
+    %137 = arith.addi %135, %136 : i64
+    %138 = arith.subi %137, %133 : i64
+    %139 = llvm.load %arg1 : !llvm.ptr -> i64
+    %140 = arith.cmpi ult, %139, %138 : i64
+    scf.if %140 {
     } else {
-      %191 = arith.subi %151, %150 : i64
-      llvm.store %191, %arg1 : i64, !llvm.ptr
+      %179 = arith.subi %139, %138 : i64
+      llvm.store %179, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_73 = arith.constant 80 : i8
-    cf.cond_br %152, ^bb1(%c80_i8_73 : i8), ^bb51
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %140, ^bb1(%c80_i8_61 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %153 = call @dora_fn_extend_memory(%arg0, %136) : (!llvm.ptr, i64) -> !llvm.ptr
-    %154 = llvm.getelementptr %153[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %155 = llvm.load %154 : !llvm.ptr -> i8
-    %c0_i8_74 = arith.constant 0 : i8
-    %156 = arith.cmpi ne, %155, %c0_i8_74 : i8
-    cf.cond_br %156, ^bb1(%155 : i8), ^bb52
+    %141 = call @dora_fn_extend_memory(%arg0, %124) : (!llvm.ptr, i64) -> !llvm.ptr
+    %142 = llvm.getelementptr %141[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %143 = llvm.load %142 : !llvm.ptr -> i8
+    %c0_i8_62 = arith.constant 0 : i8
+    %144 = arith.cmpi ne, %143, %c0_i8_62 : i8
+    cf.cond_br %144, ^bb1(%143 : i8), ^bb52
   ^bb52:  // pred: ^bb51
     cf.br ^bb49
   ^bb53:  // pred: ^bb31
     %c49152_i64 = arith.constant 49152 : i64
-    %157 = arith.cmpi ugt, %82, %c49152_i64 : i64
+    %145 = arith.cmpi ugt, %73, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %157, ^bb1(%c100_i8 : i8), ^bb54
+    cf.cond_br %145, ^bb1(%c100_i8 : i8), ^bb54
   ^bb54:  // pred: ^bb53
-    %c31_i64_75 = arith.constant 31 : i64
-    %c32_i64_76 = arith.constant 32 : i64
-    %158 = arith.addi %82, %c31_i64_75 : i64
-    %159 = arith.divui %158, %c32_i64_76 : i64
-    %c2_i64_77 = arith.constant 2 : i64
-    %160 = arith.muli %159, %c2_i64_77 : i64
-    %161 = llvm.load %arg1 : !llvm.ptr -> i64
-    %162 = arith.cmpi ult, %161, %160 : i64
-    scf.if %162 {
+    %c31_i64_63 = arith.constant 31 : i64
+    %c32_i64_64 = arith.constant 32 : i64
+    %146 = arith.addi %73, %c31_i64_63 : i64
+    %147 = arith.divui %146, %c32_i64_64 : i64
+    %c2_i64_65 = arith.constant 2 : i64
+    %148 = arith.muli %147, %c2_i64_65 : i64
+    %149 = llvm.load %arg1 : !llvm.ptr -> i64
+    %150 = arith.cmpi ult, %149, %148 : i64
+    scf.if %150 {
     } else {
-      %191 = arith.subi %161, %160 : i64
-      llvm.store %191, %arg1 : i64, !llvm.ptr
+      %179 = arith.subi %149, %148 : i64
+      llvm.store %179, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_78 = arith.constant 80 : i8
-    cf.cond_br %162, ^bb1(%c80_i8_78 : i8), ^bb55
+    %c80_i8_66 = arith.constant 80 : i8
+    cf.cond_br %150, ^bb1(%c80_i8_66 : i8), ^bb55
   ^bb55:  // pred: ^bb54
-    %c18446744073709551615_i256_79 = arith.constant 18446744073709551615 : i256
-    %163 = arith.cmpi sgt, %74, %c18446744073709551615_i256_79 : i256
-    %c84_i8_80 = arith.constant 84 : i8
-    cf.cond_br %163, ^bb1(%c84_i8_80 : i8), ^bb56
+    %c18446744073709551615_i256_67 = arith.constant 18446744073709551615 : i256
+    %151 = arith.cmpi sgt, %66, %c18446744073709551615_i256_67 : i256
+    %c84_i8_68 = arith.constant 84 : i8
+    cf.cond_br %151, ^bb1(%c84_i8_68 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %164 = arith.trunci %74 : i256 to i64
-    %c0_i64_81 = arith.constant 0 : i64
-    %165 = arith.cmpi slt, %164, %c0_i64_81 : i64
-    %c84_i8_82 = arith.constant 84 : i8
-    cf.cond_br %165, ^bb1(%c84_i8_82 : i8), ^bb57
+    %152 = arith.trunci %66 : i256 to i64
+    %c0_i64_69 = arith.constant 0 : i64
+    %153 = arith.cmpi slt, %152, %c0_i64_69 : i64
+    %c84_i8_70 = arith.constant 84 : i8
+    cf.cond_br %153, ^bb1(%c84_i8_70 : i8), ^bb57
   ^bb57:  // pred: ^bb56
-    %166 = arith.addi %164, %82 : i64
-    %c0_i64_83 = arith.constant 0 : i64
-    %167 = arith.cmpi slt, %166, %c0_i64_83 : i64
-    %c84_i8_84 = arith.constant 84 : i8
-    cf.cond_br %167, ^bb1(%c84_i8_84 : i8), ^bb58
+    %154 = arith.addi %152, %73 : i64
+    %c0_i64_71 = arith.constant 0 : i64
+    %155 = arith.cmpi slt, %154, %c0_i64_71 : i64
+    %c84_i8_72 = arith.constant 84 : i8
+    cf.cond_br %155, ^bb1(%c84_i8_72 : i8), ^bb58
   ^bb58:  // pred: ^bb57
-    %c31_i64_85 = arith.constant 31 : i64
-    %c32_i64_86 = arith.constant 32 : i64
-    %168 = arith.addi %166, %c31_i64_85 : i64
-    %169 = arith.divui %168, %c32_i64_86 : i64
-    %c32_i64_87 = arith.constant 32 : i64
-    %170 = arith.muli %169, %c32_i64_87 : i64
-    %171 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_88 = arith.constant 31 : i64
-    %c32_i64_89 = arith.constant 32 : i64
-    %172 = arith.addi %171, %c31_i64_88 : i64
-    %173 = arith.divui %172, %c32_i64_89 : i64
-    %174 = arith.muli %173, %c32_i64_87 : i64
-    %175 = arith.cmpi ult, %174, %170 : i64
-    cf.cond_br %175, ^bb60, ^bb59
+    %c31_i64_73 = arith.constant 31 : i64
+    %c32_i64_74 = arith.constant 32 : i64
+    %156 = arith.addi %154, %c31_i64_73 : i64
+    %157 = arith.divui %156, %c32_i64_74 : i64
+    %c32_i64_75 = arith.constant 32 : i64
+    %158 = arith.muli %157, %c32_i64_75 : i64
+    %159 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_76 = arith.constant 31 : i64
+    %c32_i64_77 = arith.constant 32 : i64
+    %160 = arith.addi %159, %c31_i64_76 : i64
+    %161 = arith.divui %160, %c32_i64_77 : i64
+    %162 = arith.muli %161, %c32_i64_75 : i64
+    %163 = arith.cmpi ult, %162, %158 : i64
+    cf.cond_br %163, ^bb60, ^bb59
   ^bb59:  // 2 preds: ^bb58, ^bb62
     cf.br ^bb32
   ^bb60:  // pred: ^bb58
-    %c3_i64_90 = arith.constant 3 : i64
-    %c512_i64_91 = arith.constant 512 : i64
-    %176 = arith.muli %173, %173 : i64
-    %177 = arith.divui %176, %c512_i64_91 : i64
-    %178 = arith.muli %173, %c3_i64_90 : i64
-    %179 = arith.addi %177, %178 : i64
-    %c3_i64_92 = arith.constant 3 : i64
-    %c512_i64_93 = arith.constant 512 : i64
-    %180 = arith.muli %169, %169 : i64
-    %181 = arith.divui %180, %c512_i64_93 : i64
-    %182 = arith.muli %169, %c3_i64_92 : i64
-    %183 = arith.addi %181, %182 : i64
-    %184 = arith.subi %183, %179 : i64
-    %185 = llvm.load %arg1 : !llvm.ptr -> i64
-    %186 = arith.cmpi ult, %185, %184 : i64
-    scf.if %186 {
+    %c3_i64_78 = arith.constant 3 : i64
+    %c512_i64_79 = arith.constant 512 : i64
+    %164 = arith.muli %161, %161 : i64
+    %165 = arith.divui %164, %c512_i64_79 : i64
+    %166 = arith.muli %161, %c3_i64_78 : i64
+    %167 = arith.addi %165, %166 : i64
+    %c3_i64_80 = arith.constant 3 : i64
+    %c512_i64_81 = arith.constant 512 : i64
+    %168 = arith.muli %157, %157 : i64
+    %169 = arith.divui %168, %c512_i64_81 : i64
+    %170 = arith.muli %157, %c3_i64_80 : i64
+    %171 = arith.addi %169, %170 : i64
+    %172 = arith.subi %171, %167 : i64
+    %173 = llvm.load %arg1 : !llvm.ptr -> i64
+    %174 = arith.cmpi ult, %173, %172 : i64
+    scf.if %174 {
     } else {
-      %191 = arith.subi %185, %184 : i64
-      llvm.store %191, %arg1 : i64, !llvm.ptr
+      %179 = arith.subi %173, %172 : i64
+      llvm.store %179, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_94 = arith.constant 80 : i8
-    cf.cond_br %186, ^bb1(%c80_i8_94 : i8), ^bb61
+    %c80_i8_82 = arith.constant 80 : i8
+    cf.cond_br %174, ^bb1(%c80_i8_82 : i8), ^bb61
   ^bb61:  // pred: ^bb60
-    %187 = call @dora_fn_extend_memory(%arg0, %170) : (!llvm.ptr, i64) -> !llvm.ptr
-    %188 = llvm.getelementptr %187[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %189 = llvm.load %188 : !llvm.ptr -> i8
-    %c0_i8_95 = arith.constant 0 : i8
-    %190 = arith.cmpi ne, %189, %c0_i8_95 : i8
-    cf.cond_br %190, ^bb1(%189 : i8), ^bb62
+    %175 = call @dora_fn_extend_memory(%arg0, %158) : (!llvm.ptr, i64) -> !llvm.ptr
+    %176 = llvm.getelementptr %175[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %177 = llvm.load %176 : !llvm.ptr -> i8
+    %c0_i8_83 = arith.constant 0 : i8
+    %178 = arith.cmpi ne, %177, %c0_i8_83 : i8
+    cf.cond_br %178, ^bb1(%177 : i8), ^bb62
   ^bb62:  // pred: ^bb61
     cf.br ^bb59
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_extcodesize.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 47 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb49, ^bb50, ^bb52, ^bb54, ^bb55, ^bb58, ^bb59, ^bb60, ^bb63, ^bb64, ^bb66, ^bb67, ^bb68, ^bb71, ^bb72, ^bb74, ^bb75, ^bb76, ^bb77, ^bb78, ^bb81, ^bb82
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 47 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb49, ^bb50, ^bb52, ^bb54, ^bb55, ^bb58, ^bb59, ^bb60, ^bb63, ^bb64, ^bb66, ^bb67, ^bb68, ^bb71, ^bb72, ^bb74, ^bb75, ^bb76, ^bb77, ^bb78, ^bb81, ^bb82
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c170141183460469231731687303715884105727_i256 = arith.constant 170141183460469231731687303715884105727 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c170141183460469231731687303715884105727_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,639 +96,617 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb58, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb58, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb62
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c170141183460469231731687303715884105727_i256_13 = arith.constant 170141183460469231731687303715884105727 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c170141183460469231731687303715884105727_i256_13, %41 : i256, !llvm.ptr
+    %c170141183460469231731687303715884105727_i256_10 = arith.constant 170141183460469231731687303715884105727 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c170141183460469231731687303715884105727_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c32_i256 = arith.constant 32 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
-    %c32_i64_28 = arith.constant 32 : i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %66 = arith.cmpi ne, %c32_i64_28, %c0_i64_29 : i64
-    cf.cond_br %66, ^bb66, ^bb25
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_21 = arith.constant 32 : i64
+    %c0_i64_22 = arith.constant 0 : i64
+    %59 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
+    cf.cond_br %59, ^bb66, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb70
-    %67 = arith.trunci %61 : i256 to i64
-    %68 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %69 = llvm.getelementptr %68[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %70 = llvm.intr.bswap(%65)  : (i256) -> i256
-    llvm.store %70, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = arith.trunci %55 : i256 to i64
+    %61 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %63 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %63, %62 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb31
   ^bb26:  // pred: ^bb28
-    %c1024_i64_30 = arith.constant 1024 : i64
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_31 = arith.constant -2 : i64
-    %72 = arith.addi %71, %c-2_i64_31 : i64
-    %c2_i64_32 = arith.constant 2 : i64
-    %73 = arith.cmpi ult, %71, %c2_i64_32 : i64
-    %c91_i8_33 = arith.constant 91 : i8
-    cf.cond_br %73, ^bb1(%c91_i8_33 : i8), ^bb24
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_24 = arith.constant -2 : i64
+    %65 = arith.addi %64, %c-2_i64_24 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c2_i64_25 = arith.constant 2 : i64
+    %66 = arith.cmpi ult, %64, %c2_i64_25 : i64
+    %c91_i8_26 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_26 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_34 = arith.constant 3 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_27 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %75 = arith.cmpi uge, %74, %c3_i64_34 : i64
-    %c80_i8_35 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb28, ^bb1(%c80_i8_35 : i8)
+    %68 = arith.cmpi uge, %67, %c3_i64_27 : i64
+    %c80_i8_28 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb28, ^bb1(%c80_i8_28 : i8)
   ^bb28:  // pred: ^bb27
-    %76 = arith.subi %74, %c3_i64_34 : i64
-    llvm.store %76, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c3_i64_27 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb30
     %c41_i256 = arith.constant 41 : i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %78 = llvm.getelementptr %arg2[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_36 = arith.constant 1 : i64
-    %79 = arith.addi %77, %c1_i64_36 : i64
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    llvm.store %c41_i256, %78 : i256, !llvm.ptr
+    %70 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c41_i256, %70 : i256, !llvm.ptr
+    %71 = llvm.getelementptr %70[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %71, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_37 = arith.constant 1024 : i64
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %81 = arith.addi %80, %c1_i64_38 : i64
-    %82 = arith.cmpi ult, %c1024_i64_37, %81 : i64
-    %c92_i8_39 = arith.constant 92 : i8
-    cf.cond_br %82, ^bb1(%c92_i8_39 : i8), ^bb29
+    %c1024_i64_29 = arith.constant 1024 : i64
+    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_30 = arith.constant 1 : i64
+    %73 = arith.addi %72, %c1_i64_30 : i64
+    llvm.store %73, %arg3 : i64, !llvm.ptr
+    %74 = arith.cmpi ult, %c1024_i64_29, %73 : i64
+    %c92_i8_31 = arith.constant 92 : i8
+    cf.cond_br %74, ^bb1(%c92_i8_31 : i8), ^bb29
   ^bb31:  // pred: ^bb25
-    %83 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_40 = arith.constant 3 : i64
+    %75 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_32 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %84 = arith.cmpi uge, %83, %c3_i64_40 : i64
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %84, ^bb32, ^bb1(%c80_i8_41 : i8)
+    %76 = arith.cmpi uge, %75, %c3_i64_32 : i64
+    %c80_i8_33 = arith.constant 80 : i8
+    cf.cond_br %76, ^bb32, ^bb1(%c80_i8_33 : i8)
   ^bb32:  // pred: ^bb31
-    %85 = arith.subi %83, %c3_i64_40 : i64
-    llvm.store %85, %arg1 : i64, !llvm.ptr
+    %77 = arith.subi %75, %c3_i64_32 : i64
+    llvm.store %77, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
-    %c0_i256_42 = arith.constant 0 : i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %87 = llvm.getelementptr %arg2[%86] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_43 = arith.constant 1 : i64
-    %88 = arith.addi %86, %c1_i64_43 : i64
-    llvm.store %88, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_42, %87 : i256, !llvm.ptr
+    %c0_i256_34 = arith.constant 0 : i256
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_34, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb34:  // pred: ^bb36
-    %c1024_i64_44 = arith.constant 1024 : i64
-    %89 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_45 = arith.constant 1 : i64
-    %90 = arith.addi %89, %c1_i64_45 : i64
-    %91 = arith.cmpi ult, %c1024_i64_44, %90 : i64
-    %c92_i8_46 = arith.constant 92 : i8
-    cf.cond_br %91, ^bb1(%c92_i8_46 : i8), ^bb33
+    %c1024_i64_35 = arith.constant 1024 : i64
+    %80 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_36 = arith.constant 1 : i64
+    %81 = arith.addi %80, %c1_i64_36 : i64
+    llvm.store %81, %arg3 : i64, !llvm.ptr
+    %82 = arith.cmpi ult, %c1024_i64_35, %81 : i64
+    %c92_i8_37 = arith.constant 92 : i8
+    cf.cond_br %82, ^bb1(%c92_i8_37 : i8), ^bb33
   ^bb35:  // pred: ^bb29
-    %92 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_47 = arith.constant 3 : i64
+    %83 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_38 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %93 = arith.cmpi uge, %92, %c3_i64_47 : i64
-    %c80_i8_48 = arith.constant 80 : i8
-    cf.cond_br %93, ^bb36, ^bb1(%c80_i8_48 : i8)
+    %84 = arith.cmpi uge, %83, %c3_i64_38 : i64
+    %c80_i8_39 = arith.constant 80 : i8
+    cf.cond_br %84, ^bb36, ^bb1(%c80_i8_39 : i8)
   ^bb36:  // pred: ^bb35
-    %94 = arith.subi %92, %c3_i64_47 : i64
-    llvm.store %94, %arg1 : i64, !llvm.ptr
+    %85 = arith.subi %83, %c3_i64_38 : i64
+    llvm.store %85, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb38
-    %c0_i256_49 = arith.constant 0 : i256
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
-    %96 = llvm.getelementptr %arg2[%95] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_50 = arith.constant 1 : i64
-    %97 = arith.addi %95, %c1_i64_50 : i64
-    llvm.store %97, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_49, %96 : i256, !llvm.ptr
+    %c0_i256_40 = arith.constant 0 : i256
+    %86 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_40, %86 : i256, !llvm.ptr
+    %87 = llvm.getelementptr %86[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %87, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb50
   ^bb38:  // pred: ^bb40
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %98 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_52 = arith.constant 1 : i64
-    %99 = arith.addi %98, %c1_i64_52 : i64
-    %100 = arith.cmpi ult, %c1024_i64_51, %99 : i64
-    %c92_i8_53 = arith.constant 92 : i8
-    cf.cond_br %100, ^bb1(%c92_i8_53 : i8), ^bb37
+    %c1024_i64_41 = arith.constant 1024 : i64
+    %88 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_42 = arith.constant 1 : i64
+    %89 = arith.addi %88, %c1_i64_42 : i64
+    llvm.store %89, %arg3 : i64, !llvm.ptr
+    %90 = arith.cmpi ult, %c1024_i64_41, %89 : i64
+    %c92_i8_43 = arith.constant 92 : i8
+    cf.cond_br %90, ^bb1(%c92_i8_43 : i8), ^bb37
   ^bb39:  // pred: ^bb33
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_54 = arith.constant 3 : i64
+    %91 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_44 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %102 = arith.cmpi uge, %101, %c3_i64_54 : i64
-    %c80_i8_55 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb40, ^bb1(%c80_i8_55 : i8)
+    %92 = arith.cmpi uge, %91, %c3_i64_44 : i64
+    %c80_i8_45 = arith.constant 80 : i8
+    cf.cond_br %92, ^bb40, ^bb1(%c80_i8_45 : i8)
   ^bb40:  // pred: ^bb39
-    %103 = arith.subi %101, %c3_i64_54 : i64
-    llvm.store %103, %arg1 : i64, !llvm.ptr
+    %93 = arith.subi %91, %c3_i64_44 : i64
+    llvm.store %93, %arg1 : i64, !llvm.ptr
     cf.br ^bb38
   ^bb41:  // pred: ^bb49
-    %104 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_56 = arith.constant 1 : i64
-    %105 = arith.subi %104, %c1_i64_56 : i64
-    %106 = llvm.getelementptr %arg2[%105] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %105, %arg3 : i64, !llvm.ptr
-    %107 = llvm.load %106 : !llvm.ptr -> i256
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_57 = arith.constant 1 : i64
-    %109 = arith.subi %108, %c1_i64_57 : i64
-    %110 = llvm.getelementptr %arg2[%109] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %109, %arg3 : i64, !llvm.ptr
-    %111 = llvm.load %110 : !llvm.ptr -> i256
-    %112 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_58 = arith.constant 1 : i64
-    %113 = arith.subi %112, %c1_i64_58 : i64
-    %114 = llvm.getelementptr %arg2[%113] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %113, %arg3 : i64, !llvm.ptr
-    %115 = llvm.load %114 : !llvm.ptr -> i256
-    %116 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %94 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %95 = llvm.getelementptr %94[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %96 = llvm.load %95 : !llvm.ptr -> i256
+    llvm.store %95, %0 : !llvm.ptr, !llvm.ptr
+    %97 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %98 = llvm.getelementptr %97[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %99 = llvm.load %98 : !llvm.ptr -> i256
+    llvm.store %98, %0 : !llvm.ptr, !llvm.ptr
+    %100 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %101 = llvm.getelementptr %100[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %102 = llvm.load %101 : !llvm.ptr -> i256
+    llvm.store %101, %0 : !llvm.ptr, !llvm.ptr
+    %103 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %117 = arith.cmpi ne, %116, %c0_i8 : i8
+    %104 = arith.cmpi ne, %103, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %117, ^bb1(%c87_i8 : i8), ^bb42
+    cf.cond_br %104, ^bb1(%c87_i8 : i8), ^bb42
   ^bb42:  // pred: ^bb41
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %118 = arith.cmpi sgt, %115, %c18446744073709551615_i256 : i256
+    %105 = arith.cmpi sgt, %102, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8 : i8), ^bb43
+    cf.cond_br %105, ^bb1(%c84_i8 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %119 = arith.trunci %115 : i256 to i64
-    %c0_i64_59 = arith.constant 0 : i64
-    %120 = arith.cmpi slt, %119, %c0_i64_59 : i64
-    %c84_i8_60 = arith.constant 84 : i8
-    cf.cond_br %120, ^bb1(%c84_i8_60 : i8), ^bb44
+    %106 = arith.trunci %102 : i256 to i64
+    %c0_i64_46 = arith.constant 0 : i64
+    %107 = arith.cmpi slt, %106, %c0_i64_46 : i64
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %107, ^bb1(%c84_i8_47 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c0_i64_61 = arith.constant 0 : i64
-    %121 = arith.cmpi ne, %119, %c0_i64_61 : i64
-    cf.cond_br %121, ^bb74, ^bb45
+    %c0_i64_48 = arith.constant 0 : i64
+    %108 = arith.cmpi ne, %106, %c0_i64_48 : i64
+    cf.cond_br %108, ^bb74, ^bb45
   ^bb45:  // 2 preds: ^bb44, ^bb80
     %c32000_i64 = arith.constant 32000 : i64
-    %122 = llvm.load %arg1 : !llvm.ptr -> i64
-    %123 = arith.cmpi ult, %122, %c32000_i64 : i64
-    scf.if %123 {
+    %109 = llvm.load %arg1 : !llvm.ptr -> i64
+    %110 = arith.cmpi ult, %109, %c32000_i64 : i64
+    scf.if %110 {
     } else {
-      %258 = arith.subi %122, %c32000_i64 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %109, %c32000_i64 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %123, ^bb1(%c80_i8_62 : i8), ^bb46
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %110, ^bb1(%c80_i8_49 : i8), ^bb46
   ^bb46:  // pred: ^bb45
     %c1_i256 = arith.constant 1 : i256
-    %124 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %107, %124 {alignment = 1 : i64} : i256, !llvm.ptr
-    %125 = llvm.load %arg1 : !llvm.ptr -> i64
-    %126 = arith.trunci %111 : i256 to i64
-    %127 = call @dora_fn_create(%arg0, %119, %126, %124, %125) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %128 = llvm.getelementptr %127[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %129 = llvm.load %128 : !llvm.ptr -> i8
-    %c0_i8_63 = arith.constant 0 : i8
-    %130 = arith.cmpi ne, %129, %c0_i8_63 : i8
-    cf.cond_br %130, ^bb1(%129 : i8), ^bb47
+    %111 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %96, %111 {alignment = 1 : i64} : i256, !llvm.ptr
+    %112 = llvm.load %arg1 : !llvm.ptr -> i64
+    %113 = arith.trunci %99 : i256 to i64
+    %114 = call @dora_fn_create(%arg0, %106, %113, %111, %112) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %115 = llvm.getelementptr %114[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %116 = llvm.load %115 : !llvm.ptr -> i8
+    %c0_i8_50 = arith.constant 0 : i8
+    %117 = arith.cmpi ne, %116, %c0_i8_50 : i8
+    cf.cond_br %117, ^bb1(%116 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %131 = llvm.getelementptr %127[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %132 = llvm.load %131 : !llvm.ptr -> i64
-    %133 = llvm.load %arg1 : !llvm.ptr -> i64
-    %134 = arith.cmpi ult, %133, %132 : i64
-    scf.if %134 {
+    %118 = llvm.getelementptr %114[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %119 = llvm.load %118 : !llvm.ptr -> i64
+    %120 = llvm.load %arg1 : !llvm.ptr -> i64
+    %121 = arith.cmpi ult, %120, %119 : i64
+    scf.if %121 {
     } else {
-      %258 = arith.subi %133, %132 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %120, %119 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_64 = arith.constant 80 : i8
-    cf.cond_br %134, ^bb1(%c80_i8_64 : i8), ^bb48
+    %c80_i8_51 = arith.constant 80 : i8
+    cf.cond_br %121, ^bb1(%c80_i8_51 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %135 = llvm.load %124 : !llvm.ptr -> i256
-    %136 = llvm.load %arg3 : !llvm.ptr -> i64
-    %137 = llvm.getelementptr %arg2[%136] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_65 = arith.constant 1 : i64
-    %138 = arith.addi %136, %c1_i64_65 : i64
-    llvm.store %138, %arg3 : i64, !llvm.ptr
-    llvm.store %135, %137 : i256, !llvm.ptr
+    %122 = llvm.load %111 : !llvm.ptr -> i256
+    %123 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %122, %123 : i256, !llvm.ptr
+    %124 = llvm.getelementptr %123[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %124, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb55
   ^bb49:  // pred: ^bb51
-    %c1024_i64_66 = arith.constant 1024 : i64
-    %139 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_67 = arith.constant -2 : i64
-    %140 = arith.addi %139, %c-2_i64_67 : i64
-    %c3_i64_68 = arith.constant 3 : i64
-    %141 = arith.cmpi ult, %139, %c3_i64_68 : i64
-    %c91_i8_69 = arith.constant 91 : i8
-    cf.cond_br %141, ^bb1(%c91_i8_69 : i8), ^bb41
+    %c1024_i64_52 = arith.constant 1024 : i64
+    %125 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_53 = arith.constant -2 : i64
+    %126 = arith.addi %125, %c-2_i64_53 : i64
+    llvm.store %126, %arg3 : i64, !llvm.ptr
+    %c3_i64_54 = arith.constant 3 : i64
+    %127 = arith.cmpi ult, %125, %c3_i64_54 : i64
+    %c91_i8_55 = arith.constant 91 : i8
+    cf.cond_br %127, ^bb1(%c91_i8_55 : i8), ^bb41
   ^bb50:  // pred: ^bb37
-    %142 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_70 = arith.constant 0 : i64
+    %128 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_56 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %143 = arith.cmpi uge, %142, %c0_i64_70 : i64
-    %c80_i8_71 = arith.constant 80 : i8
-    cf.cond_br %143, ^bb51, ^bb1(%c80_i8_71 : i8)
+    %129 = arith.cmpi uge, %128, %c0_i64_56 : i64
+    %c80_i8_57 = arith.constant 80 : i8
+    cf.cond_br %129, ^bb51, ^bb1(%c80_i8_57 : i8)
   ^bb51:  // pred: ^bb50
-    %144 = arith.subi %142, %c0_i64_70 : i64
-    llvm.store %144, %arg1 : i64, !llvm.ptr
+    %130 = arith.subi %128, %c0_i64_56 : i64
+    llvm.store %130, %arg1 : i64, !llvm.ptr
     cf.br ^bb49
   ^bb52:  // pred: ^bb54
-    %145 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_72 = arith.constant 1 : i64
-    %146 = arith.subi %145, %c1_i64_72 : i64
-    %147 = llvm.getelementptr %arg2[%146] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> i256
-    %c1_i256_73 = arith.constant 1 : i256
-    %149 = llvm.alloca %c1_i256_73 x i256 : (i256) -> !llvm.ptr
-    llvm.store %148, %149 {alignment = 1 : i64} : i256, !llvm.ptr
-    %150 = call @dora_fn_extcodesize(%arg0, %149) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %151 = llvm.getelementptr %150[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %152 = llvm.load %151 : !llvm.ptr -> i64
-    %153 = llvm.getelementptr %150[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %154 = llvm.load %153 : !llvm.ptr -> i64
-    %155 = llvm.load %arg1 : !llvm.ptr -> i64
-    %156 = arith.cmpi ult, %155, %154 : i64
-    scf.if %156 {
+    %131 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %132 = llvm.getelementptr %131[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %133 = llvm.load %132 : !llvm.ptr -> i256
+    llvm.store %132, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_58 = arith.constant 1 : i256
+    %134 = llvm.alloca %c1_i256_58 x i256 : (i256) -> !llvm.ptr
+    llvm.store %133, %134 {alignment = 1 : i64} : i256, !llvm.ptr
+    %135 = call @dora_fn_extcodesize(%arg0, %134) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %136 = llvm.getelementptr %135[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %137 = llvm.load %136 : !llvm.ptr -> i64
+    %138 = llvm.getelementptr %135[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %139 = llvm.load %138 : !llvm.ptr -> i64
+    %140 = llvm.load %arg1 : !llvm.ptr -> i64
+    %141 = arith.cmpi ult, %140, %139 : i64
+    scf.if %141 {
     } else {
-      %258 = arith.subi %155, %154 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %140, %139 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_74 = arith.constant 80 : i8
-    cf.cond_br %156, ^bb1(%c80_i8_74 : i8), ^bb53
+    %c80_i8_59 = arith.constant 80 : i8
+    cf.cond_br %141, ^bb1(%c80_i8_59 : i8), ^bb53
   ^bb53:  // pred: ^bb52
-    %157 = arith.extui %152 : i64 to i256
-    %158 = llvm.load %arg3 : !llvm.ptr -> i64
-    %159 = llvm.getelementptr %arg2[%158] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_75 = arith.constant 1 : i64
-    %160 = arith.addi %158, %c1_i64_75 : i64
-    llvm.store %160, %arg3 : i64, !llvm.ptr
-    llvm.store %157, %159 : i256, !llvm.ptr
+    %142 = arith.extui %137 : i64 to i256
+    %143 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %142, %143 : i256, !llvm.ptr
+    %144 = llvm.getelementptr %143[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %144, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb57
   ^bb54:  // pred: ^bb56
-    %c1024_i64_76 = arith.constant 1024 : i64
-    %161 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_77 = arith.constant 0 : i64
-    %162 = arith.addi %161, %c0_i64_77 : i64
-    %c1_i64_78 = arith.constant 1 : i64
-    %163 = arith.cmpi ult, %161, %c1_i64_78 : i64
-    %c91_i8_79 = arith.constant 91 : i8
-    cf.cond_br %163, ^bb1(%c91_i8_79 : i8), ^bb52
+    %c1024_i64_60 = arith.constant 1024 : i64
+    %145 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_61 = arith.constant 0 : i64
+    %146 = arith.addi %145, %c0_i64_61 : i64
+    llvm.store %146, %arg3 : i64, !llvm.ptr
+    %c1_i64_62 = arith.constant 1 : i64
+    %147 = arith.cmpi ult, %145, %c1_i64_62 : i64
+    %c91_i8_63 = arith.constant 91 : i8
+    cf.cond_br %147, ^bb1(%c91_i8_63 : i8), ^bb52
   ^bb55:  // pred: ^bb48
-    %164 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_80 = arith.constant 0 : i64
+    %148 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_64 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %165 = arith.cmpi uge, %164, %c0_i64_80 : i64
-    %c80_i8_81 = arith.constant 80 : i8
-    cf.cond_br %165, ^bb56, ^bb1(%c80_i8_81 : i8)
+    %149 = arith.cmpi uge, %148, %c0_i64_64 : i64
+    %c80_i8_65 = arith.constant 80 : i8
+    cf.cond_br %149, ^bb56, ^bb1(%c80_i8_65 : i8)
   ^bb56:  // pred: ^bb55
-    %166 = arith.subi %164, %c0_i64_80 : i64
-    llvm.store %166, %arg1 : i64, !llvm.ptr
+    %150 = arith.subi %148, %c0_i64_64 : i64
+    llvm.store %150, %arg1 : i64, !llvm.ptr
     cf.br ^bb54
   ^bb57:  // pred: ^bb53
-    %c0_i64_82 = arith.constant 0 : i64
+    %c0_i64_66 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %167 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_82, %c0_i64_82, %167, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %151 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_66, %c0_i64_66, %151, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb58:  // pred: ^bb11
-    %c18446744073709551615_i256_83 = arith.constant 18446744073709551615 : i256
-    %168 = arith.cmpi sgt, %24, %c18446744073709551615_i256_83 : i256
-    %c84_i8_84 = arith.constant 84 : i8
-    cf.cond_br %168, ^bb1(%c84_i8_84 : i8), ^bb59
+    %c18446744073709551615_i256_67 = arith.constant 18446744073709551615 : i256
+    %152 = arith.cmpi sgt, %22, %c18446744073709551615_i256_67 : i256
+    %c84_i8_68 = arith.constant 84 : i8
+    cf.cond_br %152, ^bb1(%c84_i8_68 : i8), ^bb59
   ^bb59:  // pred: ^bb58
-    %169 = arith.trunci %24 : i256 to i64
-    %c0_i64_85 = arith.constant 0 : i64
-    %170 = arith.cmpi slt, %169, %c0_i64_85 : i64
-    %c84_i8_86 = arith.constant 84 : i8
-    cf.cond_br %170, ^bb1(%c84_i8_86 : i8), ^bb60
+    %153 = arith.trunci %22 : i256 to i64
+    %c0_i64_69 = arith.constant 0 : i64
+    %154 = arith.cmpi slt, %153, %c0_i64_69 : i64
+    %c84_i8_70 = arith.constant 84 : i8
+    cf.cond_br %154, ^bb1(%c84_i8_70 : i8), ^bb60
   ^bb60:  // pred: ^bb59
-    %171 = arith.addi %169, %c32_i64 : i64
-    %c0_i64_87 = arith.constant 0 : i64
-    %172 = arith.cmpi slt, %171, %c0_i64_87 : i64
-    %c84_i8_88 = arith.constant 84 : i8
-    cf.cond_br %172, ^bb1(%c84_i8_88 : i8), ^bb61
+    %155 = arith.addi %153, %c32_i64 : i64
+    %c0_i64_71 = arith.constant 0 : i64
+    %156 = arith.cmpi slt, %155, %c0_i64_71 : i64
+    %c84_i8_72 = arith.constant 84 : i8
+    cf.cond_br %156, ^bb1(%c84_i8_72 : i8), ^bb61
   ^bb61:  // pred: ^bb60
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_89 = arith.constant 32 : i64
-    %173 = arith.addi %171, %c31_i64 : i64
-    %174 = arith.divui %173, %c32_i64_89 : i64
-    %c32_i64_90 = arith.constant 32 : i64
-    %175 = arith.muli %174, %c32_i64_90 : i64
-    %176 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_91 = arith.constant 31 : i64
-    %c32_i64_92 = arith.constant 32 : i64
-    %177 = arith.addi %176, %c31_i64_91 : i64
-    %178 = arith.divui %177, %c32_i64_92 : i64
-    %179 = arith.muli %178, %c32_i64_90 : i64
-    %180 = arith.cmpi ult, %179, %175 : i64
-    cf.cond_br %180, ^bb63, ^bb62
+    %c32_i64_73 = arith.constant 32 : i64
+    %157 = arith.addi %155, %c31_i64 : i64
+    %158 = arith.divui %157, %c32_i64_73 : i64
+    %c32_i64_74 = arith.constant 32 : i64
+    %159 = arith.muli %158, %c32_i64_74 : i64
+    %160 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_75 = arith.constant 31 : i64
+    %c32_i64_76 = arith.constant 32 : i64
+    %161 = arith.addi %160, %c31_i64_75 : i64
+    %162 = arith.divui %161, %c32_i64_76 : i64
+    %163 = arith.muli %162, %c32_i64_74 : i64
+    %164 = arith.cmpi ult, %163, %159 : i64
+    cf.cond_br %164, ^bb63, ^bb62
   ^bb62:  // 2 preds: ^bb61, ^bb65
     cf.br ^bb12
   ^bb63:  // pred: ^bb61
-    %c3_i64_93 = arith.constant 3 : i64
+    %c3_i64_77 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %181 = arith.muli %178, %178 : i64
-    %182 = arith.divui %181, %c512_i64 : i64
-    %183 = arith.muli %178, %c3_i64_93 : i64
-    %184 = arith.addi %182, %183 : i64
-    %c3_i64_94 = arith.constant 3 : i64
-    %c512_i64_95 = arith.constant 512 : i64
-    %185 = arith.muli %174, %174 : i64
-    %186 = arith.divui %185, %c512_i64_95 : i64
-    %187 = arith.muli %174, %c3_i64_94 : i64
-    %188 = arith.addi %186, %187 : i64
-    %189 = arith.subi %188, %184 : i64
-    %190 = llvm.load %arg1 : !llvm.ptr -> i64
-    %191 = arith.cmpi ult, %190, %189 : i64
-    scf.if %191 {
+    %165 = arith.muli %162, %162 : i64
+    %166 = arith.divui %165, %c512_i64 : i64
+    %167 = arith.muli %162, %c3_i64_77 : i64
+    %168 = arith.addi %166, %167 : i64
+    %c3_i64_78 = arith.constant 3 : i64
+    %c512_i64_79 = arith.constant 512 : i64
+    %169 = arith.muli %158, %158 : i64
+    %170 = arith.divui %169, %c512_i64_79 : i64
+    %171 = arith.muli %158, %c3_i64_78 : i64
+    %172 = arith.addi %170, %171 : i64
+    %173 = arith.subi %172, %168 : i64
+    %174 = llvm.load %arg1 : !llvm.ptr -> i64
+    %175 = arith.cmpi ult, %174, %173 : i64
+    scf.if %175 {
     } else {
-      %258 = arith.subi %190, %189 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %174, %173 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_96 = arith.constant 80 : i8
-    cf.cond_br %191, ^bb1(%c80_i8_96 : i8), ^bb64
+    %c80_i8_80 = arith.constant 80 : i8
+    cf.cond_br %175, ^bb1(%c80_i8_80 : i8), ^bb64
   ^bb64:  // pred: ^bb63
-    %192 = call @dora_fn_extend_memory(%arg0, %175) : (!llvm.ptr, i64) -> !llvm.ptr
-    %193 = llvm.getelementptr %192[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %194 = llvm.load %193 : !llvm.ptr -> i8
-    %c0_i8_97 = arith.constant 0 : i8
-    %195 = arith.cmpi ne, %194, %c0_i8_97 : i8
-    cf.cond_br %195, ^bb1(%194 : i8), ^bb65
+    %176 = call @dora_fn_extend_memory(%arg0, %159) : (!llvm.ptr, i64) -> !llvm.ptr
+    %177 = llvm.getelementptr %176[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %178 = llvm.load %177 : !llvm.ptr -> i8
+    %c0_i8_81 = arith.constant 0 : i8
+    %179 = arith.cmpi ne, %178, %c0_i8_81 : i8
+    cf.cond_br %179, ^bb1(%178 : i8), ^bb65
   ^bb65:  // pred: ^bb64
     cf.br ^bb62
   ^bb66:  // pred: ^bb24
-    %c18446744073709551615_i256_98 = arith.constant 18446744073709551615 : i256
-    %196 = arith.cmpi sgt, %61, %c18446744073709551615_i256_98 : i256
-    %c84_i8_99 = arith.constant 84 : i8
-    cf.cond_br %196, ^bb1(%c84_i8_99 : i8), ^bb67
+    %c18446744073709551615_i256_82 = arith.constant 18446744073709551615 : i256
+    %180 = arith.cmpi sgt, %55, %c18446744073709551615_i256_82 : i256
+    %c84_i8_83 = arith.constant 84 : i8
+    cf.cond_br %180, ^bb1(%c84_i8_83 : i8), ^bb67
   ^bb67:  // pred: ^bb66
-    %197 = arith.trunci %61 : i256 to i64
-    %c0_i64_100 = arith.constant 0 : i64
-    %198 = arith.cmpi slt, %197, %c0_i64_100 : i64
-    %c84_i8_101 = arith.constant 84 : i8
-    cf.cond_br %198, ^bb1(%c84_i8_101 : i8), ^bb68
+    %181 = arith.trunci %55 : i256 to i64
+    %c0_i64_84 = arith.constant 0 : i64
+    %182 = arith.cmpi slt, %181, %c0_i64_84 : i64
+    %c84_i8_85 = arith.constant 84 : i8
+    cf.cond_br %182, ^bb1(%c84_i8_85 : i8), ^bb68
   ^bb68:  // pred: ^bb67
-    %199 = arith.addi %197, %c32_i64_28 : i64
-    %c0_i64_102 = arith.constant 0 : i64
-    %200 = arith.cmpi slt, %199, %c0_i64_102 : i64
-    %c84_i8_103 = arith.constant 84 : i8
-    cf.cond_br %200, ^bb1(%c84_i8_103 : i8), ^bb69
+    %183 = arith.addi %181, %c32_i64_21 : i64
+    %c0_i64_86 = arith.constant 0 : i64
+    %184 = arith.cmpi slt, %183, %c0_i64_86 : i64
+    %c84_i8_87 = arith.constant 84 : i8
+    cf.cond_br %184, ^bb1(%c84_i8_87 : i8), ^bb69
   ^bb69:  // pred: ^bb68
-    %c31_i64_104 = arith.constant 31 : i64
-    %c32_i64_105 = arith.constant 32 : i64
-    %201 = arith.addi %199, %c31_i64_104 : i64
-    %202 = arith.divui %201, %c32_i64_105 : i64
-    %c32_i64_106 = arith.constant 32 : i64
-    %203 = arith.muli %202, %c32_i64_106 : i64
-    %204 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_107 = arith.constant 31 : i64
-    %c32_i64_108 = arith.constant 32 : i64
-    %205 = arith.addi %204, %c31_i64_107 : i64
-    %206 = arith.divui %205, %c32_i64_108 : i64
-    %207 = arith.muli %206, %c32_i64_106 : i64
-    %208 = arith.cmpi ult, %207, %203 : i64
-    cf.cond_br %208, ^bb71, ^bb70
+    %c31_i64_88 = arith.constant 31 : i64
+    %c32_i64_89 = arith.constant 32 : i64
+    %185 = arith.addi %183, %c31_i64_88 : i64
+    %186 = arith.divui %185, %c32_i64_89 : i64
+    %c32_i64_90 = arith.constant 32 : i64
+    %187 = arith.muli %186, %c32_i64_90 : i64
+    %188 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_91 = arith.constant 31 : i64
+    %c32_i64_92 = arith.constant 32 : i64
+    %189 = arith.addi %188, %c31_i64_91 : i64
+    %190 = arith.divui %189, %c32_i64_92 : i64
+    %191 = arith.muli %190, %c32_i64_90 : i64
+    %192 = arith.cmpi ult, %191, %187 : i64
+    cf.cond_br %192, ^bb71, ^bb70
   ^bb70:  // 2 preds: ^bb69, ^bb73
     cf.br ^bb25
   ^bb71:  // pred: ^bb69
-    %c3_i64_109 = arith.constant 3 : i64
-    %c512_i64_110 = arith.constant 512 : i64
-    %209 = arith.muli %206, %206 : i64
-    %210 = arith.divui %209, %c512_i64_110 : i64
-    %211 = arith.muli %206, %c3_i64_109 : i64
-    %212 = arith.addi %210, %211 : i64
-    %c3_i64_111 = arith.constant 3 : i64
-    %c512_i64_112 = arith.constant 512 : i64
-    %213 = arith.muli %202, %202 : i64
-    %214 = arith.divui %213, %c512_i64_112 : i64
-    %215 = arith.muli %202, %c3_i64_111 : i64
-    %216 = arith.addi %214, %215 : i64
-    %217 = arith.subi %216, %212 : i64
-    %218 = llvm.load %arg1 : !llvm.ptr -> i64
-    %219 = arith.cmpi ult, %218, %217 : i64
-    scf.if %219 {
+    %c3_i64_93 = arith.constant 3 : i64
+    %c512_i64_94 = arith.constant 512 : i64
+    %193 = arith.muli %190, %190 : i64
+    %194 = arith.divui %193, %c512_i64_94 : i64
+    %195 = arith.muli %190, %c3_i64_93 : i64
+    %196 = arith.addi %194, %195 : i64
+    %c3_i64_95 = arith.constant 3 : i64
+    %c512_i64_96 = arith.constant 512 : i64
+    %197 = arith.muli %186, %186 : i64
+    %198 = arith.divui %197, %c512_i64_96 : i64
+    %199 = arith.muli %186, %c3_i64_95 : i64
+    %200 = arith.addi %198, %199 : i64
+    %201 = arith.subi %200, %196 : i64
+    %202 = llvm.load %arg1 : !llvm.ptr -> i64
+    %203 = arith.cmpi ult, %202, %201 : i64
+    scf.if %203 {
     } else {
-      %258 = arith.subi %218, %217 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %202, %201 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_113 = arith.constant 80 : i8
-    cf.cond_br %219, ^bb1(%c80_i8_113 : i8), ^bb72
+    %c80_i8_97 = arith.constant 80 : i8
+    cf.cond_br %203, ^bb1(%c80_i8_97 : i8), ^bb72
   ^bb72:  // pred: ^bb71
-    %220 = call @dora_fn_extend_memory(%arg0, %203) : (!llvm.ptr, i64) -> !llvm.ptr
-    %221 = llvm.getelementptr %220[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %222 = llvm.load %221 : !llvm.ptr -> i8
-    %c0_i8_114 = arith.constant 0 : i8
-    %223 = arith.cmpi ne, %222, %c0_i8_114 : i8
-    cf.cond_br %223, ^bb1(%222 : i8), ^bb73
+    %204 = call @dora_fn_extend_memory(%arg0, %187) : (!llvm.ptr, i64) -> !llvm.ptr
+    %205 = llvm.getelementptr %204[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %206 = llvm.load %205 : !llvm.ptr -> i8
+    %c0_i8_98 = arith.constant 0 : i8
+    %207 = arith.cmpi ne, %206, %c0_i8_98 : i8
+    cf.cond_br %207, ^bb1(%206 : i8), ^bb73
   ^bb73:  // pred: ^bb72
     cf.br ^bb70
   ^bb74:  // pred: ^bb44
     %c49152_i64 = arith.constant 49152 : i64
-    %224 = arith.cmpi ugt, %119, %c49152_i64 : i64
+    %208 = arith.cmpi ugt, %106, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %224, ^bb1(%c100_i8 : i8), ^bb75
+    cf.cond_br %208, ^bb1(%c100_i8 : i8), ^bb75
   ^bb75:  // pred: ^bb74
-    %c31_i64_115 = arith.constant 31 : i64
-    %c32_i64_116 = arith.constant 32 : i64
-    %225 = arith.addi %119, %c31_i64_115 : i64
-    %226 = arith.divui %225, %c32_i64_116 : i64
-    %c2_i64_117 = arith.constant 2 : i64
-    %227 = arith.muli %226, %c2_i64_117 : i64
-    %228 = llvm.load %arg1 : !llvm.ptr -> i64
-    %229 = arith.cmpi ult, %228, %227 : i64
-    scf.if %229 {
+    %c31_i64_99 = arith.constant 31 : i64
+    %c32_i64_100 = arith.constant 32 : i64
+    %209 = arith.addi %106, %c31_i64_99 : i64
+    %210 = arith.divui %209, %c32_i64_100 : i64
+    %c2_i64_101 = arith.constant 2 : i64
+    %211 = arith.muli %210, %c2_i64_101 : i64
+    %212 = llvm.load %arg1 : !llvm.ptr -> i64
+    %213 = arith.cmpi ult, %212, %211 : i64
+    scf.if %213 {
     } else {
-      %258 = arith.subi %228, %227 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %212, %211 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_118 = arith.constant 80 : i8
-    cf.cond_br %229, ^bb1(%c80_i8_118 : i8), ^bb76
+    %c80_i8_102 = arith.constant 80 : i8
+    cf.cond_br %213, ^bb1(%c80_i8_102 : i8), ^bb76
   ^bb76:  // pred: ^bb75
-    %c18446744073709551615_i256_119 = arith.constant 18446744073709551615 : i256
-    %230 = arith.cmpi sgt, %111, %c18446744073709551615_i256_119 : i256
-    %c84_i8_120 = arith.constant 84 : i8
-    cf.cond_br %230, ^bb1(%c84_i8_120 : i8), ^bb77
+    %c18446744073709551615_i256_103 = arith.constant 18446744073709551615 : i256
+    %214 = arith.cmpi sgt, %99, %c18446744073709551615_i256_103 : i256
+    %c84_i8_104 = arith.constant 84 : i8
+    cf.cond_br %214, ^bb1(%c84_i8_104 : i8), ^bb77
   ^bb77:  // pred: ^bb76
-    %231 = arith.trunci %111 : i256 to i64
-    %c0_i64_121 = arith.constant 0 : i64
-    %232 = arith.cmpi slt, %231, %c0_i64_121 : i64
-    %c84_i8_122 = arith.constant 84 : i8
-    cf.cond_br %232, ^bb1(%c84_i8_122 : i8), ^bb78
+    %215 = arith.trunci %99 : i256 to i64
+    %c0_i64_105 = arith.constant 0 : i64
+    %216 = arith.cmpi slt, %215, %c0_i64_105 : i64
+    %c84_i8_106 = arith.constant 84 : i8
+    cf.cond_br %216, ^bb1(%c84_i8_106 : i8), ^bb78
   ^bb78:  // pred: ^bb77
-    %233 = arith.addi %231, %119 : i64
-    %c0_i64_123 = arith.constant 0 : i64
-    %234 = arith.cmpi slt, %233, %c0_i64_123 : i64
-    %c84_i8_124 = arith.constant 84 : i8
-    cf.cond_br %234, ^bb1(%c84_i8_124 : i8), ^bb79
+    %217 = arith.addi %215, %106 : i64
+    %c0_i64_107 = arith.constant 0 : i64
+    %218 = arith.cmpi slt, %217, %c0_i64_107 : i64
+    %c84_i8_108 = arith.constant 84 : i8
+    cf.cond_br %218, ^bb1(%c84_i8_108 : i8), ^bb79
   ^bb79:  // pred: ^bb78
-    %c31_i64_125 = arith.constant 31 : i64
-    %c32_i64_126 = arith.constant 32 : i64
-    %235 = arith.addi %233, %c31_i64_125 : i64
-    %236 = arith.divui %235, %c32_i64_126 : i64
-    %c32_i64_127 = arith.constant 32 : i64
-    %237 = arith.muli %236, %c32_i64_127 : i64
-    %238 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_128 = arith.constant 31 : i64
-    %c32_i64_129 = arith.constant 32 : i64
-    %239 = arith.addi %238, %c31_i64_128 : i64
-    %240 = arith.divui %239, %c32_i64_129 : i64
-    %241 = arith.muli %240, %c32_i64_127 : i64
-    %242 = arith.cmpi ult, %241, %237 : i64
-    cf.cond_br %242, ^bb81, ^bb80
+    %c31_i64_109 = arith.constant 31 : i64
+    %c32_i64_110 = arith.constant 32 : i64
+    %219 = arith.addi %217, %c31_i64_109 : i64
+    %220 = arith.divui %219, %c32_i64_110 : i64
+    %c32_i64_111 = arith.constant 32 : i64
+    %221 = arith.muli %220, %c32_i64_111 : i64
+    %222 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_112 = arith.constant 31 : i64
+    %c32_i64_113 = arith.constant 32 : i64
+    %223 = arith.addi %222, %c31_i64_112 : i64
+    %224 = arith.divui %223, %c32_i64_113 : i64
+    %225 = arith.muli %224, %c32_i64_111 : i64
+    %226 = arith.cmpi ult, %225, %221 : i64
+    cf.cond_br %226, ^bb81, ^bb80
   ^bb80:  // 2 preds: ^bb79, ^bb83
     cf.br ^bb45
   ^bb81:  // pred: ^bb79
-    %c3_i64_130 = arith.constant 3 : i64
-    %c512_i64_131 = arith.constant 512 : i64
-    %243 = arith.muli %240, %240 : i64
-    %244 = arith.divui %243, %c512_i64_131 : i64
-    %245 = arith.muli %240, %c3_i64_130 : i64
-    %246 = arith.addi %244, %245 : i64
-    %c3_i64_132 = arith.constant 3 : i64
-    %c512_i64_133 = arith.constant 512 : i64
-    %247 = arith.muli %236, %236 : i64
-    %248 = arith.divui %247, %c512_i64_133 : i64
-    %249 = arith.muli %236, %c3_i64_132 : i64
-    %250 = arith.addi %248, %249 : i64
-    %251 = arith.subi %250, %246 : i64
-    %252 = llvm.load %arg1 : !llvm.ptr -> i64
-    %253 = arith.cmpi ult, %252, %251 : i64
-    scf.if %253 {
+    %c3_i64_114 = arith.constant 3 : i64
+    %c512_i64_115 = arith.constant 512 : i64
+    %227 = arith.muli %224, %224 : i64
+    %228 = arith.divui %227, %c512_i64_115 : i64
+    %229 = arith.muli %224, %c3_i64_114 : i64
+    %230 = arith.addi %228, %229 : i64
+    %c3_i64_116 = arith.constant 3 : i64
+    %c512_i64_117 = arith.constant 512 : i64
+    %231 = arith.muli %220, %220 : i64
+    %232 = arith.divui %231, %c512_i64_117 : i64
+    %233 = arith.muli %220, %c3_i64_116 : i64
+    %234 = arith.addi %232, %233 : i64
+    %235 = arith.subi %234, %230 : i64
+    %236 = llvm.load %arg1 : !llvm.ptr -> i64
+    %237 = arith.cmpi ult, %236, %235 : i64
+    scf.if %237 {
     } else {
-      %258 = arith.subi %252, %251 : i64
-      llvm.store %258, %arg1 : i64, !llvm.ptr
+      %242 = arith.subi %236, %235 : i64
+      llvm.store %242, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_134 = arith.constant 80 : i8
-    cf.cond_br %253, ^bb1(%c80_i8_134 : i8), ^bb82
+    %c80_i8_118 = arith.constant 80 : i8
+    cf.cond_br %237, ^bb1(%c80_i8_118 : i8), ^bb82
   ^bb82:  // pred: ^bb81
-    %254 = call @dora_fn_extend_memory(%arg0, %237) : (!llvm.ptr, i64) -> !llvm.ptr
-    %255 = llvm.getelementptr %254[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %256 = llvm.load %255 : !llvm.ptr -> i8
-    %c0_i8_135 = arith.constant 0 : i8
-    %257 = arith.cmpi ne, %256, %c0_i8_135 : i8
-    cf.cond_br %257, ^bb1(%256 : i8), ^bb83
+    %238 = call @dora_fn_extend_memory(%arg0, %221) : (!llvm.ptr, i64) -> !llvm.ptr
+    %239 = llvm.getelementptr %238[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %240 = llvm.load %239 : !llvm.ptr -> i8
+    %c0_i8_119 = arith.constant 0 : i8
+    %241 = arith.cmpi ne, %240, %c0_i8_119 : i8
+    cf.cond_br %241, ^bb1(%240 : i8), ^bb83
   ^bb83:  // pred: ^bb82
     cf.br ^bb80
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 139 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb39, ^bb40, ^bb43, ^bb44, ^bb47, ^bb48, ^bb51, ^bb52, ^bb54, ^bb55, ^bb56, ^bb58, ^bb59, ^bb60, ^bb62, ^bb63, ^bb66, ^bb67, ^bb70, ^bb71, ^bb74, ^bb75, ^bb78, ^bb79, ^bb82, ^bb83, ^bb86, ^bb87, ^bb89, ^bb90, ^bb92, ^bb93, ^bb95, ^bb96, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb110, ^bb111, ^bb114, ^bb115, ^bb119, ^bb120, ^bb123, ^bb124, ^bb127, ^bb128, ^bb132, ^bb133, ^bb136, ^bb137, ^bb140, ^bb141, ^bb145, ^bb146, ^bb149, ^bb150, ^bb153, ^bb154, ^bb157, ^bb158, ^bb160, ^bb161, ^bb162, ^bb164, ^bb166, ^bb167, ^bb170, ^bb171, ^bb172, ^bb175, ^bb176, ^bb178, ^bb179, ^bb180, ^bb183, ^bb184, ^bb186, ^bb187, ^bb188, ^bb191, ^bb192, ^bb194, ^bb195, ^bb196, ^bb197, ^bb198, ^bb201, ^bb202, ^bb204, ^bb205, ^bb206, ^bb209, ^bb210, ^bb212, ^bb213, ^bb214, ^bb217, ^bb218, ^bb220, ^bb221, ^bb222, ^bb225, ^bb226, ^bb228, ^bb229, ^bb230, ^bb233, ^bb234, ^bb236, ^bb237, ^bb238, ^bb241, ^bb242, ^bb244, ^bb245, ^bb246, ^bb249, ^bb250
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 139 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb39, ^bb40, ^bb43, ^bb44, ^bb47, ^bb48, ^bb51, ^bb52, ^bb54, ^bb55, ^bb56, ^bb58, ^bb59, ^bb60, ^bb62, ^bb63, ^bb66, ^bb67, ^bb70, ^bb71, ^bb74, ^bb75, ^bb78, ^bb79, ^bb82, ^bb83, ^bb86, ^bb87, ^bb89, ^bb90, ^bb92, ^bb93, ^bb95, ^bb96, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb110, ^bb111, ^bb114, ^bb115, ^bb119, ^bb120, ^bb123, ^bb124, ^bb127, ^bb128, ^bb132, ^bb133, ^bb136, ^bb137, ^bb140, ^bb141, ^bb145, ^bb146, ^bb149, ^bb150, ^bb153, ^bb154, ^bb157, ^bb158, ^bb160, ^bb161, ^bb162, ^bb164, ^bb166, ^bb167, ^bb170, ^bb171, ^bb172, ^bb175, ^bb176, ^bb178, ^bb179, ^bb180, ^bb183, ^bb184, ^bb186, ^bb187, ^bb188, ^bb191, ^bb192, ^bb194, ^bb195, ^bb196, ^bb197, ^bb198, ^bb201, ^bb202, ^bb204, ^bb205, ^bb206, ^bb209, ^bb210, ^bb212, ^bb213, ^bb214, ^bb217, ^bb218, ^bb220, ^bb221, ^bb222, ^bb225, ^bb226, ^bb228, ^bb229, ^bb230, ^bb233, ^bb234, ^bb236, ^bb237, ^bb238, ^bb241, ^bb242, ^bb244, ^bb245, ^bb246, ^bb249, ^bb250
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c57669888194366464517598830424248860356609074394020202793089226410191109488639_i256 = arith.constant 57669888194366464517598830424248860356609074394020202793089226410191109488639 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c57669888194366464517598830424248860356609074394020202793089226410191109488639_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,1974 +96,1905 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb170, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb170, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb174
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256 = arith.constant -282693306169198560872784742741978202424711039104693490077813924759764729856 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c32_i256 = arith.constant 32 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_25 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_25 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_26 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
-    %c32_i64_27 = arith.constant 32 : i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %66 = arith.cmpi ne, %c32_i64_27, %c0_i64_28 : i64
-    cf.cond_br %66, ^bb178, ^bb25
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_20 = arith.constant 32 : i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %59 = arith.cmpi ne, %c32_i64_20, %c0_i64_21 : i64
+    cf.cond_br %59, ^bb178, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb182
-    %67 = arith.trunci %61 : i256 to i64
-    %68 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %69 = llvm.getelementptr %68[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %70 = llvm.intr.bswap(%65)  : (i256) -> i256
-    llvm.store %70, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = arith.trunci %55 : i256 to i64
+    %61 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %63 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %63, %62 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb31
   ^bb26:  // pred: ^bb28
-    %c1024_i64_29 = arith.constant 1024 : i64
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_30 = arith.constant -2 : i64
-    %72 = arith.addi %71, %c-2_i64_30 : i64
-    %c2_i64_31 = arith.constant 2 : i64
-    %73 = arith.cmpi ult, %71, %c2_i64_31 : i64
-    %c91_i8_32 = arith.constant 91 : i8
-    cf.cond_br %73, ^bb1(%c91_i8_32 : i8), ^bb24
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_23 = arith.constant -2 : i64
+    %65 = arith.addi %64, %c-2_i64_23 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c2_i64_24 = arith.constant 2 : i64
+    %66 = arith.cmpi ult, %64, %c2_i64_24 : i64
+    %c91_i8_25 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_25 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_33 = arith.constant 3 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_26 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %75 = arith.cmpi uge, %74, %c3_i64_33 : i64
-    %c80_i8_34 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb28, ^bb1(%c80_i8_34 : i8)
+    %68 = arith.cmpi uge, %67, %c3_i64_26 : i64
+    %c80_i8_27 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb28, ^bb1(%c80_i8_27 : i8)
   ^bb28:  // pred: ^bb27
-    %76 = arith.subi %74, %c3_i64_33 : i64
-    llvm.store %76, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c3_i64_26 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb30
     %c10123276409175967808859434475862811765392092841461775252157603250176_i256 = arith.constant 10123276409175967808859434475862811765392092841461775252157603250176 : i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %78 = llvm.getelementptr %arg2[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_35 = arith.constant 1 : i64
-    %79 = arith.addi %77, %c1_i64_35 : i64
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %78 : i256, !llvm.ptr
+    %70 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %70 : i256, !llvm.ptr
+    %71 = llvm.getelementptr %70[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %71, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_36 = arith.constant 1024 : i64
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_37 = arith.constant 1 : i64
-    %81 = arith.addi %80, %c1_i64_37 : i64
-    %82 = arith.cmpi ult, %c1024_i64_36, %81 : i64
-    %c92_i8_38 = arith.constant 92 : i8
-    cf.cond_br %82, ^bb1(%c92_i8_38 : i8), ^bb29
+    %c1024_i64_28 = arith.constant 1024 : i64
+    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_29 = arith.constant 1 : i64
+    %73 = arith.addi %72, %c1_i64_29 : i64
+    llvm.store %73, %arg3 : i64, !llvm.ptr
+    %74 = arith.cmpi ult, %c1024_i64_28, %73 : i64
+    %c92_i8_30 = arith.constant 92 : i8
+    cf.cond_br %74, ^bb1(%c92_i8_30 : i8), ^bb29
   ^bb31:  // pred: ^bb25
-    %83 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_39 = arith.constant 3 : i64
+    %75 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_31 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %84 = arith.cmpi uge, %83, %c3_i64_39 : i64
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %84, ^bb32, ^bb1(%c80_i8_40 : i8)
+    %76 = arith.cmpi uge, %75, %c3_i64_31 : i64
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %76, ^bb32, ^bb1(%c80_i8_32 : i8)
   ^bb32:  // pred: ^bb31
-    %85 = arith.subi %83, %c3_i64_39 : i64
-    llvm.store %85, %arg1 : i64, !llvm.ptr
+    %77 = arith.subi %75, %c3_i64_31 : i64
+    llvm.store %77, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
     %c64_i256 = arith.constant 64 : i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %87 = llvm.getelementptr %arg2[%86] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %88 = arith.addi %86, %c1_i64_41 : i64
-    llvm.store %88, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %87 : i256, !llvm.ptr
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb40
   ^bb34:  // pred: ^bb36
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %89 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_43 = arith.constant 1 : i64
-    %90 = arith.addi %89, %c1_i64_43 : i64
-    %91 = arith.cmpi ult, %c1024_i64_42, %90 : i64
-    %c92_i8_44 = arith.constant 92 : i8
-    cf.cond_br %91, ^bb1(%c92_i8_44 : i8), ^bb33
+    %c1024_i64_33 = arith.constant 1024 : i64
+    %80 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %81 = arith.addi %80, %c1_i64_34 : i64
+    llvm.store %81, %arg3 : i64, !llvm.ptr
+    %82 = arith.cmpi ult, %c1024_i64_33, %81 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %82, ^bb1(%c92_i8_35 : i8), ^bb33
   ^bb35:  // pred: ^bb29
-    %92 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_45 = arith.constant 3 : i64
+    %83 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_36 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %93 = arith.cmpi uge, %92, %c3_i64_45 : i64
-    %c80_i8_46 = arith.constant 80 : i8
-    cf.cond_br %93, ^bb36, ^bb1(%c80_i8_46 : i8)
+    %84 = arith.cmpi uge, %83, %c3_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %84, ^bb36, ^bb1(%c80_i8_37 : i8)
   ^bb36:  // pred: ^bb35
-    %94 = arith.subi %92, %c3_i64_45 : i64
-    llvm.store %94, %arg1 : i64, !llvm.ptr
+    %85 = arith.subi %83, %c3_i64_36 : i64
+    llvm.store %85, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb39
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_47 = arith.constant 1 : i64
-    %96 = arith.subi %95, %c1_i64_47 : i64
-    %97 = llvm.getelementptr %arg2[%96] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %96, %arg3 : i64, !llvm.ptr
-    %98 = llvm.load %97 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_48 = arith.constant 1 : i64
-    %100 = arith.subi %99, %c1_i64_48 : i64
-    %101 = llvm.getelementptr %arg2[%100] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %100, %arg3 : i64, !llvm.ptr
-    %102 = llvm.load %101 : !llvm.ptr -> i256
-    %c32_i64_49 = arith.constant 32 : i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %103 = arith.cmpi ne, %c32_i64_49, %c0_i64_50 : i64
-    cf.cond_br %103, ^bb186, ^bb38
+    %86 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %87 = llvm.getelementptr %86[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %88 = llvm.load %87 : !llvm.ptr -> i256
+    llvm.store %87, %0 : !llvm.ptr, !llvm.ptr
+    %89 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %90 = llvm.getelementptr %89[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %91 = llvm.load %90 : !llvm.ptr -> i256
+    llvm.store %90, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_38 = arith.constant 32 : i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %92 = arith.cmpi ne, %c32_i64_38, %c0_i64_39 : i64
+    cf.cond_br %92, ^bb186, ^bb38
   ^bb38:  // 2 preds: ^bb37, ^bb190
-    %104 = arith.trunci %98 : i256 to i64
-    %105 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %106 = llvm.getelementptr %105[%104] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %107 = llvm.intr.bswap(%102)  : (i256) -> i256
-    llvm.store %107, %106 {alignment = 1 : i64} : i256, !llvm.ptr
+    %93 = arith.trunci %88 : i256 to i64
+    %94 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %95 = llvm.getelementptr %94[%93] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %96 = llvm.intr.bswap(%91)  : (i256) -> i256
+    llvm.store %96, %95 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb44
   ^bb39:  // pred: ^bb41
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_52 = arith.constant -2 : i64
-    %109 = arith.addi %108, %c-2_i64_52 : i64
-    %c2_i64_53 = arith.constant 2 : i64
-    %110 = arith.cmpi ult, %108, %c2_i64_53 : i64
-    %c91_i8_54 = arith.constant 91 : i8
-    cf.cond_br %110, ^bb1(%c91_i8_54 : i8), ^bb37
+    %c1024_i64_40 = arith.constant 1024 : i64
+    %97 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_41 = arith.constant -2 : i64
+    %98 = arith.addi %97, %c-2_i64_41 : i64
+    llvm.store %98, %arg3 : i64, !llvm.ptr
+    %c2_i64_42 = arith.constant 2 : i64
+    %99 = arith.cmpi ult, %97, %c2_i64_42 : i64
+    %c91_i8_43 = arith.constant 91 : i8
+    cf.cond_br %99, ^bb1(%c91_i8_43 : i8), ^bb37
   ^bb40:  // pred: ^bb33
-    %111 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_55 = arith.constant 3 : i64
+    %100 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_44 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %112 = arith.cmpi uge, %111, %c3_i64_55 : i64
-    %c80_i8_56 = arith.constant 80 : i8
-    cf.cond_br %112, ^bb41, ^bb1(%c80_i8_56 : i8)
+    %101 = arith.cmpi uge, %100, %c3_i64_44 : i64
+    %c80_i8_45 = arith.constant 80 : i8
+    cf.cond_br %101, ^bb41, ^bb1(%c80_i8_45 : i8)
   ^bb41:  // pred: ^bb40
-    %113 = arith.subi %111, %c3_i64_55 : i64
-    llvm.store %113, %arg1 : i64, !llvm.ptr
+    %102 = arith.subi %100, %c3_i64_44 : i64
+    llvm.store %102, %arg1 : i64, !llvm.ptr
     cf.br ^bb39
   ^bb42:  // pred: ^bb43
     %c77_i256 = arith.constant 77 : i256
-    %114 = llvm.load %arg3 : !llvm.ptr -> i64
-    %115 = llvm.getelementptr %arg2[%114] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_57 = arith.constant 1 : i64
-    %116 = arith.addi %114, %c1_i64_57 : i64
-    llvm.store %116, %arg3 : i64, !llvm.ptr
-    llvm.store %c77_i256, %115 : i256, !llvm.ptr
+    %103 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c77_i256, %103 : i256, !llvm.ptr
+    %104 = llvm.getelementptr %103[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %104, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb48
   ^bb43:  // pred: ^bb45
-    %c1024_i64_58 = arith.constant 1024 : i64
-    %117 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_59 = arith.constant 1 : i64
-    %118 = arith.addi %117, %c1_i64_59 : i64
-    %119 = arith.cmpi ult, %c1024_i64_58, %118 : i64
-    %c92_i8_60 = arith.constant 92 : i8
-    cf.cond_br %119, ^bb1(%c92_i8_60 : i8), ^bb42
+    %c1024_i64_46 = arith.constant 1024 : i64
+    %105 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_47 = arith.constant 1 : i64
+    %106 = arith.addi %105, %c1_i64_47 : i64
+    llvm.store %106, %arg3 : i64, !llvm.ptr
+    %107 = arith.cmpi ult, %c1024_i64_46, %106 : i64
+    %c92_i8_48 = arith.constant 92 : i8
+    cf.cond_br %107, ^bb1(%c92_i8_48 : i8), ^bb42
   ^bb44:  // pred: ^bb38
-    %120 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_61 = arith.constant 3 : i64
+    %108 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_49 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %121 = arith.cmpi uge, %120, %c3_i64_61 : i64
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %121, ^bb45, ^bb1(%c80_i8_62 : i8)
+    %109 = arith.cmpi uge, %108, %c3_i64_49 : i64
+    %c80_i8_50 = arith.constant 80 : i8
+    cf.cond_br %109, ^bb45, ^bb1(%c80_i8_50 : i8)
   ^bb45:  // pred: ^bb44
-    %122 = arith.subi %120, %c3_i64_61 : i64
-    llvm.store %122, %arg1 : i64, !llvm.ptr
+    %110 = arith.subi %108, %c3_i64_49 : i64
+    llvm.store %110, %arg1 : i64, !llvm.ptr
     cf.br ^bb43
   ^bb46:  // pred: ^bb47
-    %c0_i256_63 = arith.constant 0 : i256
-    %123 = llvm.load %arg3 : !llvm.ptr -> i64
-    %124 = llvm.getelementptr %arg2[%123] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_64 = arith.constant 1 : i64
-    %125 = arith.addi %123, %c1_i64_64 : i64
-    llvm.store %125, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_63, %124 : i256, !llvm.ptr
+    %c0_i256_51 = arith.constant 0 : i256
+    %111 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_51, %111 : i256, !llvm.ptr
+    %112 = llvm.getelementptr %111[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %112, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb52
   ^bb47:  // pred: ^bb49
-    %c1024_i64_65 = arith.constant 1024 : i64
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_66 = arith.constant 1 : i64
-    %127 = arith.addi %126, %c1_i64_66 : i64
-    %128 = arith.cmpi ult, %c1024_i64_65, %127 : i64
-    %c92_i8_67 = arith.constant 92 : i8
-    cf.cond_br %128, ^bb1(%c92_i8_67 : i8), ^bb46
+    %c1024_i64_52 = arith.constant 1024 : i64
+    %113 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_53 = arith.constant 1 : i64
+    %114 = arith.addi %113, %c1_i64_53 : i64
+    llvm.store %114, %arg3 : i64, !llvm.ptr
+    %115 = arith.cmpi ult, %c1024_i64_52, %114 : i64
+    %c92_i8_54 = arith.constant 92 : i8
+    cf.cond_br %115, ^bb1(%c92_i8_54 : i8), ^bb46
   ^bb48:  // pred: ^bb42
-    %129 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_68 = arith.constant 3 : i64
+    %116 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_55 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %130 = arith.cmpi uge, %129, %c3_i64_68 : i64
-    %c80_i8_69 = arith.constant 80 : i8
-    cf.cond_br %130, ^bb49, ^bb1(%c80_i8_69 : i8)
+    %117 = arith.cmpi uge, %116, %c3_i64_55 : i64
+    %c80_i8_56 = arith.constant 80 : i8
+    cf.cond_br %117, ^bb49, ^bb1(%c80_i8_56 : i8)
   ^bb49:  // pred: ^bb48
-    %131 = arith.subi %129, %c3_i64_68 : i64
-    llvm.store %131, %arg1 : i64, !llvm.ptr
+    %118 = arith.subi %116, %c3_i64_55 : i64
+    llvm.store %118, %arg1 : i64, !llvm.ptr
     cf.br ^bb47
   ^bb50:  // pred: ^bb51
-    %c0_i256_70 = arith.constant 0 : i256
-    %132 = llvm.load %arg3 : !llvm.ptr -> i64
-    %133 = llvm.getelementptr %arg2[%132] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_71 = arith.constant 1 : i64
-    %134 = arith.addi %132, %c1_i64_71 : i64
-    llvm.store %134, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_70, %133 : i256, !llvm.ptr
+    %c0_i256_57 = arith.constant 0 : i256
+    %119 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_57, %119 : i256, !llvm.ptr
+    %120 = llvm.getelementptr %119[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %120, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb63
   ^bb51:  // pred: ^bb53
-    %c1024_i64_72 = arith.constant 1024 : i64
-    %135 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_73 = arith.constant 1 : i64
-    %136 = arith.addi %135, %c1_i64_73 : i64
-    %137 = arith.cmpi ult, %c1024_i64_72, %136 : i64
-    %c92_i8_74 = arith.constant 92 : i8
-    cf.cond_br %137, ^bb1(%c92_i8_74 : i8), ^bb50
+    %c1024_i64_58 = arith.constant 1024 : i64
+    %121 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_59 = arith.constant 1 : i64
+    %122 = arith.addi %121, %c1_i64_59 : i64
+    llvm.store %122, %arg3 : i64, !llvm.ptr
+    %123 = arith.cmpi ult, %c1024_i64_58, %122 : i64
+    %c92_i8_60 = arith.constant 92 : i8
+    cf.cond_br %123, ^bb1(%c92_i8_60 : i8), ^bb50
   ^bb52:  // pred: ^bb46
-    %138 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_75 = arith.constant 3 : i64
+    %124 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_61 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %139 = arith.cmpi uge, %138, %c3_i64_75 : i64
-    %c80_i8_76 = arith.constant 80 : i8
-    cf.cond_br %139, ^bb53, ^bb1(%c80_i8_76 : i8)
+    %125 = arith.cmpi uge, %124, %c3_i64_61 : i64
+    %c80_i8_62 = arith.constant 80 : i8
+    cf.cond_br %125, ^bb53, ^bb1(%c80_i8_62 : i8)
   ^bb53:  // pred: ^bb52
-    %140 = arith.subi %138, %c3_i64_75 : i64
-    llvm.store %140, %arg1 : i64, !llvm.ptr
+    %126 = arith.subi %124, %c3_i64_61 : i64
+    llvm.store %126, %arg1 : i64, !llvm.ptr
     cf.br ^bb51
   ^bb54:  // pred: ^bb62
-    %141 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_77 = arith.constant 1 : i64
-    %142 = arith.subi %141, %c1_i64_77 : i64
-    %143 = llvm.getelementptr %arg2[%142] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %142, %arg3 : i64, !llvm.ptr
-    %144 = llvm.load %143 : !llvm.ptr -> i256
-    %145 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_78 = arith.constant 1 : i64
-    %146 = arith.subi %145, %c1_i64_78 : i64
-    %147 = llvm.getelementptr %arg2[%146] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> i256
-    %149 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %150 = arith.subi %149, %c1_i64_79 : i64
-    %151 = llvm.getelementptr %arg2[%150] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %150, %arg3 : i64, !llvm.ptr
-    %152 = llvm.load %151 : !llvm.ptr -> i256
-    %153 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %127 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %0 : !llvm.ptr, !llvm.ptr
+    %130 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %131 = llvm.getelementptr %130[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %132 = llvm.load %131 : !llvm.ptr -> i256
+    llvm.store %131, %0 : !llvm.ptr, !llvm.ptr
+    %133 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %134 = llvm.getelementptr %133[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %135 = llvm.load %134 : !llvm.ptr -> i256
+    llvm.store %134, %0 : !llvm.ptr, !llvm.ptr
+    %136 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %154 = arith.cmpi ne, %153, %c0_i8 : i8
+    %137 = arith.cmpi ne, %136, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %154, ^bb1(%c87_i8 : i8), ^bb55
+    cf.cond_br %137, ^bb1(%c87_i8 : i8), ^bb55
   ^bb55:  // pred: ^bb54
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %155 = arith.cmpi sgt, %152, %c18446744073709551615_i256 : i256
+    %138 = arith.cmpi sgt, %135, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %155, ^bb1(%c84_i8 : i8), ^bb56
+    cf.cond_br %138, ^bb1(%c84_i8 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %156 = arith.trunci %152 : i256 to i64
-    %c0_i64_80 = arith.constant 0 : i64
-    %157 = arith.cmpi slt, %156, %c0_i64_80 : i64
-    %c84_i8_81 = arith.constant 84 : i8
-    cf.cond_br %157, ^bb1(%c84_i8_81 : i8), ^bb57
+    %139 = arith.trunci %135 : i256 to i64
+    %c0_i64_63 = arith.constant 0 : i64
+    %140 = arith.cmpi slt, %139, %c0_i64_63 : i64
+    %c84_i8_64 = arith.constant 84 : i8
+    cf.cond_br %140, ^bb1(%c84_i8_64 : i8), ^bb57
   ^bb57:  // pred: ^bb56
-    %c0_i64_82 = arith.constant 0 : i64
-    %158 = arith.cmpi ne, %156, %c0_i64_82 : i64
-    cf.cond_br %158, ^bb194, ^bb58
+    %c0_i64_65 = arith.constant 0 : i64
+    %141 = arith.cmpi ne, %139, %c0_i64_65 : i64
+    cf.cond_br %141, ^bb194, ^bb58
   ^bb58:  // 2 preds: ^bb57, ^bb200
     %c32000_i64 = arith.constant 32000 : i64
-    %159 = llvm.load %arg1 : !llvm.ptr -> i64
-    %160 = arith.cmpi ult, %159, %c32000_i64 : i64
-    scf.if %160 {
+    %142 = llvm.load %arg1 : !llvm.ptr -> i64
+    %143 = arith.cmpi ult, %142, %c32000_i64 : i64
+    scf.if %143 {
     } else {
-      %778 = arith.subi %159, %c32000_i64 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %142, %c32000_i64 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_83 = arith.constant 80 : i8
-    cf.cond_br %160, ^bb1(%c80_i8_83 : i8), ^bb59
+    %c80_i8_66 = arith.constant 80 : i8
+    cf.cond_br %143, ^bb1(%c80_i8_66 : i8), ^bb59
   ^bb59:  // pred: ^bb58
     %c1_i256 = arith.constant 1 : i256
-    %161 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %144, %161 {alignment = 1 : i64} : i256, !llvm.ptr
-    %162 = llvm.load %arg1 : !llvm.ptr -> i64
-    %163 = arith.trunci %148 : i256 to i64
-    %164 = call @dora_fn_create(%arg0, %156, %163, %161, %162) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %165 = llvm.getelementptr %164[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %166 = llvm.load %165 : !llvm.ptr -> i8
-    %c0_i8_84 = arith.constant 0 : i8
-    %167 = arith.cmpi ne, %166, %c0_i8_84 : i8
-    cf.cond_br %167, ^bb1(%166 : i8), ^bb60
+    %144 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %129, %144 {alignment = 1 : i64} : i256, !llvm.ptr
+    %145 = llvm.load %arg1 : !llvm.ptr -> i64
+    %146 = arith.trunci %132 : i256 to i64
+    %147 = call @dora_fn_create(%arg0, %139, %146, %144, %145) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %148 = llvm.getelementptr %147[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %149 = llvm.load %148 : !llvm.ptr -> i8
+    %c0_i8_67 = arith.constant 0 : i8
+    %150 = arith.cmpi ne, %149, %c0_i8_67 : i8
+    cf.cond_br %150, ^bb1(%149 : i8), ^bb60
   ^bb60:  // pred: ^bb59
-    %168 = llvm.getelementptr %164[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %169 = llvm.load %168 : !llvm.ptr -> i64
-    %170 = llvm.load %arg1 : !llvm.ptr -> i64
-    %171 = arith.cmpi ult, %170, %169 : i64
-    scf.if %171 {
+    %151 = llvm.getelementptr %147[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %152 = llvm.load %151 : !llvm.ptr -> i64
+    %153 = llvm.load %arg1 : !llvm.ptr -> i64
+    %154 = arith.cmpi ult, %153, %152 : i64
+    scf.if %154 {
     } else {
-      %778 = arith.subi %170, %169 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %153, %152 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_85 = arith.constant 80 : i8
-    cf.cond_br %171, ^bb1(%c80_i8_85 : i8), ^bb61
+    %c80_i8_68 = arith.constant 80 : i8
+    cf.cond_br %154, ^bb1(%c80_i8_68 : i8), ^bb61
   ^bb61:  // pred: ^bb60
-    %172 = llvm.load %161 : !llvm.ptr -> i256
-    %173 = llvm.load %arg3 : !llvm.ptr -> i64
-    %174 = llvm.getelementptr %arg2[%173] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_86 = arith.constant 1 : i64
-    %175 = arith.addi %173, %c1_i64_86 : i64
-    llvm.store %175, %arg3 : i64, !llvm.ptr
-    llvm.store %172, %174 : i256, !llvm.ptr
+    %155 = llvm.load %144 : !llvm.ptr -> i256
+    %156 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %155, %156 : i256, !llvm.ptr
+    %157 = llvm.getelementptr %156[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %157, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb67
   ^bb62:  // pred: ^bb64
-    %c1024_i64_87 = arith.constant 1024 : i64
-    %176 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_88 = arith.constant -2 : i64
-    %177 = arith.addi %176, %c-2_i64_88 : i64
-    %c3_i64_89 = arith.constant 3 : i64
-    %178 = arith.cmpi ult, %176, %c3_i64_89 : i64
-    %c91_i8_90 = arith.constant 91 : i8
-    cf.cond_br %178, ^bb1(%c91_i8_90 : i8), ^bb54
+    %c1024_i64_69 = arith.constant 1024 : i64
+    %158 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_70 = arith.constant -2 : i64
+    %159 = arith.addi %158, %c-2_i64_70 : i64
+    llvm.store %159, %arg3 : i64, !llvm.ptr
+    %c3_i64_71 = arith.constant 3 : i64
+    %160 = arith.cmpi ult, %158, %c3_i64_71 : i64
+    %c91_i8_72 = arith.constant 91 : i8
+    cf.cond_br %160, ^bb1(%c91_i8_72 : i8), ^bb54
   ^bb63:  // pred: ^bb50
-    %179 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_91 = arith.constant 0 : i64
+    %161 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_73 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %180 = arith.cmpi uge, %179, %c0_i64_91 : i64
-    %c80_i8_92 = arith.constant 80 : i8
-    cf.cond_br %180, ^bb64, ^bb1(%c80_i8_92 : i8)
+    %162 = arith.cmpi uge, %161, %c0_i64_73 : i64
+    %c80_i8_74 = arith.constant 80 : i8
+    cf.cond_br %162, ^bb64, ^bb1(%c80_i8_74 : i8)
   ^bb64:  // pred: ^bb63
-    %181 = arith.subi %179, %c0_i64_91 : i64
-    llvm.store %181, %arg1 : i64, !llvm.ptr
+    %163 = arith.subi %161, %c0_i64_73 : i64
+    llvm.store %163, %arg1 : i64, !llvm.ptr
     cf.br ^bb62
   ^bb65:  // pred: ^bb66
-    %c0_i256_93 = arith.constant 0 : i256
-    %182 = llvm.load %arg3 : !llvm.ptr -> i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_94 = arith.constant 1 : i64
-    %184 = arith.addi %182, %c1_i64_94 : i64
-    llvm.store %184, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_93, %183 : i256, !llvm.ptr
+    %c0_i256_75 = arith.constant 0 : i256
+    %164 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_75, %164 : i256, !llvm.ptr
+    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %165, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb71
   ^bb66:  // pred: ^bb68
-    %c1024_i64_95 = arith.constant 1024 : i64
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %186 = arith.addi %185, %c1_i64_96 : i64
-    %187 = arith.cmpi ult, %c1024_i64_95, %186 : i64
-    %c92_i8_97 = arith.constant 92 : i8
-    cf.cond_br %187, ^bb1(%c92_i8_97 : i8), ^bb65
+    %c1024_i64_76 = arith.constant 1024 : i64
+    %166 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_77 = arith.constant 1 : i64
+    %167 = arith.addi %166, %c1_i64_77 : i64
+    llvm.store %167, %arg3 : i64, !llvm.ptr
+    %168 = arith.cmpi ult, %c1024_i64_76, %167 : i64
+    %c92_i8_78 = arith.constant 92 : i8
+    cf.cond_br %168, ^bb1(%c92_i8_78 : i8), ^bb65
   ^bb67:  // pred: ^bb61
-    %188 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_98 = arith.constant 3 : i64
+    %169 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_79 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %189 = arith.cmpi uge, %188, %c3_i64_98 : i64
-    %c80_i8_99 = arith.constant 80 : i8
-    cf.cond_br %189, ^bb68, ^bb1(%c80_i8_99 : i8)
+    %170 = arith.cmpi uge, %169, %c3_i64_79 : i64
+    %c80_i8_80 = arith.constant 80 : i8
+    cf.cond_br %170, ^bb68, ^bb1(%c80_i8_80 : i8)
   ^bb68:  // pred: ^bb67
-    %190 = arith.subi %188, %c3_i64_98 : i64
-    llvm.store %190, %arg1 : i64, !llvm.ptr
+    %171 = arith.subi %169, %c3_i64_79 : i64
+    llvm.store %171, %arg1 : i64, !llvm.ptr
     cf.br ^bb66
   ^bb69:  // pred: ^bb70
-    %c0_i256_100 = arith.constant 0 : i256
-    %191 = llvm.load %arg3 : !llvm.ptr -> i64
-    %192 = llvm.getelementptr %arg2[%191] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_101 = arith.constant 1 : i64
-    %193 = arith.addi %191, %c1_i64_101 : i64
-    llvm.store %193, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_100, %192 : i256, !llvm.ptr
+    %c0_i256_81 = arith.constant 0 : i256
+    %172 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_81, %172 : i256, !llvm.ptr
+    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %173, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb75
   ^bb70:  // pred: ^bb72
-    %c1024_i64_102 = arith.constant 1024 : i64
-    %194 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_103 = arith.constant 1 : i64
-    %195 = arith.addi %194, %c1_i64_103 : i64
-    %196 = arith.cmpi ult, %c1024_i64_102, %195 : i64
-    %c92_i8_104 = arith.constant 92 : i8
-    cf.cond_br %196, ^bb1(%c92_i8_104 : i8), ^bb69
+    %c1024_i64_82 = arith.constant 1024 : i64
+    %174 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_83 = arith.constant 1 : i64
+    %175 = arith.addi %174, %c1_i64_83 : i64
+    llvm.store %175, %arg3 : i64, !llvm.ptr
+    %176 = arith.cmpi ult, %c1024_i64_82, %175 : i64
+    %c92_i8_84 = arith.constant 92 : i8
+    cf.cond_br %176, ^bb1(%c92_i8_84 : i8), ^bb69
   ^bb71:  // pred: ^bb65
-    %197 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_105 = arith.constant 3 : i64
+    %177 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_85 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %198 = arith.cmpi uge, %197, %c3_i64_105 : i64
-    %c80_i8_106 = arith.constant 80 : i8
-    cf.cond_br %198, ^bb72, ^bb1(%c80_i8_106 : i8)
+    %178 = arith.cmpi uge, %177, %c3_i64_85 : i64
+    %c80_i8_86 = arith.constant 80 : i8
+    cf.cond_br %178, ^bb72, ^bb1(%c80_i8_86 : i8)
   ^bb72:  // pred: ^bb71
-    %199 = arith.subi %197, %c3_i64_105 : i64
-    llvm.store %199, %arg1 : i64, !llvm.ptr
+    %179 = arith.subi %177, %c3_i64_85 : i64
+    llvm.store %179, %arg1 : i64, !llvm.ptr
     cf.br ^bb70
   ^bb73:  // pred: ^bb74
-    %c0_i256_107 = arith.constant 0 : i256
-    %200 = llvm.load %arg3 : !llvm.ptr -> i64
-    %201 = llvm.getelementptr %arg2[%200] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_108 = arith.constant 1 : i64
-    %202 = arith.addi %200, %c1_i64_108 : i64
-    llvm.store %202, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_107, %201 : i256, !llvm.ptr
+    %c0_i256_87 = arith.constant 0 : i256
+    %180 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_87, %180 : i256, !llvm.ptr
+    %181 = llvm.getelementptr %180[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %181, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb79
   ^bb74:  // pred: ^bb76
-    %c1024_i64_109 = arith.constant 1024 : i64
-    %203 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_110 = arith.constant 1 : i64
-    %204 = arith.addi %203, %c1_i64_110 : i64
-    %205 = arith.cmpi ult, %c1024_i64_109, %204 : i64
-    %c92_i8_111 = arith.constant 92 : i8
-    cf.cond_br %205, ^bb1(%c92_i8_111 : i8), ^bb73
+    %c1024_i64_88 = arith.constant 1024 : i64
+    %182 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_89 = arith.constant 1 : i64
+    %183 = arith.addi %182, %c1_i64_89 : i64
+    llvm.store %183, %arg3 : i64, !llvm.ptr
+    %184 = arith.cmpi ult, %c1024_i64_88, %183 : i64
+    %c92_i8_90 = arith.constant 92 : i8
+    cf.cond_br %184, ^bb1(%c92_i8_90 : i8), ^bb73
   ^bb75:  // pred: ^bb69
-    %206 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_112 = arith.constant 3 : i64
+    %185 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_91 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %207 = arith.cmpi uge, %206, %c3_i64_112 : i64
-    %c80_i8_113 = arith.constant 80 : i8
-    cf.cond_br %207, ^bb76, ^bb1(%c80_i8_113 : i8)
+    %186 = arith.cmpi uge, %185, %c3_i64_91 : i64
+    %c80_i8_92 = arith.constant 80 : i8
+    cf.cond_br %186, ^bb76, ^bb1(%c80_i8_92 : i8)
   ^bb76:  // pred: ^bb75
-    %208 = arith.subi %206, %c3_i64_112 : i64
-    llvm.store %208, %arg1 : i64, !llvm.ptr
+    %187 = arith.subi %185, %c3_i64_91 : i64
+    llvm.store %187, %arg1 : i64, !llvm.ptr
     cf.br ^bb74
   ^bb77:  // pred: ^bb78
-    %c0_i256_114 = arith.constant 0 : i256
-    %209 = llvm.load %arg3 : !llvm.ptr -> i64
-    %210 = llvm.getelementptr %arg2[%209] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_115 = arith.constant 1 : i64
-    %211 = arith.addi %209, %c1_i64_115 : i64
-    llvm.store %211, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_114, %210 : i256, !llvm.ptr
+    %c0_i256_93 = arith.constant 0 : i256
+    %188 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_93, %188 : i256, !llvm.ptr
+    %189 = llvm.getelementptr %188[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %189, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb83
   ^bb78:  // pred: ^bb80
-    %c1024_i64_116 = arith.constant 1024 : i64
-    %212 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_117 = arith.constant 1 : i64
-    %213 = arith.addi %212, %c1_i64_117 : i64
-    %214 = arith.cmpi ult, %c1024_i64_116, %213 : i64
-    %c92_i8_118 = arith.constant 92 : i8
-    cf.cond_br %214, ^bb1(%c92_i8_118 : i8), ^bb77
+    %c1024_i64_94 = arith.constant 1024 : i64
+    %190 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_95 = arith.constant 1 : i64
+    %191 = arith.addi %190, %c1_i64_95 : i64
+    llvm.store %191, %arg3 : i64, !llvm.ptr
+    %192 = arith.cmpi ult, %c1024_i64_94, %191 : i64
+    %c92_i8_96 = arith.constant 92 : i8
+    cf.cond_br %192, ^bb1(%c92_i8_96 : i8), ^bb77
   ^bb79:  // pred: ^bb73
-    %215 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_119 = arith.constant 3 : i64
+    %193 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_97 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %216 = arith.cmpi uge, %215, %c3_i64_119 : i64
-    %c80_i8_120 = arith.constant 80 : i8
-    cf.cond_br %216, ^bb80, ^bb1(%c80_i8_120 : i8)
+    %194 = arith.cmpi uge, %193, %c3_i64_97 : i64
+    %c80_i8_98 = arith.constant 80 : i8
+    cf.cond_br %194, ^bb80, ^bb1(%c80_i8_98 : i8)
   ^bb80:  // pred: ^bb79
-    %217 = arith.subi %215, %c3_i64_119 : i64
-    llvm.store %217, %arg1 : i64, !llvm.ptr
+    %195 = arith.subi %193, %c3_i64_97 : i64
+    llvm.store %195, %arg1 : i64, !llvm.ptr
     cf.br ^bb78
   ^bb81:  // pred: ^bb82
-    %218 = llvm.load %arg3 : !llvm.ptr -> i64
-    %219 = llvm.getelementptr %arg2[%218] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %220 = llvm.getelementptr %219[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %221 = llvm.load %220 : !llvm.ptr -> i256
-    %222 = llvm.load %arg3 : !llvm.ptr -> i64
-    %223 = llvm.getelementptr %arg2[%222] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_121 = arith.constant 1 : i64
-    %224 = arith.addi %222, %c1_i64_121 : i64
-    llvm.store %224, %arg3 : i64, !llvm.ptr
-    llvm.store %221, %223 : i256, !llvm.ptr
+    %196 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %197 = llvm.getelementptr %196[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %198 = llvm.load %197 : !llvm.ptr -> i256
+    %199 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %198, %199 : i256, !llvm.ptr
+    %200 = llvm.getelementptr %199[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %200, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb87
   ^bb82:  // pred: ^bb84
-    %c1024_i64_122 = arith.constant 1024 : i64
-    %225 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_123 = arith.constant 1 : i64
-    %226 = arith.addi %225, %c1_i64_123 : i64
+    %c1024_i64_99 = arith.constant 1024 : i64
+    %201 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_100 = arith.constant 1 : i64
+    %202 = arith.addi %201, %c1_i64_100 : i64
+    llvm.store %202, %arg3 : i64, !llvm.ptr
     %c5_i64 = arith.constant 5 : i64
-    %227 = arith.cmpi ult, %225, %c5_i64 : i64
-    %228 = arith.cmpi ult, %c1024_i64_122, %226 : i64
-    %229 = arith.xori %227, %228 : i1
-    %c92_i8_124 = arith.constant 92 : i8
-    cf.cond_br %229, ^bb1(%c92_i8_124 : i8), ^bb81
+    %203 = arith.cmpi ult, %201, %c5_i64 : i64
+    %204 = arith.cmpi ult, %c1024_i64_99, %202 : i64
+    %205 = arith.xori %203, %204 : i1
+    %c92_i8_101 = arith.constant 92 : i8
+    cf.cond_br %205, ^bb1(%c92_i8_101 : i8), ^bb81
   ^bb83:  // pred: ^bb77
-    %230 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_125 = arith.constant 3 : i64
+    %206 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_102 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %231 = arith.cmpi uge, %230, %c3_i64_125 : i64
-    %c80_i8_126 = arith.constant 80 : i8
-    cf.cond_br %231, ^bb84, ^bb1(%c80_i8_126 : i8)
+    %207 = arith.cmpi uge, %206, %c3_i64_102 : i64
+    %c80_i8_103 = arith.constant 80 : i8
+    cf.cond_br %207, ^bb84, ^bb1(%c80_i8_103 : i8)
   ^bb84:  // pred: ^bb83
-    %232 = arith.subi %230, %c3_i64_125 : i64
-    llvm.store %232, %arg1 : i64, !llvm.ptr
+    %208 = arith.subi %206, %c3_i64_102 : i64
+    llvm.store %208, %arg1 : i64, !llvm.ptr
     cf.br ^bb82
   ^bb85:  // pred: ^bb86
     %c4294967295_i256 = arith.constant 4294967295 : i256
-    %233 = llvm.load %arg3 : !llvm.ptr -> i64
-    %234 = llvm.getelementptr %arg2[%233] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_127 = arith.constant 1 : i64
-    %235 = arith.addi %233, %c1_i64_127 : i64
-    llvm.store %235, %arg3 : i64, !llvm.ptr
-    llvm.store %c4294967295_i256, %234 : i256, !llvm.ptr
+    %209 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4294967295_i256, %209 : i256, !llvm.ptr
+    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %210, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb99
   ^bb86:  // pred: ^bb88
-    %c1024_i64_128 = arith.constant 1024 : i64
-    %236 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_129 = arith.constant 1 : i64
-    %237 = arith.addi %236, %c1_i64_129 : i64
-    %238 = arith.cmpi ult, %c1024_i64_128, %237 : i64
-    %c92_i8_130 = arith.constant 92 : i8
-    cf.cond_br %238, ^bb1(%c92_i8_130 : i8), ^bb85
+    %c1024_i64_104 = arith.constant 1024 : i64
+    %211 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_105 = arith.constant 1 : i64
+    %212 = arith.addi %211, %c1_i64_105 : i64
+    llvm.store %212, %arg3 : i64, !llvm.ptr
+    %213 = arith.cmpi ult, %c1024_i64_104, %212 : i64
+    %c92_i8_106 = arith.constant 92 : i8
+    cf.cond_br %213, ^bb1(%c92_i8_106 : i8), ^bb85
   ^bb87:  // pred: ^bb81
-    %239 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_131 = arith.constant 3 : i64
+    %214 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_107 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %240 = arith.cmpi uge, %239, %c3_i64_131 : i64
-    %c80_i8_132 = arith.constant 80 : i8
-    cf.cond_br %240, ^bb88, ^bb1(%c80_i8_132 : i8)
+    %215 = arith.cmpi uge, %214, %c3_i64_107 : i64
+    %c80_i8_108 = arith.constant 80 : i8
+    cf.cond_br %215, ^bb88, ^bb1(%c80_i8_108 : i8)
   ^bb88:  // pred: ^bb87
-    %241 = arith.subi %239, %c3_i64_131 : i64
-    llvm.store %241, %arg1 : i64, !llvm.ptr
+    %216 = arith.subi %214, %c3_i64_107 : i64
+    llvm.store %216, %arg1 : i64, !llvm.ptr
     cf.br ^bb86
   ^bb89:  // pred: ^bb98
-    %242 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_133 = arith.constant 1 : i64
-    %243 = arith.subi %242, %c1_i64_133 : i64
-    %244 = llvm.getelementptr %arg2[%243] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %243, %arg3 : i64, !llvm.ptr
-    %245 = llvm.load %244 : !llvm.ptr -> i256
-    %246 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_134 = arith.constant 1 : i64
-    %247 = arith.subi %246, %c1_i64_134 : i64
-    %248 = llvm.getelementptr %arg2[%247] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %247, %arg3 : i64, !llvm.ptr
-    %249 = llvm.load %248 : !llvm.ptr -> i256
-    %250 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_135 = arith.constant 1 : i64
-    %251 = arith.subi %250, %c1_i64_135 : i64
-    %252 = llvm.getelementptr %arg2[%251] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %251, %arg3 : i64, !llvm.ptr
-    %253 = llvm.load %252 : !llvm.ptr -> i256
-    %254 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_136 = arith.constant 1 : i64
-    %255 = arith.subi %254, %c1_i64_136 : i64
-    %256 = llvm.getelementptr %arg2[%255] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %255, %arg3 : i64, !llvm.ptr
-    %257 = llvm.load %256 : !llvm.ptr -> i256
-    %258 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_137 = arith.constant 1 : i64
-    %259 = arith.subi %258, %c1_i64_137 : i64
-    %260 = llvm.getelementptr %arg2[%259] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %259, %arg3 : i64, !llvm.ptr
-    %261 = llvm.load %260 : !llvm.ptr -> i256
-    %262 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_138 = arith.constant 1 : i64
-    %263 = arith.subi %262, %c1_i64_138 : i64
-    %264 = llvm.getelementptr %arg2[%263] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %263, %arg3 : i64, !llvm.ptr
-    %265 = llvm.load %264 : !llvm.ptr -> i256
-    %c0_i256_139 = arith.constant 0 : i256
-    %c18446744073709551615_i256_140 = arith.constant 18446744073709551615 : i256
-    %266 = arith.cmpi sgt, %257, %c18446744073709551615_i256_140 : i256
-    %c84_i8_141 = arith.constant 84 : i8
-    cf.cond_br %266, ^bb1(%c84_i8_141 : i8), ^bb90
+    %217 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %218 = llvm.getelementptr %217[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %219 = llvm.load %218 : !llvm.ptr -> i256
+    llvm.store %218, %0 : !llvm.ptr, !llvm.ptr
+    %220 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %221 = llvm.getelementptr %220[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %222 = llvm.load %221 : !llvm.ptr -> i256
+    llvm.store %221, %0 : !llvm.ptr, !llvm.ptr
+    %223 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %224 = llvm.getelementptr %223[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %225 = llvm.load %224 : !llvm.ptr -> i256
+    llvm.store %224, %0 : !llvm.ptr, !llvm.ptr
+    %226 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %227 = llvm.getelementptr %226[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %228 = llvm.load %227 : !llvm.ptr -> i256
+    llvm.store %227, %0 : !llvm.ptr, !llvm.ptr
+    %229 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    llvm.store %230, %0 : !llvm.ptr, !llvm.ptr
+    %232 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %233 = llvm.getelementptr %232[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %234 = llvm.load %233 : !llvm.ptr -> i256
+    llvm.store %233, %0 : !llvm.ptr, !llvm.ptr
+    %c0_i256_109 = arith.constant 0 : i256
+    %c18446744073709551615_i256_110 = arith.constant 18446744073709551615 : i256
+    %235 = arith.cmpi sgt, %228, %c18446744073709551615_i256_110 : i256
+    %c84_i8_111 = arith.constant 84 : i8
+    cf.cond_br %235, ^bb1(%c84_i8_111 : i8), ^bb90
   ^bb90:  // pred: ^bb89
-    %267 = arith.trunci %257 : i256 to i64
-    %c0_i64_142 = arith.constant 0 : i64
-    %268 = arith.cmpi slt, %267, %c0_i64_142 : i64
-    %c84_i8_143 = arith.constant 84 : i8
-    cf.cond_br %268, ^bb1(%c84_i8_143 : i8), ^bb91
+    %236 = arith.trunci %228 : i256 to i64
+    %c0_i64_112 = arith.constant 0 : i64
+    %237 = arith.cmpi slt, %236, %c0_i64_112 : i64
+    %c84_i8_113 = arith.constant 84 : i8
+    cf.cond_br %237, ^bb1(%c84_i8_113 : i8), ^bb91
   ^bb91:  // pred: ^bb90
-    %c0_i64_144 = arith.constant 0 : i64
-    %269 = arith.cmpi ne, %267, %c0_i64_144 : i64
-    cf.cond_br %269, ^bb204, ^bb92
+    %c0_i64_114 = arith.constant 0 : i64
+    %238 = arith.cmpi ne, %236, %c0_i64_114 : i64
+    cf.cond_br %238, ^bb204, ^bb92
   ^bb92:  // 2 preds: ^bb91, ^bb208
-    %c18446744073709551615_i256_145 = arith.constant 18446744073709551615 : i256
-    %270 = arith.cmpi sgt, %265, %c18446744073709551615_i256_145 : i256
-    %c84_i8_146 = arith.constant 84 : i8
-    cf.cond_br %270, ^bb1(%c84_i8_146 : i8), ^bb93
+    %c18446744073709551615_i256_115 = arith.constant 18446744073709551615 : i256
+    %239 = arith.cmpi sgt, %234, %c18446744073709551615_i256_115 : i256
+    %c84_i8_116 = arith.constant 84 : i8
+    cf.cond_br %239, ^bb1(%c84_i8_116 : i8), ^bb93
   ^bb93:  // pred: ^bb92
-    %271 = arith.trunci %265 : i256 to i64
-    %c0_i64_147 = arith.constant 0 : i64
-    %272 = arith.cmpi slt, %271, %c0_i64_147 : i64
-    %c84_i8_148 = arith.constant 84 : i8
-    cf.cond_br %272, ^bb1(%c84_i8_148 : i8), ^bb94
+    %240 = arith.trunci %234 : i256 to i64
+    %c0_i64_117 = arith.constant 0 : i64
+    %241 = arith.cmpi slt, %240, %c0_i64_117 : i64
+    %c84_i8_118 = arith.constant 84 : i8
+    cf.cond_br %241, ^bb1(%c84_i8_118 : i8), ^bb94
   ^bb94:  // pred: ^bb93
-    %c0_i64_149 = arith.constant 0 : i64
-    %273 = arith.cmpi ne, %271, %c0_i64_149 : i64
-    cf.cond_br %273, ^bb212, ^bb95
+    %c0_i64_119 = arith.constant 0 : i64
+    %242 = arith.cmpi ne, %240, %c0_i64_119 : i64
+    cf.cond_br %242, ^bb212, ^bb95
   ^bb95:  // 2 preds: ^bb94, ^bb216
-    %274 = arith.trunci %253 : i256 to i64
-    %275 = arith.trunci %261 : i256 to i64
-    %276 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_150 = arith.constant 1 : i256
-    %277 = llvm.alloca %c1_i256_150 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_139, %277 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_151 = arith.constant 1 : i256
-    %278 = llvm.alloca %c1_i256_151 x i256 : (i256) -> !llvm.ptr
-    llvm.store %245, %278 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_152 = arith.constant 1 : i256
-    %279 = llvm.alloca %c1_i256_152 x i256 : (i256) -> !llvm.ptr
-    llvm.store %249, %279 {alignment = 1 : i64} : i256, !llvm.ptr
+    %243 = arith.trunci %225 : i256 to i64
+    %244 = arith.trunci %231 : i256 to i64
+    %245 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_120 = arith.constant 1 : i256
+    %246 = llvm.alloca %c1_i256_120 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_109, %246 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_121 = arith.constant 1 : i256
+    %247 = llvm.alloca %c1_i256_121 x i256 : (i256) -> !llvm.ptr
+    llvm.store %219, %247 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_122 = arith.constant 1 : i256
+    %248 = llvm.alloca %c1_i256_122 x i256 : (i256) -> !llvm.ptr
+    llvm.store %222, %248 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i8 = arith.constant 1 : i8
-    %280 = call @dora_fn_call(%arg0, %278, %279, %277, %274, %267, %275, %271, %276, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %281 = llvm.getelementptr %280[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %282 = llvm.load %281 : !llvm.ptr -> i8
-    %283 = llvm.getelementptr %280[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %284 = llvm.load %283 : !llvm.ptr -> i8
-    %c0_i8_153 = arith.constant 0 : i8
-    %285 = arith.cmpi ne, %284, %c0_i8_153 : i8
-    cf.cond_br %285, ^bb1(%284 : i8), ^bb96
+    %249 = call @dora_fn_call(%arg0, %247, %248, %246, %243, %236, %244, %240, %245, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %250 = llvm.getelementptr %249[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %251 = llvm.load %250 : !llvm.ptr -> i8
+    %252 = llvm.getelementptr %249[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %253 = llvm.load %252 : !llvm.ptr -> i8
+    %c0_i8_123 = arith.constant 0 : i8
+    %254 = arith.cmpi ne, %253, %c0_i8_123 : i8
+    cf.cond_br %254, ^bb1(%253 : i8), ^bb96
   ^bb96:  // pred: ^bb95
-    %286 = llvm.getelementptr %280[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %287 = llvm.load %286 : !llvm.ptr -> i64
-    %288 = llvm.load %arg1 : !llvm.ptr -> i64
-    %289 = arith.cmpi ult, %288, %287 : i64
-    scf.if %289 {
+    %255 = llvm.getelementptr %249[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %256 = llvm.load %255 : !llvm.ptr -> i64
+    %257 = llvm.load %arg1 : !llvm.ptr -> i64
+    %258 = arith.cmpi ult, %257, %256 : i64
+    scf.if %258 {
     } else {
-      %778 = arith.subi %288, %287 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %257, %256 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_154 = arith.constant 80 : i8
-    cf.cond_br %289, ^bb1(%c80_i8_154 : i8), ^bb97
+    %c80_i8_124 = arith.constant 80 : i8
+    cf.cond_br %258, ^bb1(%c80_i8_124 : i8), ^bb97
   ^bb97:  // pred: ^bb96
-    %290 = arith.extui %282 : i8 to i256
-    %291 = llvm.load %arg3 : !llvm.ptr -> i64
-    %292 = llvm.getelementptr %arg2[%291] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_155 = arith.constant 1 : i64
-    %293 = arith.addi %291, %c1_i64_155 : i64
-    llvm.store %293, %arg3 : i64, !llvm.ptr
-    llvm.store %290, %292 : i256, !llvm.ptr
+    %259 = arith.extui %251 : i8 to i256
+    %260 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %259, %260 : i256, !llvm.ptr
+    %261 = llvm.getelementptr %260[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %261, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb103
   ^bb98:  // pred: ^bb100
-    %c1024_i64_156 = arith.constant 1024 : i64
-    %294 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_125 = arith.constant 1024 : i64
+    %262 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %295 = arith.addi %294, %c-5_i64 : i64
+    %263 = arith.addi %262, %c-5_i64 : i64
+    llvm.store %263, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %296 = arith.cmpi ult, %294, %c6_i64 : i64
-    %c91_i8_157 = arith.constant 91 : i8
-    cf.cond_br %296, ^bb1(%c91_i8_157 : i8), ^bb89
+    %264 = arith.cmpi ult, %262, %c6_i64 : i64
+    %c91_i8_126 = arith.constant 91 : i8
+    cf.cond_br %264, ^bb1(%c91_i8_126 : i8), ^bb89
   ^bb99:  // pred: ^bb85
-    %297 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_158 = arith.constant 0 : i64
+    %265 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_127 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %298 = arith.cmpi uge, %297, %c0_i64_158 : i64
-    %c80_i8_159 = arith.constant 80 : i8
-    cf.cond_br %298, ^bb100, ^bb1(%c80_i8_159 : i8)
+    %266 = arith.cmpi uge, %265, %c0_i64_127 : i64
+    %c80_i8_128 = arith.constant 80 : i8
+    cf.cond_br %266, ^bb100, ^bb1(%c80_i8_128 : i8)
   ^bb100:  // pred: ^bb99
-    %299 = arith.subi %297, %c0_i64_158 : i64
-    llvm.store %299, %arg1 : i64, !llvm.ptr
+    %267 = arith.subi %265, %c0_i64_127 : i64
+    llvm.store %267, %arg1 : i64, !llvm.ptr
     cf.br ^bb98
   ^bb101:  // pred: ^bb102
-    %300 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_160 = arith.constant 1 : i64
-    %301 = arith.subi %300, %c1_i64_160 : i64
-    %302 = llvm.getelementptr %arg2[%301] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %301, %arg3 : i64, !llvm.ptr
-    %303 = llvm.load %302 : !llvm.ptr -> i256
+    %268 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %269 = llvm.getelementptr %268[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %270 = llvm.load %269 : !llvm.ptr -> i256
+    llvm.store %269, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb107
   ^bb102:  // pred: ^bb104
-    %c1024_i64_161 = arith.constant 1024 : i64
-    %304 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_129 = arith.constant 1024 : i64
+    %271 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %305 = arith.addi %304, %c-1_i64 : i64
-    %c1_i64_162 = arith.constant 1 : i64
-    %306 = arith.cmpi ult, %304, %c1_i64_162 : i64
-    %c91_i8_163 = arith.constant 91 : i8
-    cf.cond_br %306, ^bb1(%c91_i8_163 : i8), ^bb101
+    %272 = arith.addi %271, %c-1_i64 : i64
+    llvm.store %272, %arg3 : i64, !llvm.ptr
+    %c1_i64_130 = arith.constant 1 : i64
+    %273 = arith.cmpi ult, %271, %c1_i64_130 : i64
+    %c91_i8_131 = arith.constant 91 : i8
+    cf.cond_br %273, ^bb1(%c91_i8_131 : i8), ^bb101
   ^bb103:  // pred: ^bb97
-    %307 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_164 = arith.constant 2 : i64
+    %274 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_132 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %308 = arith.cmpi uge, %307, %c2_i64_164 : i64
-    %c80_i8_165 = arith.constant 80 : i8
-    cf.cond_br %308, ^bb104, ^bb1(%c80_i8_165 : i8)
+    %275 = arith.cmpi uge, %274, %c2_i64_132 : i64
+    %c80_i8_133 = arith.constant 80 : i8
+    cf.cond_br %275, ^bb104, ^bb1(%c80_i8_133 : i8)
   ^bb104:  // pred: ^bb103
-    %309 = arith.subi %307, %c2_i64_164 : i64
-    llvm.store %309, %arg1 : i64, !llvm.ptr
+    %276 = arith.subi %274, %c2_i64_132 : i64
+    llvm.store %276, %arg1 : i64, !llvm.ptr
     cf.br ^bb102
   ^bb105:  // pred: ^bb106
-    %310 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_166 = arith.constant 1 : i64
-    %311 = arith.subi %310, %c1_i64_166 : i64
-    %312 = llvm.getelementptr %arg2[%311] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %311, %arg3 : i64, !llvm.ptr
-    %313 = llvm.load %312 : !llvm.ptr -> i256
+    %277 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %278 = llvm.getelementptr %277[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %279 = llvm.load %278 : !llvm.ptr -> i256
+    llvm.store %278, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb111
   ^bb106:  // pred: ^bb108
-    %c1024_i64_167 = arith.constant 1024 : i64
-    %314 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_168 = arith.constant -1 : i64
-    %315 = arith.addi %314, %c-1_i64_168 : i64
-    %c1_i64_169 = arith.constant 1 : i64
-    %316 = arith.cmpi ult, %314, %c1_i64_169 : i64
-    %c91_i8_170 = arith.constant 91 : i8
-    cf.cond_br %316, ^bb1(%c91_i8_170 : i8), ^bb105
+    %c1024_i64_134 = arith.constant 1024 : i64
+    %280 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_135 = arith.constant -1 : i64
+    %281 = arith.addi %280, %c-1_i64_135 : i64
+    llvm.store %281, %arg3 : i64, !llvm.ptr
+    %c1_i64_136 = arith.constant 1 : i64
+    %282 = arith.cmpi ult, %280, %c1_i64_136 : i64
+    %c91_i8_137 = arith.constant 91 : i8
+    cf.cond_br %282, ^bb1(%c91_i8_137 : i8), ^bb105
   ^bb107:  // pred: ^bb101
-    %317 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_171 = arith.constant 2 : i64
+    %283 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_138 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %318 = arith.cmpi uge, %317, %c2_i64_171 : i64
-    %c80_i8_172 = arith.constant 80 : i8
-    cf.cond_br %318, ^bb108, ^bb1(%c80_i8_172 : i8)
+    %284 = arith.cmpi uge, %283, %c2_i64_138 : i64
+    %c80_i8_139 = arith.constant 80 : i8
+    cf.cond_br %284, ^bb108, ^bb1(%c80_i8_139 : i8)
   ^bb108:  // pred: ^bb107
-    %319 = arith.subi %317, %c2_i64_171 : i64
-    llvm.store %319, %arg1 : i64, !llvm.ptr
+    %285 = arith.subi %283, %c2_i64_138 : i64
+    llvm.store %285, %arg1 : i64, !llvm.ptr
     cf.br ^bb106
   ^bb109:  // pred: ^bb110
-    %c0_i256_173 = arith.constant 0 : i256
-    %320 = llvm.load %arg3 : !llvm.ptr -> i64
-    %321 = llvm.getelementptr %arg2[%320] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_174 = arith.constant 1 : i64
-    %322 = arith.addi %320, %c1_i64_174 : i64
-    llvm.store %322, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_173, %321 : i256, !llvm.ptr
+    %c0_i256_140 = arith.constant 0 : i256
+    %286 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_140, %286 : i256, !llvm.ptr
+    %287 = llvm.getelementptr %286[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %287, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb115
   ^bb110:  // pred: ^bb112
-    %c1024_i64_175 = arith.constant 1024 : i64
-    %323 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_176 = arith.constant 1 : i64
-    %324 = arith.addi %323, %c1_i64_176 : i64
-    %325 = arith.cmpi ult, %c1024_i64_175, %324 : i64
-    %c92_i8_177 = arith.constant 92 : i8
-    cf.cond_br %325, ^bb1(%c92_i8_177 : i8), ^bb109
+    %c1024_i64_141 = arith.constant 1024 : i64
+    %288 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_142 = arith.constant 1 : i64
+    %289 = arith.addi %288, %c1_i64_142 : i64
+    llvm.store %289, %arg3 : i64, !llvm.ptr
+    %290 = arith.cmpi ult, %c1024_i64_141, %289 : i64
+    %c92_i8_143 = arith.constant 92 : i8
+    cf.cond_br %290, ^bb1(%c92_i8_143 : i8), ^bb109
   ^bb111:  // pred: ^bb105
-    %326 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_178 = arith.constant 3 : i64
+    %291 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_144 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %327 = arith.cmpi uge, %326, %c3_i64_178 : i64
-    %c80_i8_179 = arith.constant 80 : i8
-    cf.cond_br %327, ^bb112, ^bb1(%c80_i8_179 : i8)
+    %292 = arith.cmpi uge, %291, %c3_i64_144 : i64
+    %c80_i8_145 = arith.constant 80 : i8
+    cf.cond_br %292, ^bb112, ^bb1(%c80_i8_145 : i8)
   ^bb112:  // pred: ^bb111
-    %328 = arith.subi %326, %c3_i64_178 : i64
-    llvm.store %328, %arg1 : i64, !llvm.ptr
+    %293 = arith.subi %291, %c3_i64_144 : i64
+    llvm.store %293, %arg1 : i64, !llvm.ptr
     cf.br ^bb110
   ^bb113:  // pred: ^bb114
-    %c0_i256_180 = arith.constant 0 : i256
-    %329 = llvm.load %arg3 : !llvm.ptr -> i64
-    %330 = llvm.getelementptr %arg2[%329] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_181 = arith.constant 1 : i64
-    %331 = arith.addi %329, %c1_i64_181 : i64
-    llvm.store %331, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_180, %330 : i256, !llvm.ptr
+    %c0_i256_146 = arith.constant 0 : i256
+    %294 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_146, %294 : i256, !llvm.ptr
+    %295 = llvm.getelementptr %294[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %295, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb120
   ^bb114:  // pred: ^bb116
-    %c1024_i64_182 = arith.constant 1024 : i64
-    %332 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_183 = arith.constant 1 : i64
-    %333 = arith.addi %332, %c1_i64_183 : i64
-    %334 = arith.cmpi ult, %c1024_i64_182, %333 : i64
-    %c92_i8_184 = arith.constant 92 : i8
-    cf.cond_br %334, ^bb1(%c92_i8_184 : i8), ^bb113
+    %c1024_i64_147 = arith.constant 1024 : i64
+    %296 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_148 = arith.constant 1 : i64
+    %297 = arith.addi %296, %c1_i64_148 : i64
+    llvm.store %297, %arg3 : i64, !llvm.ptr
+    %298 = arith.cmpi ult, %c1024_i64_147, %297 : i64
+    %c92_i8_149 = arith.constant 92 : i8
+    cf.cond_br %298, ^bb1(%c92_i8_149 : i8), ^bb113
   ^bb115:  // pred: ^bb109
-    %335 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_185 = arith.constant 3 : i64
+    %299 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_150 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %336 = arith.cmpi uge, %335, %c3_i64_185 : i64
-    %c80_i8_186 = arith.constant 80 : i8
-    cf.cond_br %336, ^bb116, ^bb1(%c80_i8_186 : i8)
+    %300 = arith.cmpi uge, %299, %c3_i64_150 : i64
+    %c80_i8_151 = arith.constant 80 : i8
+    cf.cond_br %300, ^bb116, ^bb1(%c80_i8_151 : i8)
   ^bb116:  // pred: ^bb115
-    %337 = arith.subi %335, %c3_i64_185 : i64
-    llvm.store %337, %arg1 : i64, !llvm.ptr
+    %301 = arith.subi %299, %c3_i64_150 : i64
+    llvm.store %301, %arg1 : i64, !llvm.ptr
     cf.br ^bb114
   ^bb117:  // pred: ^bb119
-    %338 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_187 = arith.constant 1 : i64
-    %339 = arith.subi %338, %c1_i64_187 : i64
-    %340 = llvm.getelementptr %arg2[%339] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %339, %arg3 : i64, !llvm.ptr
-    %341 = llvm.load %340 : !llvm.ptr -> i256
-    %342 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_188 = arith.constant 1 : i64
-    %343 = arith.subi %342, %c1_i64_188 : i64
-    %344 = llvm.getelementptr %arg2[%343] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %343, %arg3 : i64, !llvm.ptr
-    %345 = llvm.load %344 : !llvm.ptr -> i256
-    %c32_i64_189 = arith.constant 32 : i64
-    %c0_i64_190 = arith.constant 0 : i64
-    %346 = arith.cmpi ne, %c32_i64_189, %c0_i64_190 : i64
-    cf.cond_br %346, ^bb220, ^bb118
+    %302 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %303 = llvm.getelementptr %302[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %304 = llvm.load %303 : !llvm.ptr -> i256
+    llvm.store %303, %0 : !llvm.ptr, !llvm.ptr
+    %305 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %306 = llvm.getelementptr %305[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %307 = llvm.load %306 : !llvm.ptr -> i256
+    llvm.store %306, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_152 = arith.constant 32 : i64
+    %c0_i64_153 = arith.constant 0 : i64
+    %308 = arith.cmpi ne, %c32_i64_152, %c0_i64_153 : i64
+    cf.cond_br %308, ^bb220, ^bb118
   ^bb118:  // 2 preds: ^bb117, ^bb224
-    %347 = arith.trunci %341 : i256 to i64
-    %348 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %349 = llvm.getelementptr %348[%347] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %350 = llvm.intr.bswap(%345)  : (i256) -> i256
-    llvm.store %350, %349 {alignment = 1 : i64} : i256, !llvm.ptr
+    %309 = arith.trunci %304 : i256 to i64
+    %310 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %311 = llvm.getelementptr %310[%309] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %312 = llvm.intr.bswap(%307)  : (i256) -> i256
+    llvm.store %312, %311 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb124
   ^bb119:  // pred: ^bb121
-    %c1024_i64_191 = arith.constant 1024 : i64
-    %351 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_192 = arith.constant -2 : i64
-    %352 = arith.addi %351, %c-2_i64_192 : i64
-    %c2_i64_193 = arith.constant 2 : i64
-    %353 = arith.cmpi ult, %351, %c2_i64_193 : i64
-    %c91_i8_194 = arith.constant 91 : i8
-    cf.cond_br %353, ^bb1(%c91_i8_194 : i8), ^bb117
+    %c1024_i64_154 = arith.constant 1024 : i64
+    %313 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_155 = arith.constant -2 : i64
+    %314 = arith.addi %313, %c-2_i64_155 : i64
+    llvm.store %314, %arg3 : i64, !llvm.ptr
+    %c2_i64_156 = arith.constant 2 : i64
+    %315 = arith.cmpi ult, %313, %c2_i64_156 : i64
+    %c91_i8_157 = arith.constant 91 : i8
+    cf.cond_br %315, ^bb1(%c91_i8_157 : i8), ^bb117
   ^bb120:  // pred: ^bb113
-    %354 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_195 = arith.constant 3 : i64
+    %316 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_158 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %355 = arith.cmpi uge, %354, %c3_i64_195 : i64
-    %c80_i8_196 = arith.constant 80 : i8
-    cf.cond_br %355, ^bb121, ^bb1(%c80_i8_196 : i8)
+    %317 = arith.cmpi uge, %316, %c3_i64_158 : i64
+    %c80_i8_159 = arith.constant 80 : i8
+    cf.cond_br %317, ^bb121, ^bb1(%c80_i8_159 : i8)
   ^bb121:  // pred: ^bb120
-    %356 = arith.subi %354, %c3_i64_195 : i64
-    llvm.store %356, %arg1 : i64, !llvm.ptr
+    %318 = arith.subi %316, %c3_i64_158 : i64
+    llvm.store %318, %arg1 : i64, !llvm.ptr
     cf.br ^bb119
   ^bb122:  // pred: ^bb123
-    %c0_i256_197 = arith.constant 0 : i256
-    %357 = llvm.load %arg3 : !llvm.ptr -> i64
-    %358 = llvm.getelementptr %arg2[%357] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_198 = arith.constant 1 : i64
-    %359 = arith.addi %357, %c1_i64_198 : i64
-    llvm.store %359, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_197, %358 : i256, !llvm.ptr
+    %c0_i256_160 = arith.constant 0 : i256
+    %319 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_160, %319 : i256, !llvm.ptr
+    %320 = llvm.getelementptr %319[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %320, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb128
   ^bb123:  // pred: ^bb125
-    %c1024_i64_199 = arith.constant 1024 : i64
-    %360 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_200 = arith.constant 1 : i64
-    %361 = arith.addi %360, %c1_i64_200 : i64
-    %362 = arith.cmpi ult, %c1024_i64_199, %361 : i64
-    %c92_i8_201 = arith.constant 92 : i8
-    cf.cond_br %362, ^bb1(%c92_i8_201 : i8), ^bb122
+    %c1024_i64_161 = arith.constant 1024 : i64
+    %321 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_162 = arith.constant 1 : i64
+    %322 = arith.addi %321, %c1_i64_162 : i64
+    llvm.store %322, %arg3 : i64, !llvm.ptr
+    %323 = arith.cmpi ult, %c1024_i64_161, %322 : i64
+    %c92_i8_163 = arith.constant 92 : i8
+    cf.cond_br %323, ^bb1(%c92_i8_163 : i8), ^bb122
   ^bb124:  // pred: ^bb118
-    %363 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_202 = arith.constant 3 : i64
+    %324 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_164 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %364 = arith.cmpi uge, %363, %c3_i64_202 : i64
-    %c80_i8_203 = arith.constant 80 : i8
-    cf.cond_br %364, ^bb125, ^bb1(%c80_i8_203 : i8)
+    %325 = arith.cmpi uge, %324, %c3_i64_164 : i64
+    %c80_i8_165 = arith.constant 80 : i8
+    cf.cond_br %325, ^bb125, ^bb1(%c80_i8_165 : i8)
   ^bb125:  // pred: ^bb124
-    %365 = arith.subi %363, %c3_i64_202 : i64
-    llvm.store %365, %arg1 : i64, !llvm.ptr
+    %326 = arith.subi %324, %c3_i64_164 : i64
+    llvm.store %326, %arg1 : i64, !llvm.ptr
     cf.br ^bb123
   ^bb126:  // pred: ^bb127
-    %c32_i256_204 = arith.constant 32 : i256
-    %366 = llvm.load %arg3 : !llvm.ptr -> i64
-    %367 = llvm.getelementptr %arg2[%366] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_205 = arith.constant 1 : i64
-    %368 = arith.addi %366, %c1_i64_205 : i64
-    llvm.store %368, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_204, %367 : i256, !llvm.ptr
+    %c32_i256_166 = arith.constant 32 : i256
+    %327 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_166, %327 : i256, !llvm.ptr
+    %328 = llvm.getelementptr %327[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %328, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb133
   ^bb127:  // pred: ^bb129
-    %c1024_i64_206 = arith.constant 1024 : i64
-    %369 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_207 = arith.constant 1 : i64
-    %370 = arith.addi %369, %c1_i64_207 : i64
-    %371 = arith.cmpi ult, %c1024_i64_206, %370 : i64
-    %c92_i8_208 = arith.constant 92 : i8
-    cf.cond_br %371, ^bb1(%c92_i8_208 : i8), ^bb126
+    %c1024_i64_167 = arith.constant 1024 : i64
+    %329 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_168 = arith.constant 1 : i64
+    %330 = arith.addi %329, %c1_i64_168 : i64
+    llvm.store %330, %arg3 : i64, !llvm.ptr
+    %331 = arith.cmpi ult, %c1024_i64_167, %330 : i64
+    %c92_i8_169 = arith.constant 92 : i8
+    cf.cond_br %331, ^bb1(%c92_i8_169 : i8), ^bb126
   ^bb128:  // pred: ^bb122
-    %372 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_209 = arith.constant 3 : i64
+    %332 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_170 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %373 = arith.cmpi uge, %372, %c3_i64_209 : i64
-    %c80_i8_210 = arith.constant 80 : i8
-    cf.cond_br %373, ^bb129, ^bb1(%c80_i8_210 : i8)
+    %333 = arith.cmpi uge, %332, %c3_i64_170 : i64
+    %c80_i8_171 = arith.constant 80 : i8
+    cf.cond_br %333, ^bb129, ^bb1(%c80_i8_171 : i8)
   ^bb129:  // pred: ^bb128
-    %374 = arith.subi %372, %c3_i64_209 : i64
-    llvm.store %374, %arg1 : i64, !llvm.ptr
+    %334 = arith.subi %332, %c3_i64_170 : i64
+    llvm.store %334, %arg1 : i64, !llvm.ptr
     cf.br ^bb127
   ^bb130:  // pred: ^bb132
-    %375 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_211 = arith.constant 1 : i64
-    %376 = arith.subi %375, %c1_i64_211 : i64
-    %377 = llvm.getelementptr %arg2[%376] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %376, %arg3 : i64, !llvm.ptr
-    %378 = llvm.load %377 : !llvm.ptr -> i256
-    %379 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_212 = arith.constant 1 : i64
-    %380 = arith.subi %379, %c1_i64_212 : i64
-    %381 = llvm.getelementptr %arg2[%380] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %380, %arg3 : i64, !llvm.ptr
-    %382 = llvm.load %381 : !llvm.ptr -> i256
-    %c32_i64_213 = arith.constant 32 : i64
-    %c0_i64_214 = arith.constant 0 : i64
-    %383 = arith.cmpi ne, %c32_i64_213, %c0_i64_214 : i64
-    cf.cond_br %383, ^bb228, ^bb131
+    %335 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %336 = llvm.getelementptr %335[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %337 = llvm.load %336 : !llvm.ptr -> i256
+    llvm.store %336, %0 : !llvm.ptr, !llvm.ptr
+    %338 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %339 = llvm.getelementptr %338[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %340 = llvm.load %339 : !llvm.ptr -> i256
+    llvm.store %339, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_172 = arith.constant 32 : i64
+    %c0_i64_173 = arith.constant 0 : i64
+    %341 = arith.cmpi ne, %c32_i64_172, %c0_i64_173 : i64
+    cf.cond_br %341, ^bb228, ^bb131
   ^bb131:  // 2 preds: ^bb130, ^bb232
-    %384 = arith.trunci %378 : i256 to i64
-    %385 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %386 = llvm.getelementptr %385[%384] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %387 = llvm.intr.bswap(%382)  : (i256) -> i256
-    llvm.store %387, %386 {alignment = 1 : i64} : i256, !llvm.ptr
+    %342 = arith.trunci %337 : i256 to i64
+    %343 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %344 = llvm.getelementptr %343[%342] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %345 = llvm.intr.bswap(%340)  : (i256) -> i256
+    llvm.store %345, %344 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb137
   ^bb132:  // pred: ^bb134
-    %c1024_i64_215 = arith.constant 1024 : i64
-    %388 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_216 = arith.constant -2 : i64
-    %389 = arith.addi %388, %c-2_i64_216 : i64
-    %c2_i64_217 = arith.constant 2 : i64
-    %390 = arith.cmpi ult, %388, %c2_i64_217 : i64
-    %c91_i8_218 = arith.constant 91 : i8
-    cf.cond_br %390, ^bb1(%c91_i8_218 : i8), ^bb130
+    %c1024_i64_174 = arith.constant 1024 : i64
+    %346 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_175 = arith.constant -2 : i64
+    %347 = arith.addi %346, %c-2_i64_175 : i64
+    llvm.store %347, %arg3 : i64, !llvm.ptr
+    %c2_i64_176 = arith.constant 2 : i64
+    %348 = arith.cmpi ult, %346, %c2_i64_176 : i64
+    %c91_i8_177 = arith.constant 91 : i8
+    cf.cond_br %348, ^bb1(%c91_i8_177 : i8), ^bb130
   ^bb133:  // pred: ^bb126
-    %391 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_219 = arith.constant 3 : i64
+    %349 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_178 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %392 = arith.cmpi uge, %391, %c3_i64_219 : i64
-    %c80_i8_220 = arith.constant 80 : i8
-    cf.cond_br %392, ^bb134, ^bb1(%c80_i8_220 : i8)
+    %350 = arith.cmpi uge, %349, %c3_i64_178 : i64
+    %c80_i8_179 = arith.constant 80 : i8
+    cf.cond_br %350, ^bb134, ^bb1(%c80_i8_179 : i8)
   ^bb134:  // pred: ^bb133
-    %393 = arith.subi %391, %c3_i64_219 : i64
-    llvm.store %393, %arg1 : i64, !llvm.ptr
+    %351 = arith.subi %349, %c3_i64_178 : i64
+    llvm.store %351, %arg1 : i64, !llvm.ptr
     cf.br ^bb132
   ^bb135:  // pred: ^bb136
-    %c0_i256_221 = arith.constant 0 : i256
-    %394 = llvm.load %arg3 : !llvm.ptr -> i64
-    %395 = llvm.getelementptr %arg2[%394] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_222 = arith.constant 1 : i64
-    %396 = arith.addi %394, %c1_i64_222 : i64
-    llvm.store %396, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_221, %395 : i256, !llvm.ptr
+    %c0_i256_180 = arith.constant 0 : i256
+    %352 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_180, %352 : i256, !llvm.ptr
+    %353 = llvm.getelementptr %352[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %353, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb141
   ^bb136:  // pred: ^bb138
-    %c1024_i64_223 = arith.constant 1024 : i64
-    %397 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_224 = arith.constant 1 : i64
-    %398 = arith.addi %397, %c1_i64_224 : i64
-    %399 = arith.cmpi ult, %c1024_i64_223, %398 : i64
-    %c92_i8_225 = arith.constant 92 : i8
-    cf.cond_br %399, ^bb1(%c92_i8_225 : i8), ^bb135
+    %c1024_i64_181 = arith.constant 1024 : i64
+    %354 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_182 = arith.constant 1 : i64
+    %355 = arith.addi %354, %c1_i64_182 : i64
+    llvm.store %355, %arg3 : i64, !llvm.ptr
+    %356 = arith.cmpi ult, %c1024_i64_181, %355 : i64
+    %c92_i8_183 = arith.constant 92 : i8
+    cf.cond_br %356, ^bb1(%c92_i8_183 : i8), ^bb135
   ^bb137:  // pred: ^bb131
-    %400 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_226 = arith.constant 3 : i64
+    %357 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_184 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %401 = arith.cmpi uge, %400, %c3_i64_226 : i64
-    %c80_i8_227 = arith.constant 80 : i8
-    cf.cond_br %401, ^bb138, ^bb1(%c80_i8_227 : i8)
+    %358 = arith.cmpi uge, %357, %c3_i64_184 : i64
+    %c80_i8_185 = arith.constant 80 : i8
+    cf.cond_br %358, ^bb138, ^bb1(%c80_i8_185 : i8)
   ^bb138:  // pred: ^bb137
-    %402 = arith.subi %400, %c3_i64_226 : i64
-    llvm.store %402, %arg1 : i64, !llvm.ptr
+    %359 = arith.subi %357, %c3_i64_184 : i64
+    llvm.store %359, %arg1 : i64, !llvm.ptr
     cf.br ^bb136
   ^bb139:  // pred: ^bb140
-    %c64_i256_228 = arith.constant 64 : i256
-    %403 = llvm.load %arg3 : !llvm.ptr -> i64
-    %404 = llvm.getelementptr %arg2[%403] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_229 = arith.constant 1 : i64
-    %405 = arith.addi %403, %c1_i64_229 : i64
-    llvm.store %405, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256_228, %404 : i256, !llvm.ptr
+    %c64_i256_186 = arith.constant 64 : i256
+    %360 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_186, %360 : i256, !llvm.ptr
+    %361 = llvm.getelementptr %360[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %361, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb146
   ^bb140:  // pred: ^bb142
-    %c1024_i64_230 = arith.constant 1024 : i64
-    %406 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_231 = arith.constant 1 : i64
-    %407 = arith.addi %406, %c1_i64_231 : i64
-    %408 = arith.cmpi ult, %c1024_i64_230, %407 : i64
-    %c92_i8_232 = arith.constant 92 : i8
-    cf.cond_br %408, ^bb1(%c92_i8_232 : i8), ^bb139
+    %c1024_i64_187 = arith.constant 1024 : i64
+    %362 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_188 = arith.constant 1 : i64
+    %363 = arith.addi %362, %c1_i64_188 : i64
+    llvm.store %363, %arg3 : i64, !llvm.ptr
+    %364 = arith.cmpi ult, %c1024_i64_187, %363 : i64
+    %c92_i8_189 = arith.constant 92 : i8
+    cf.cond_br %364, ^bb1(%c92_i8_189 : i8), ^bb139
   ^bb141:  // pred: ^bb135
-    %409 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_233 = arith.constant 3 : i64
+    %365 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_190 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %410 = arith.cmpi uge, %409, %c3_i64_233 : i64
-    %c80_i8_234 = arith.constant 80 : i8
-    cf.cond_br %410, ^bb142, ^bb1(%c80_i8_234 : i8)
+    %366 = arith.cmpi uge, %365, %c3_i64_190 : i64
+    %c80_i8_191 = arith.constant 80 : i8
+    cf.cond_br %366, ^bb142, ^bb1(%c80_i8_191 : i8)
   ^bb142:  // pred: ^bb141
-    %411 = arith.subi %409, %c3_i64_233 : i64
-    llvm.store %411, %arg1 : i64, !llvm.ptr
+    %367 = arith.subi %365, %c3_i64_190 : i64
+    llvm.store %367, %arg1 : i64, !llvm.ptr
     cf.br ^bb140
   ^bb143:  // pred: ^bb145
-    %412 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_235 = arith.constant 1 : i64
-    %413 = arith.subi %412, %c1_i64_235 : i64
-    %414 = llvm.getelementptr %arg2[%413] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %413, %arg3 : i64, !llvm.ptr
-    %415 = llvm.load %414 : !llvm.ptr -> i256
-    %416 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_236 = arith.constant 1 : i64
-    %417 = arith.subi %416, %c1_i64_236 : i64
-    %418 = llvm.getelementptr %arg2[%417] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %417, %arg3 : i64, !llvm.ptr
-    %419 = llvm.load %418 : !llvm.ptr -> i256
-    %c32_i64_237 = arith.constant 32 : i64
-    %c0_i64_238 = arith.constant 0 : i64
-    %420 = arith.cmpi ne, %c32_i64_237, %c0_i64_238 : i64
-    cf.cond_br %420, ^bb236, ^bb144
+    %368 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %369 = llvm.getelementptr %368[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %370 = llvm.load %369 : !llvm.ptr -> i256
+    llvm.store %369, %0 : !llvm.ptr, !llvm.ptr
+    %371 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %372 = llvm.getelementptr %371[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %373 = llvm.load %372 : !llvm.ptr -> i256
+    llvm.store %372, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_192 = arith.constant 32 : i64
+    %c0_i64_193 = arith.constant 0 : i64
+    %374 = arith.cmpi ne, %c32_i64_192, %c0_i64_193 : i64
+    cf.cond_br %374, ^bb236, ^bb144
   ^bb144:  // 2 preds: ^bb143, ^bb240
-    %421 = arith.trunci %415 : i256 to i64
-    %422 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %423 = llvm.getelementptr %422[%421] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %424 = llvm.intr.bswap(%419)  : (i256) -> i256
-    llvm.store %424, %423 {alignment = 1 : i64} : i256, !llvm.ptr
+    %375 = arith.trunci %370 : i256 to i64
+    %376 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %377 = llvm.getelementptr %376[%375] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %378 = llvm.intr.bswap(%373)  : (i256) -> i256
+    llvm.store %378, %377 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb150
   ^bb145:  // pred: ^bb147
-    %c1024_i64_239 = arith.constant 1024 : i64
-    %425 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_240 = arith.constant -2 : i64
-    %426 = arith.addi %425, %c-2_i64_240 : i64
-    %c2_i64_241 = arith.constant 2 : i64
-    %427 = arith.cmpi ult, %425, %c2_i64_241 : i64
-    %c91_i8_242 = arith.constant 91 : i8
-    cf.cond_br %427, ^bb1(%c91_i8_242 : i8), ^bb143
+    %c1024_i64_194 = arith.constant 1024 : i64
+    %379 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_195 = arith.constant -2 : i64
+    %380 = arith.addi %379, %c-2_i64_195 : i64
+    llvm.store %380, %arg3 : i64, !llvm.ptr
+    %c2_i64_196 = arith.constant 2 : i64
+    %381 = arith.cmpi ult, %379, %c2_i64_196 : i64
+    %c91_i8_197 = arith.constant 91 : i8
+    cf.cond_br %381, ^bb1(%c91_i8_197 : i8), ^bb143
   ^bb146:  // pred: ^bb139
-    %428 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_243 = arith.constant 3 : i64
+    %382 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_198 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %429 = arith.cmpi uge, %428, %c3_i64_243 : i64
-    %c80_i8_244 = arith.constant 80 : i8
-    cf.cond_br %429, ^bb147, ^bb1(%c80_i8_244 : i8)
+    %383 = arith.cmpi uge, %382, %c3_i64_198 : i64
+    %c80_i8_199 = arith.constant 80 : i8
+    cf.cond_br %383, ^bb147, ^bb1(%c80_i8_199 : i8)
   ^bb147:  // pred: ^bb146
-    %430 = arith.subi %428, %c3_i64_243 : i64
-    llvm.store %430, %arg1 : i64, !llvm.ptr
+    %384 = arith.subi %382, %c3_i64_198 : i64
+    llvm.store %384, %arg1 : i64, !llvm.ptr
     cf.br ^bb145
   ^bb148:  // pred: ^bb149
-    %c32_i256_245 = arith.constant 32 : i256
-    %431 = llvm.load %arg3 : !llvm.ptr -> i64
-    %432 = llvm.getelementptr %arg2[%431] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_246 = arith.constant 1 : i64
-    %433 = arith.addi %431, %c1_i64_246 : i64
-    llvm.store %433, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_245, %432 : i256, !llvm.ptr
+    %c32_i256_200 = arith.constant 32 : i256
+    %385 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_200, %385 : i256, !llvm.ptr
+    %386 = llvm.getelementptr %385[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %386, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb154
   ^bb149:  // pred: ^bb151
-    %c1024_i64_247 = arith.constant 1024 : i64
-    %434 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_248 = arith.constant 1 : i64
-    %435 = arith.addi %434, %c1_i64_248 : i64
-    %436 = arith.cmpi ult, %c1024_i64_247, %435 : i64
-    %c92_i8_249 = arith.constant 92 : i8
-    cf.cond_br %436, ^bb1(%c92_i8_249 : i8), ^bb148
+    %c1024_i64_201 = arith.constant 1024 : i64
+    %387 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_202 = arith.constant 1 : i64
+    %388 = arith.addi %387, %c1_i64_202 : i64
+    llvm.store %388, %arg3 : i64, !llvm.ptr
+    %389 = arith.cmpi ult, %c1024_i64_201, %388 : i64
+    %c92_i8_203 = arith.constant 92 : i8
+    cf.cond_br %389, ^bb1(%c92_i8_203 : i8), ^bb148
   ^bb150:  // pred: ^bb144
-    %437 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_250 = arith.constant 3 : i64
+    %390 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_204 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %438 = arith.cmpi uge, %437, %c3_i64_250 : i64
-    %c80_i8_251 = arith.constant 80 : i8
-    cf.cond_br %438, ^bb151, ^bb1(%c80_i8_251 : i8)
+    %391 = arith.cmpi uge, %390, %c3_i64_204 : i64
+    %c80_i8_205 = arith.constant 80 : i8
+    cf.cond_br %391, ^bb151, ^bb1(%c80_i8_205 : i8)
   ^bb151:  // pred: ^bb150
-    %439 = arith.subi %437, %c3_i64_250 : i64
-    llvm.store %439, %arg1 : i64, !llvm.ptr
+    %392 = arith.subi %390, %c3_i64_204 : i64
+    llvm.store %392, %arg1 : i64, !llvm.ptr
     cf.br ^bb149
   ^bb152:  // pred: ^bb153
-    %c0_i256_252 = arith.constant 0 : i256
-    %440 = llvm.load %arg3 : !llvm.ptr -> i64
-    %441 = llvm.getelementptr %arg2[%440] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_253 = arith.constant 1 : i64
-    %442 = arith.addi %440, %c1_i64_253 : i64
-    llvm.store %442, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_252, %441 : i256, !llvm.ptr
+    %c0_i256_206 = arith.constant 0 : i256
+    %393 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_206, %393 : i256, !llvm.ptr
+    %394 = llvm.getelementptr %393[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %394, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb158
   ^bb153:  // pred: ^bb155
-    %c1024_i64_254 = arith.constant 1024 : i64
-    %443 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_255 = arith.constant 1 : i64
-    %444 = arith.addi %443, %c1_i64_255 : i64
-    %445 = arith.cmpi ult, %c1024_i64_254, %444 : i64
-    %c92_i8_256 = arith.constant 92 : i8
-    cf.cond_br %445, ^bb1(%c92_i8_256 : i8), ^bb152
+    %c1024_i64_207 = arith.constant 1024 : i64
+    %395 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_208 = arith.constant 1 : i64
+    %396 = arith.addi %395, %c1_i64_208 : i64
+    llvm.store %396, %arg3 : i64, !llvm.ptr
+    %397 = arith.cmpi ult, %c1024_i64_207, %396 : i64
+    %c92_i8_209 = arith.constant 92 : i8
+    cf.cond_br %397, ^bb1(%c92_i8_209 : i8), ^bb152
   ^bb154:  // pred: ^bb148
-    %446 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_257 = arith.constant 3 : i64
+    %398 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_210 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %447 = arith.cmpi uge, %446, %c3_i64_257 : i64
-    %c80_i8_258 = arith.constant 80 : i8
-    cf.cond_br %447, ^bb155, ^bb1(%c80_i8_258 : i8)
+    %399 = arith.cmpi uge, %398, %c3_i64_210 : i64
+    %c80_i8_211 = arith.constant 80 : i8
+    cf.cond_br %399, ^bb155, ^bb1(%c80_i8_211 : i8)
   ^bb155:  // pred: ^bb154
-    %448 = arith.subi %446, %c3_i64_257 : i64
-    llvm.store %448, %arg1 : i64, !llvm.ptr
+    %400 = arith.subi %398, %c3_i64_210 : i64
+    llvm.store %400, %arg1 : i64, !llvm.ptr
     cf.br ^bb153
   ^bb156:  // pred: ^bb157
-    %c0_i256_259 = arith.constant 0 : i256
-    %449 = llvm.load %arg3 : !llvm.ptr -> i64
-    %450 = llvm.getelementptr %arg2[%449] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_260 = arith.constant 1 : i64
-    %451 = arith.addi %449, %c1_i64_260 : i64
-    llvm.store %451, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_259, %450 : i256, !llvm.ptr
+    %c0_i256_212 = arith.constant 0 : i256
+    %401 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_212, %401 : i256, !llvm.ptr
+    %402 = llvm.getelementptr %401[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %402, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb167
   ^bb157:  // pred: ^bb159
-    %c1024_i64_261 = arith.constant 1024 : i64
-    %452 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_262 = arith.constant 1 : i64
-    %453 = arith.addi %452, %c1_i64_262 : i64
-    %454 = arith.cmpi ult, %c1024_i64_261, %453 : i64
-    %c92_i8_263 = arith.constant 92 : i8
-    cf.cond_br %454, ^bb1(%c92_i8_263 : i8), ^bb156
+    %c1024_i64_213 = arith.constant 1024 : i64
+    %403 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_214 = arith.constant 1 : i64
+    %404 = arith.addi %403, %c1_i64_214 : i64
+    llvm.store %404, %arg3 : i64, !llvm.ptr
+    %405 = arith.cmpi ult, %c1024_i64_213, %404 : i64
+    %c92_i8_215 = arith.constant 92 : i8
+    cf.cond_br %405, ^bb1(%c92_i8_215 : i8), ^bb156
   ^bb158:  // pred: ^bb152
-    %455 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_264 = arith.constant 3 : i64
+    %406 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_216 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %456 = arith.cmpi uge, %455, %c3_i64_264 : i64
-    %c80_i8_265 = arith.constant 80 : i8
-    cf.cond_br %456, ^bb159, ^bb1(%c80_i8_265 : i8)
+    %407 = arith.cmpi uge, %406, %c3_i64_216 : i64
+    %c80_i8_217 = arith.constant 80 : i8
+    cf.cond_br %407, ^bb159, ^bb1(%c80_i8_217 : i8)
   ^bb159:  // pred: ^bb158
-    %457 = arith.subi %455, %c3_i64_264 : i64
-    llvm.store %457, %arg1 : i64, !llvm.ptr
+    %408 = arith.subi %406, %c3_i64_216 : i64
+    llvm.store %408, %arg1 : i64, !llvm.ptr
     cf.br ^bb157
   ^bb160:  // pred: ^bb166
-    %458 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_266 = arith.constant 1 : i64
-    %459 = arith.subi %458, %c1_i64_266 : i64
-    %460 = llvm.getelementptr %arg2[%459] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %459, %arg3 : i64, !llvm.ptr
-    %461 = llvm.load %460 : !llvm.ptr -> i256
-    %462 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_267 = arith.constant 1 : i64
-    %463 = arith.subi %462, %c1_i64_267 : i64
-    %464 = llvm.getelementptr %arg2[%463] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %463, %arg3 : i64, !llvm.ptr
-    %465 = llvm.load %464 : !llvm.ptr -> i256
-    %466 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_268 = arith.constant 1 : i64
-    %467 = arith.subi %466, %c1_i64_268 : i64
-    %468 = llvm.getelementptr %arg2[%467] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %467, %arg3 : i64, !llvm.ptr
-    %469 = llvm.load %468 : !llvm.ptr -> i256
-    %c18446744073709551615_i256_269 = arith.constant 18446744073709551615 : i256
-    %470 = arith.cmpi sgt, %469, %c18446744073709551615_i256_269 : i256
-    %c84_i8_270 = arith.constant 84 : i8
-    cf.cond_br %470, ^bb1(%c84_i8_270 : i8), ^bb161
+    %409 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %410 = llvm.getelementptr %409[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %411 = llvm.load %410 : !llvm.ptr -> i256
+    llvm.store %410, %0 : !llvm.ptr, !llvm.ptr
+    %412 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %413 = llvm.getelementptr %412[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %414 = llvm.load %413 : !llvm.ptr -> i256
+    llvm.store %413, %0 : !llvm.ptr, !llvm.ptr
+    %415 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %416 = llvm.getelementptr %415[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %417 = llvm.load %416 : !llvm.ptr -> i256
+    llvm.store %416, %0 : !llvm.ptr, !llvm.ptr
+    %c18446744073709551615_i256_218 = arith.constant 18446744073709551615 : i256
+    %418 = arith.cmpi sgt, %417, %c18446744073709551615_i256_218 : i256
+    %c84_i8_219 = arith.constant 84 : i8
+    cf.cond_br %418, ^bb1(%c84_i8_219 : i8), ^bb161
   ^bb161:  // pred: ^bb160
-    %471 = arith.trunci %469 : i256 to i64
-    %c0_i64_271 = arith.constant 0 : i64
-    %472 = arith.cmpi slt, %471, %c0_i64_271 : i64
-    %c84_i8_272 = arith.constant 84 : i8
-    cf.cond_br %472, ^bb1(%c84_i8_272 : i8), ^bb162
+    %419 = arith.trunci %417 : i256 to i64
+    %c0_i64_220 = arith.constant 0 : i64
+    %420 = arith.cmpi slt, %419, %c0_i64_220 : i64
+    %c84_i8_221 = arith.constant 84 : i8
+    cf.cond_br %420, ^bb1(%c84_i8_221 : i8), ^bb162
   ^bb162:  // pred: ^bb161
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_273 = arith.constant 32 : i64
-    %473 = arith.addi %471, %c31_i64 : i64
-    %474 = arith.divui %473, %c32_i64_273 : i64
-    %c3_i64_274 = arith.constant 3 : i64
-    %475 = arith.muli %474, %c3_i64_274 : i64
-    %476 = llvm.load %arg1 : !llvm.ptr -> i64
-    %477 = arith.cmpi ult, %476, %475 : i64
-    scf.if %477 {
+    %c32_i64_222 = arith.constant 32 : i64
+    %421 = arith.addi %419, %c31_i64 : i64
+    %422 = arith.divui %421, %c32_i64_222 : i64
+    %c3_i64_223 = arith.constant 3 : i64
+    %423 = arith.muli %422, %c3_i64_223 : i64
+    %424 = llvm.load %arg1 : !llvm.ptr -> i64
+    %425 = arith.cmpi ult, %424, %423 : i64
+    scf.if %425 {
     } else {
-      %778 = arith.subi %476, %475 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %424, %423 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_275 = arith.constant 80 : i8
-    cf.cond_br %477, ^bb1(%c80_i8_275 : i8), ^bb163
+    %c80_i8_224 = arith.constant 80 : i8
+    cf.cond_br %425, ^bb1(%c80_i8_224 : i8), ^bb163
   ^bb163:  // pred: ^bb162
-    %c1_i256_276 = arith.constant 1 : i256
-    %478 = llvm.alloca %c1_i256_276 x i256 : (i256) -> !llvm.ptr
-    llvm.store %465, %478 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i64_277 = arith.constant 0 : i64
-    %479 = arith.cmpi ne, %471, %c0_i64_277 : i64
-    cf.cond_br %479, ^bb244, ^bb164
+    %c1_i256_225 = arith.constant 1 : i256
+    %426 = llvm.alloca %c1_i256_225 x i256 : (i256) -> !llvm.ptr
+    llvm.store %414, %426 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i64_226 = arith.constant 0 : i64
+    %427 = arith.cmpi ne, %419, %c0_i64_226 : i64
+    cf.cond_br %427, ^bb244, ^bb164
   ^bb164:  // 2 preds: ^bb163, ^bb248
-    %480 = arith.trunci %461 : i256 to i64
-    %481 = call @dora_fn_returndata_copy(%arg0, %480, %478, %471) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %482 = llvm.getelementptr %481[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %483 = llvm.load %482 : !llvm.ptr -> i8
-    %c0_i8_278 = arith.constant 0 : i8
-    %484 = arith.cmpi ne, %483, %c0_i8_278 : i8
-    cf.cond_br %484, ^bb1(%483 : i8), ^bb165
+    %428 = arith.trunci %411 : i256 to i64
+    %429 = call @dora_fn_returndata_copy(%arg0, %428, %426, %419) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %430 = llvm.getelementptr %429[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %431 = llvm.load %430 : !llvm.ptr -> i8
+    %c0_i8_227 = arith.constant 0 : i8
+    %432 = arith.cmpi ne, %431, %c0_i8_227 : i8
+    cf.cond_br %432, ^bb1(%431 : i8), ^bb165
   ^bb165:  // pred: ^bb164
     cf.br ^bb169
   ^bb166:  // pred: ^bb168
-    %c1024_i64_279 = arith.constant 1024 : i64
-    %485 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_228 = arith.constant 1024 : i64
+    %433 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %486 = arith.addi %485, %c-3_i64 : i64
-    %c3_i64_280 = arith.constant 3 : i64
-    %487 = arith.cmpi ult, %485, %c3_i64_280 : i64
-    %c91_i8_281 = arith.constant 91 : i8
-    cf.cond_br %487, ^bb1(%c91_i8_281 : i8), ^bb160
+    %434 = arith.addi %433, %c-3_i64 : i64
+    llvm.store %434, %arg3 : i64, !llvm.ptr
+    %c3_i64_229 = arith.constant 3 : i64
+    %435 = arith.cmpi ult, %433, %c3_i64_229 : i64
+    %c91_i8_230 = arith.constant 91 : i8
+    cf.cond_br %435, ^bb1(%c91_i8_230 : i8), ^bb160
   ^bb167:  // pred: ^bb156
-    %488 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_282 = arith.constant 3 : i64
+    %436 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_231 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %489 = arith.cmpi uge, %488, %c3_i64_282 : i64
-    %c80_i8_283 = arith.constant 80 : i8
-    cf.cond_br %489, ^bb168, ^bb1(%c80_i8_283 : i8)
+    %437 = arith.cmpi uge, %436, %c3_i64_231 : i64
+    %c80_i8_232 = arith.constant 80 : i8
+    cf.cond_br %437, ^bb168, ^bb1(%c80_i8_232 : i8)
   ^bb168:  // pred: ^bb167
-    %490 = arith.subi %488, %c3_i64_282 : i64
-    llvm.store %490, %arg1 : i64, !llvm.ptr
+    %438 = arith.subi %436, %c3_i64_231 : i64
+    llvm.store %438, %arg1 : i64, !llvm.ptr
     cf.br ^bb166
   ^bb169:  // pred: ^bb165
-    %c0_i64_284 = arith.constant 0 : i64
-    %c1_i8_285 = arith.constant 1 : i8
-    %491 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_284, %c0_i64_284, %491, %c1_i8_285) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %c1_i8_285 : i8
+    %c0_i64_233 = arith.constant 0 : i64
+    %c1_i8_234 = arith.constant 1 : i8
+    %439 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_233, %c0_i64_233, %439, %c1_i8_234) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %c1_i8_234 : i8
   ^bb170:  // pred: ^bb11
-    %c18446744073709551615_i256_286 = arith.constant 18446744073709551615 : i256
-    %492 = arith.cmpi sgt, %24, %c18446744073709551615_i256_286 : i256
-    %c84_i8_287 = arith.constant 84 : i8
-    cf.cond_br %492, ^bb1(%c84_i8_287 : i8), ^bb171
+    %c18446744073709551615_i256_235 = arith.constant 18446744073709551615 : i256
+    %440 = arith.cmpi sgt, %22, %c18446744073709551615_i256_235 : i256
+    %c84_i8_236 = arith.constant 84 : i8
+    cf.cond_br %440, ^bb1(%c84_i8_236 : i8), ^bb171
   ^bb171:  // pred: ^bb170
-    %493 = arith.trunci %24 : i256 to i64
-    %c0_i64_288 = arith.constant 0 : i64
-    %494 = arith.cmpi slt, %493, %c0_i64_288 : i64
-    %c84_i8_289 = arith.constant 84 : i8
-    cf.cond_br %494, ^bb1(%c84_i8_289 : i8), ^bb172
+    %441 = arith.trunci %22 : i256 to i64
+    %c0_i64_237 = arith.constant 0 : i64
+    %442 = arith.cmpi slt, %441, %c0_i64_237 : i64
+    %c84_i8_238 = arith.constant 84 : i8
+    cf.cond_br %442, ^bb1(%c84_i8_238 : i8), ^bb172
   ^bb172:  // pred: ^bb171
-    %495 = arith.addi %493, %c32_i64 : i64
-    %c0_i64_290 = arith.constant 0 : i64
-    %496 = arith.cmpi slt, %495, %c0_i64_290 : i64
-    %c84_i8_291 = arith.constant 84 : i8
-    cf.cond_br %496, ^bb1(%c84_i8_291 : i8), ^bb173
+    %443 = arith.addi %441, %c32_i64 : i64
+    %c0_i64_239 = arith.constant 0 : i64
+    %444 = arith.cmpi slt, %443, %c0_i64_239 : i64
+    %c84_i8_240 = arith.constant 84 : i8
+    cf.cond_br %444, ^bb1(%c84_i8_240 : i8), ^bb173
   ^bb173:  // pred: ^bb172
-    %c31_i64_292 = arith.constant 31 : i64
-    %c32_i64_293 = arith.constant 32 : i64
-    %497 = arith.addi %495, %c31_i64_292 : i64
-    %498 = arith.divui %497, %c32_i64_293 : i64
-    %c32_i64_294 = arith.constant 32 : i64
-    %499 = arith.muli %498, %c32_i64_294 : i64
-    %500 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_295 = arith.constant 31 : i64
-    %c32_i64_296 = arith.constant 32 : i64
-    %501 = arith.addi %500, %c31_i64_295 : i64
-    %502 = arith.divui %501, %c32_i64_296 : i64
-    %503 = arith.muli %502, %c32_i64_294 : i64
-    %504 = arith.cmpi ult, %503, %499 : i64
-    cf.cond_br %504, ^bb175, ^bb174
+    %c31_i64_241 = arith.constant 31 : i64
+    %c32_i64_242 = arith.constant 32 : i64
+    %445 = arith.addi %443, %c31_i64_241 : i64
+    %446 = arith.divui %445, %c32_i64_242 : i64
+    %c32_i64_243 = arith.constant 32 : i64
+    %447 = arith.muli %446, %c32_i64_243 : i64
+    %448 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_244 = arith.constant 31 : i64
+    %c32_i64_245 = arith.constant 32 : i64
+    %449 = arith.addi %448, %c31_i64_244 : i64
+    %450 = arith.divui %449, %c32_i64_245 : i64
+    %451 = arith.muli %450, %c32_i64_243 : i64
+    %452 = arith.cmpi ult, %451, %447 : i64
+    cf.cond_br %452, ^bb175, ^bb174
   ^bb174:  // 2 preds: ^bb173, ^bb177
     cf.br ^bb12
   ^bb175:  // pred: ^bb173
-    %c3_i64_297 = arith.constant 3 : i64
+    %c3_i64_246 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %505 = arith.muli %502, %502 : i64
-    %506 = arith.divui %505, %c512_i64 : i64
-    %507 = arith.muli %502, %c3_i64_297 : i64
-    %508 = arith.addi %506, %507 : i64
-    %c3_i64_298 = arith.constant 3 : i64
-    %c512_i64_299 = arith.constant 512 : i64
-    %509 = arith.muli %498, %498 : i64
-    %510 = arith.divui %509, %c512_i64_299 : i64
-    %511 = arith.muli %498, %c3_i64_298 : i64
-    %512 = arith.addi %510, %511 : i64
-    %513 = arith.subi %512, %508 : i64
-    %514 = llvm.load %arg1 : !llvm.ptr -> i64
-    %515 = arith.cmpi ult, %514, %513 : i64
-    scf.if %515 {
+    %453 = arith.muli %450, %450 : i64
+    %454 = arith.divui %453, %c512_i64 : i64
+    %455 = arith.muli %450, %c3_i64_246 : i64
+    %456 = arith.addi %454, %455 : i64
+    %c3_i64_247 = arith.constant 3 : i64
+    %c512_i64_248 = arith.constant 512 : i64
+    %457 = arith.muli %446, %446 : i64
+    %458 = arith.divui %457, %c512_i64_248 : i64
+    %459 = arith.muli %446, %c3_i64_247 : i64
+    %460 = arith.addi %458, %459 : i64
+    %461 = arith.subi %460, %456 : i64
+    %462 = llvm.load %arg1 : !llvm.ptr -> i64
+    %463 = arith.cmpi ult, %462, %461 : i64
+    scf.if %463 {
     } else {
-      %778 = arith.subi %514, %513 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %462, %461 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_300 = arith.constant 80 : i8
-    cf.cond_br %515, ^bb1(%c80_i8_300 : i8), ^bb176
+    %c80_i8_249 = arith.constant 80 : i8
+    cf.cond_br %463, ^bb1(%c80_i8_249 : i8), ^bb176
   ^bb176:  // pred: ^bb175
-    %516 = call @dora_fn_extend_memory(%arg0, %499) : (!llvm.ptr, i64) -> !llvm.ptr
-    %517 = llvm.getelementptr %516[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %518 = llvm.load %517 : !llvm.ptr -> i8
-    %c0_i8_301 = arith.constant 0 : i8
-    %519 = arith.cmpi ne, %518, %c0_i8_301 : i8
-    cf.cond_br %519, ^bb1(%518 : i8), ^bb177
+    %464 = call @dora_fn_extend_memory(%arg0, %447) : (!llvm.ptr, i64) -> !llvm.ptr
+    %465 = llvm.getelementptr %464[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %466 = llvm.load %465 : !llvm.ptr -> i8
+    %c0_i8_250 = arith.constant 0 : i8
+    %467 = arith.cmpi ne, %466, %c0_i8_250 : i8
+    cf.cond_br %467, ^bb1(%466 : i8), ^bb177
   ^bb177:  // pred: ^bb176
     cf.br ^bb174
   ^bb178:  // pred: ^bb24
-    %c18446744073709551615_i256_302 = arith.constant 18446744073709551615 : i256
-    %520 = arith.cmpi sgt, %61, %c18446744073709551615_i256_302 : i256
-    %c84_i8_303 = arith.constant 84 : i8
-    cf.cond_br %520, ^bb1(%c84_i8_303 : i8), ^bb179
+    %c18446744073709551615_i256_251 = arith.constant 18446744073709551615 : i256
+    %468 = arith.cmpi sgt, %55, %c18446744073709551615_i256_251 : i256
+    %c84_i8_252 = arith.constant 84 : i8
+    cf.cond_br %468, ^bb1(%c84_i8_252 : i8), ^bb179
   ^bb179:  // pred: ^bb178
-    %521 = arith.trunci %61 : i256 to i64
-    %c0_i64_304 = arith.constant 0 : i64
-    %522 = arith.cmpi slt, %521, %c0_i64_304 : i64
-    %c84_i8_305 = arith.constant 84 : i8
-    cf.cond_br %522, ^bb1(%c84_i8_305 : i8), ^bb180
+    %469 = arith.trunci %55 : i256 to i64
+    %c0_i64_253 = arith.constant 0 : i64
+    %470 = arith.cmpi slt, %469, %c0_i64_253 : i64
+    %c84_i8_254 = arith.constant 84 : i8
+    cf.cond_br %470, ^bb1(%c84_i8_254 : i8), ^bb180
   ^bb180:  // pred: ^bb179
-    %523 = arith.addi %521, %c32_i64_27 : i64
-    %c0_i64_306 = arith.constant 0 : i64
-    %524 = arith.cmpi slt, %523, %c0_i64_306 : i64
-    %c84_i8_307 = arith.constant 84 : i8
-    cf.cond_br %524, ^bb1(%c84_i8_307 : i8), ^bb181
+    %471 = arith.addi %469, %c32_i64_20 : i64
+    %c0_i64_255 = arith.constant 0 : i64
+    %472 = arith.cmpi slt, %471, %c0_i64_255 : i64
+    %c84_i8_256 = arith.constant 84 : i8
+    cf.cond_br %472, ^bb1(%c84_i8_256 : i8), ^bb181
   ^bb181:  // pred: ^bb180
-    %c31_i64_308 = arith.constant 31 : i64
-    %c32_i64_309 = arith.constant 32 : i64
-    %525 = arith.addi %523, %c31_i64_308 : i64
-    %526 = arith.divui %525, %c32_i64_309 : i64
-    %c32_i64_310 = arith.constant 32 : i64
-    %527 = arith.muli %526, %c32_i64_310 : i64
-    %528 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_311 = arith.constant 31 : i64
-    %c32_i64_312 = arith.constant 32 : i64
-    %529 = arith.addi %528, %c31_i64_311 : i64
-    %530 = arith.divui %529, %c32_i64_312 : i64
-    %531 = arith.muli %530, %c32_i64_310 : i64
-    %532 = arith.cmpi ult, %531, %527 : i64
-    cf.cond_br %532, ^bb183, ^bb182
+    %c31_i64_257 = arith.constant 31 : i64
+    %c32_i64_258 = arith.constant 32 : i64
+    %473 = arith.addi %471, %c31_i64_257 : i64
+    %474 = arith.divui %473, %c32_i64_258 : i64
+    %c32_i64_259 = arith.constant 32 : i64
+    %475 = arith.muli %474, %c32_i64_259 : i64
+    %476 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_260 = arith.constant 31 : i64
+    %c32_i64_261 = arith.constant 32 : i64
+    %477 = arith.addi %476, %c31_i64_260 : i64
+    %478 = arith.divui %477, %c32_i64_261 : i64
+    %479 = arith.muli %478, %c32_i64_259 : i64
+    %480 = arith.cmpi ult, %479, %475 : i64
+    cf.cond_br %480, ^bb183, ^bb182
   ^bb182:  // 2 preds: ^bb181, ^bb185
     cf.br ^bb25
   ^bb183:  // pred: ^bb181
-    %c3_i64_313 = arith.constant 3 : i64
-    %c512_i64_314 = arith.constant 512 : i64
-    %533 = arith.muli %530, %530 : i64
-    %534 = arith.divui %533, %c512_i64_314 : i64
-    %535 = arith.muli %530, %c3_i64_313 : i64
-    %536 = arith.addi %534, %535 : i64
-    %c3_i64_315 = arith.constant 3 : i64
-    %c512_i64_316 = arith.constant 512 : i64
-    %537 = arith.muli %526, %526 : i64
-    %538 = arith.divui %537, %c512_i64_316 : i64
-    %539 = arith.muli %526, %c3_i64_315 : i64
-    %540 = arith.addi %538, %539 : i64
-    %541 = arith.subi %540, %536 : i64
-    %542 = llvm.load %arg1 : !llvm.ptr -> i64
-    %543 = arith.cmpi ult, %542, %541 : i64
-    scf.if %543 {
+    %c3_i64_262 = arith.constant 3 : i64
+    %c512_i64_263 = arith.constant 512 : i64
+    %481 = arith.muli %478, %478 : i64
+    %482 = arith.divui %481, %c512_i64_263 : i64
+    %483 = arith.muli %478, %c3_i64_262 : i64
+    %484 = arith.addi %482, %483 : i64
+    %c3_i64_264 = arith.constant 3 : i64
+    %c512_i64_265 = arith.constant 512 : i64
+    %485 = arith.muli %474, %474 : i64
+    %486 = arith.divui %485, %c512_i64_265 : i64
+    %487 = arith.muli %474, %c3_i64_264 : i64
+    %488 = arith.addi %486, %487 : i64
+    %489 = arith.subi %488, %484 : i64
+    %490 = llvm.load %arg1 : !llvm.ptr -> i64
+    %491 = arith.cmpi ult, %490, %489 : i64
+    scf.if %491 {
     } else {
-      %778 = arith.subi %542, %541 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %490, %489 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_317 = arith.constant 80 : i8
-    cf.cond_br %543, ^bb1(%c80_i8_317 : i8), ^bb184
+    %c80_i8_266 = arith.constant 80 : i8
+    cf.cond_br %491, ^bb1(%c80_i8_266 : i8), ^bb184
   ^bb184:  // pred: ^bb183
-    %544 = call @dora_fn_extend_memory(%arg0, %527) : (!llvm.ptr, i64) -> !llvm.ptr
-    %545 = llvm.getelementptr %544[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %546 = llvm.load %545 : !llvm.ptr -> i8
-    %c0_i8_318 = arith.constant 0 : i8
-    %547 = arith.cmpi ne, %546, %c0_i8_318 : i8
-    cf.cond_br %547, ^bb1(%546 : i8), ^bb185
+    %492 = call @dora_fn_extend_memory(%arg0, %475) : (!llvm.ptr, i64) -> !llvm.ptr
+    %493 = llvm.getelementptr %492[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %494 = llvm.load %493 : !llvm.ptr -> i8
+    %c0_i8_267 = arith.constant 0 : i8
+    %495 = arith.cmpi ne, %494, %c0_i8_267 : i8
+    cf.cond_br %495, ^bb1(%494 : i8), ^bb185
   ^bb185:  // pred: ^bb184
     cf.br ^bb182
   ^bb186:  // pred: ^bb37
-    %c18446744073709551615_i256_319 = arith.constant 18446744073709551615 : i256
-    %548 = arith.cmpi sgt, %98, %c18446744073709551615_i256_319 : i256
-    %c84_i8_320 = arith.constant 84 : i8
-    cf.cond_br %548, ^bb1(%c84_i8_320 : i8), ^bb187
+    %c18446744073709551615_i256_268 = arith.constant 18446744073709551615 : i256
+    %496 = arith.cmpi sgt, %88, %c18446744073709551615_i256_268 : i256
+    %c84_i8_269 = arith.constant 84 : i8
+    cf.cond_br %496, ^bb1(%c84_i8_269 : i8), ^bb187
   ^bb187:  // pred: ^bb186
-    %549 = arith.trunci %98 : i256 to i64
-    %c0_i64_321 = arith.constant 0 : i64
-    %550 = arith.cmpi slt, %549, %c0_i64_321 : i64
-    %c84_i8_322 = arith.constant 84 : i8
-    cf.cond_br %550, ^bb1(%c84_i8_322 : i8), ^bb188
+    %497 = arith.trunci %88 : i256 to i64
+    %c0_i64_270 = arith.constant 0 : i64
+    %498 = arith.cmpi slt, %497, %c0_i64_270 : i64
+    %c84_i8_271 = arith.constant 84 : i8
+    cf.cond_br %498, ^bb1(%c84_i8_271 : i8), ^bb188
   ^bb188:  // pred: ^bb187
-    %551 = arith.addi %549, %c32_i64_49 : i64
-    %c0_i64_323 = arith.constant 0 : i64
-    %552 = arith.cmpi slt, %551, %c0_i64_323 : i64
-    %c84_i8_324 = arith.constant 84 : i8
-    cf.cond_br %552, ^bb1(%c84_i8_324 : i8), ^bb189
+    %499 = arith.addi %497, %c32_i64_38 : i64
+    %c0_i64_272 = arith.constant 0 : i64
+    %500 = arith.cmpi slt, %499, %c0_i64_272 : i64
+    %c84_i8_273 = arith.constant 84 : i8
+    cf.cond_br %500, ^bb1(%c84_i8_273 : i8), ^bb189
   ^bb189:  // pred: ^bb188
-    %c31_i64_325 = arith.constant 31 : i64
-    %c32_i64_326 = arith.constant 32 : i64
-    %553 = arith.addi %551, %c31_i64_325 : i64
-    %554 = arith.divui %553, %c32_i64_326 : i64
-    %c32_i64_327 = arith.constant 32 : i64
-    %555 = arith.muli %554, %c32_i64_327 : i64
-    %556 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_328 = arith.constant 31 : i64
-    %c32_i64_329 = arith.constant 32 : i64
-    %557 = arith.addi %556, %c31_i64_328 : i64
-    %558 = arith.divui %557, %c32_i64_329 : i64
-    %559 = arith.muli %558, %c32_i64_327 : i64
-    %560 = arith.cmpi ult, %559, %555 : i64
-    cf.cond_br %560, ^bb191, ^bb190
+    %c31_i64_274 = arith.constant 31 : i64
+    %c32_i64_275 = arith.constant 32 : i64
+    %501 = arith.addi %499, %c31_i64_274 : i64
+    %502 = arith.divui %501, %c32_i64_275 : i64
+    %c32_i64_276 = arith.constant 32 : i64
+    %503 = arith.muli %502, %c32_i64_276 : i64
+    %504 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_277 = arith.constant 31 : i64
+    %c32_i64_278 = arith.constant 32 : i64
+    %505 = arith.addi %504, %c31_i64_277 : i64
+    %506 = arith.divui %505, %c32_i64_278 : i64
+    %507 = arith.muli %506, %c32_i64_276 : i64
+    %508 = arith.cmpi ult, %507, %503 : i64
+    cf.cond_br %508, ^bb191, ^bb190
   ^bb190:  // 2 preds: ^bb189, ^bb193
     cf.br ^bb38
   ^bb191:  // pred: ^bb189
-    %c3_i64_330 = arith.constant 3 : i64
-    %c512_i64_331 = arith.constant 512 : i64
-    %561 = arith.muli %558, %558 : i64
-    %562 = arith.divui %561, %c512_i64_331 : i64
-    %563 = arith.muli %558, %c3_i64_330 : i64
-    %564 = arith.addi %562, %563 : i64
-    %c3_i64_332 = arith.constant 3 : i64
-    %c512_i64_333 = arith.constant 512 : i64
-    %565 = arith.muli %554, %554 : i64
-    %566 = arith.divui %565, %c512_i64_333 : i64
-    %567 = arith.muli %554, %c3_i64_332 : i64
-    %568 = arith.addi %566, %567 : i64
-    %569 = arith.subi %568, %564 : i64
-    %570 = llvm.load %arg1 : !llvm.ptr -> i64
-    %571 = arith.cmpi ult, %570, %569 : i64
-    scf.if %571 {
+    %c3_i64_279 = arith.constant 3 : i64
+    %c512_i64_280 = arith.constant 512 : i64
+    %509 = arith.muli %506, %506 : i64
+    %510 = arith.divui %509, %c512_i64_280 : i64
+    %511 = arith.muli %506, %c3_i64_279 : i64
+    %512 = arith.addi %510, %511 : i64
+    %c3_i64_281 = arith.constant 3 : i64
+    %c512_i64_282 = arith.constant 512 : i64
+    %513 = arith.muli %502, %502 : i64
+    %514 = arith.divui %513, %c512_i64_282 : i64
+    %515 = arith.muli %502, %c3_i64_281 : i64
+    %516 = arith.addi %514, %515 : i64
+    %517 = arith.subi %516, %512 : i64
+    %518 = llvm.load %arg1 : !llvm.ptr -> i64
+    %519 = arith.cmpi ult, %518, %517 : i64
+    scf.if %519 {
     } else {
-      %778 = arith.subi %570, %569 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %518, %517 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_334 = arith.constant 80 : i8
-    cf.cond_br %571, ^bb1(%c80_i8_334 : i8), ^bb192
+    %c80_i8_283 = arith.constant 80 : i8
+    cf.cond_br %519, ^bb1(%c80_i8_283 : i8), ^bb192
   ^bb192:  // pred: ^bb191
-    %572 = call @dora_fn_extend_memory(%arg0, %555) : (!llvm.ptr, i64) -> !llvm.ptr
-    %573 = llvm.getelementptr %572[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %574 = llvm.load %573 : !llvm.ptr -> i8
-    %c0_i8_335 = arith.constant 0 : i8
-    %575 = arith.cmpi ne, %574, %c0_i8_335 : i8
-    cf.cond_br %575, ^bb1(%574 : i8), ^bb193
+    %520 = call @dora_fn_extend_memory(%arg0, %503) : (!llvm.ptr, i64) -> !llvm.ptr
+    %521 = llvm.getelementptr %520[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %522 = llvm.load %521 : !llvm.ptr -> i8
+    %c0_i8_284 = arith.constant 0 : i8
+    %523 = arith.cmpi ne, %522, %c0_i8_284 : i8
+    cf.cond_br %523, ^bb1(%522 : i8), ^bb193
   ^bb193:  // pred: ^bb192
     cf.br ^bb190
   ^bb194:  // pred: ^bb57
     %c49152_i64 = arith.constant 49152 : i64
-    %576 = arith.cmpi ugt, %156, %c49152_i64 : i64
+    %524 = arith.cmpi ugt, %139, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %576, ^bb1(%c100_i8 : i8), ^bb195
+    cf.cond_br %524, ^bb1(%c100_i8 : i8), ^bb195
   ^bb195:  // pred: ^bb194
-    %c31_i64_336 = arith.constant 31 : i64
-    %c32_i64_337 = arith.constant 32 : i64
-    %577 = arith.addi %156, %c31_i64_336 : i64
-    %578 = arith.divui %577, %c32_i64_337 : i64
-    %c2_i64_338 = arith.constant 2 : i64
-    %579 = arith.muli %578, %c2_i64_338 : i64
+    %c31_i64_285 = arith.constant 31 : i64
+    %c32_i64_286 = arith.constant 32 : i64
+    %525 = arith.addi %139, %c31_i64_285 : i64
+    %526 = arith.divui %525, %c32_i64_286 : i64
+    %c2_i64_287 = arith.constant 2 : i64
+    %527 = arith.muli %526, %c2_i64_287 : i64
+    %528 = llvm.load %arg1 : !llvm.ptr -> i64
+    %529 = arith.cmpi ult, %528, %527 : i64
+    scf.if %529 {
+    } else {
+      %726 = arith.subi %528, %527 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
+    }
+    %c80_i8_288 = arith.constant 80 : i8
+    cf.cond_br %529, ^bb1(%c80_i8_288 : i8), ^bb196
+  ^bb196:  // pred: ^bb195
+    %c18446744073709551615_i256_289 = arith.constant 18446744073709551615 : i256
+    %530 = arith.cmpi sgt, %132, %c18446744073709551615_i256_289 : i256
+    %c84_i8_290 = arith.constant 84 : i8
+    cf.cond_br %530, ^bb1(%c84_i8_290 : i8), ^bb197
+  ^bb197:  // pred: ^bb196
+    %531 = arith.trunci %132 : i256 to i64
+    %c0_i64_291 = arith.constant 0 : i64
+    %532 = arith.cmpi slt, %531, %c0_i64_291 : i64
+    %c84_i8_292 = arith.constant 84 : i8
+    cf.cond_br %532, ^bb1(%c84_i8_292 : i8), ^bb198
+  ^bb198:  // pred: ^bb197
+    %533 = arith.addi %531, %139 : i64
+    %c0_i64_293 = arith.constant 0 : i64
+    %534 = arith.cmpi slt, %533, %c0_i64_293 : i64
+    %c84_i8_294 = arith.constant 84 : i8
+    cf.cond_br %534, ^bb1(%c84_i8_294 : i8), ^bb199
+  ^bb199:  // pred: ^bb198
+    %c31_i64_295 = arith.constant 31 : i64
+    %c32_i64_296 = arith.constant 32 : i64
+    %535 = arith.addi %533, %c31_i64_295 : i64
+    %536 = arith.divui %535, %c32_i64_296 : i64
+    %c32_i64_297 = arith.constant 32 : i64
+    %537 = arith.muli %536, %c32_i64_297 : i64
+    %538 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_298 = arith.constant 31 : i64
+    %c32_i64_299 = arith.constant 32 : i64
+    %539 = arith.addi %538, %c31_i64_298 : i64
+    %540 = arith.divui %539, %c32_i64_299 : i64
+    %541 = arith.muli %540, %c32_i64_297 : i64
+    %542 = arith.cmpi ult, %541, %537 : i64
+    cf.cond_br %542, ^bb201, ^bb200
+  ^bb200:  // 2 preds: ^bb199, ^bb203
+    cf.br ^bb58
+  ^bb201:  // pred: ^bb199
+    %c3_i64_300 = arith.constant 3 : i64
+    %c512_i64_301 = arith.constant 512 : i64
+    %543 = arith.muli %540, %540 : i64
+    %544 = arith.divui %543, %c512_i64_301 : i64
+    %545 = arith.muli %540, %c3_i64_300 : i64
+    %546 = arith.addi %544, %545 : i64
+    %c3_i64_302 = arith.constant 3 : i64
+    %c512_i64_303 = arith.constant 512 : i64
+    %547 = arith.muli %536, %536 : i64
+    %548 = arith.divui %547, %c512_i64_303 : i64
+    %549 = arith.muli %536, %c3_i64_302 : i64
+    %550 = arith.addi %548, %549 : i64
+    %551 = arith.subi %550, %546 : i64
+    %552 = llvm.load %arg1 : !llvm.ptr -> i64
+    %553 = arith.cmpi ult, %552, %551 : i64
+    scf.if %553 {
+    } else {
+      %726 = arith.subi %552, %551 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
+    }
+    %c80_i8_304 = arith.constant 80 : i8
+    cf.cond_br %553, ^bb1(%c80_i8_304 : i8), ^bb202
+  ^bb202:  // pred: ^bb201
+    %554 = call @dora_fn_extend_memory(%arg0, %537) : (!llvm.ptr, i64) -> !llvm.ptr
+    %555 = llvm.getelementptr %554[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %556 = llvm.load %555 : !llvm.ptr -> i8
+    %c0_i8_305 = arith.constant 0 : i8
+    %557 = arith.cmpi ne, %556, %c0_i8_305 : i8
+    cf.cond_br %557, ^bb1(%556 : i8), ^bb203
+  ^bb203:  // pred: ^bb202
+    cf.br ^bb200
+  ^bb204:  // pred: ^bb91
+    %c18446744073709551615_i256_306 = arith.constant 18446744073709551615 : i256
+    %558 = arith.cmpi sgt, %225, %c18446744073709551615_i256_306 : i256
+    %c84_i8_307 = arith.constant 84 : i8
+    cf.cond_br %558, ^bb1(%c84_i8_307 : i8), ^bb205
+  ^bb205:  // pred: ^bb204
+    %559 = arith.trunci %225 : i256 to i64
+    %c0_i64_308 = arith.constant 0 : i64
+    %560 = arith.cmpi slt, %559, %c0_i64_308 : i64
+    %c84_i8_309 = arith.constant 84 : i8
+    cf.cond_br %560, ^bb1(%c84_i8_309 : i8), ^bb206
+  ^bb206:  // pred: ^bb205
+    %561 = arith.addi %559, %236 : i64
+    %c0_i64_310 = arith.constant 0 : i64
+    %562 = arith.cmpi slt, %561, %c0_i64_310 : i64
+    %c84_i8_311 = arith.constant 84 : i8
+    cf.cond_br %562, ^bb1(%c84_i8_311 : i8), ^bb207
+  ^bb207:  // pred: ^bb206
+    %c31_i64_312 = arith.constant 31 : i64
+    %c32_i64_313 = arith.constant 32 : i64
+    %563 = arith.addi %561, %c31_i64_312 : i64
+    %564 = arith.divui %563, %c32_i64_313 : i64
+    %c32_i64_314 = arith.constant 32 : i64
+    %565 = arith.muli %564, %c32_i64_314 : i64
+    %566 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_315 = arith.constant 31 : i64
+    %c32_i64_316 = arith.constant 32 : i64
+    %567 = arith.addi %566, %c31_i64_315 : i64
+    %568 = arith.divui %567, %c32_i64_316 : i64
+    %569 = arith.muli %568, %c32_i64_314 : i64
+    %570 = arith.cmpi ult, %569, %565 : i64
+    cf.cond_br %570, ^bb209, ^bb208
+  ^bb208:  // 2 preds: ^bb207, ^bb211
+    cf.br ^bb92
+  ^bb209:  // pred: ^bb207
+    %c3_i64_317 = arith.constant 3 : i64
+    %c512_i64_318 = arith.constant 512 : i64
+    %571 = arith.muli %568, %568 : i64
+    %572 = arith.divui %571, %c512_i64_318 : i64
+    %573 = arith.muli %568, %c3_i64_317 : i64
+    %574 = arith.addi %572, %573 : i64
+    %c3_i64_319 = arith.constant 3 : i64
+    %c512_i64_320 = arith.constant 512 : i64
+    %575 = arith.muli %564, %564 : i64
+    %576 = arith.divui %575, %c512_i64_320 : i64
+    %577 = arith.muli %564, %c3_i64_319 : i64
+    %578 = arith.addi %576, %577 : i64
+    %579 = arith.subi %578, %574 : i64
     %580 = llvm.load %arg1 : !llvm.ptr -> i64
     %581 = arith.cmpi ult, %580, %579 : i64
     scf.if %581 {
     } else {
-      %778 = arith.subi %580, %579 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %580, %579 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_339 = arith.constant 80 : i8
-    cf.cond_br %581, ^bb1(%c80_i8_339 : i8), ^bb196
-  ^bb196:  // pred: ^bb195
-    %c18446744073709551615_i256_340 = arith.constant 18446744073709551615 : i256
-    %582 = arith.cmpi sgt, %148, %c18446744073709551615_i256_340 : i256
-    %c84_i8_341 = arith.constant 84 : i8
-    cf.cond_br %582, ^bb1(%c84_i8_341 : i8), ^bb197
-  ^bb197:  // pred: ^bb196
-    %583 = arith.trunci %148 : i256 to i64
-    %c0_i64_342 = arith.constant 0 : i64
-    %584 = arith.cmpi slt, %583, %c0_i64_342 : i64
-    %c84_i8_343 = arith.constant 84 : i8
-    cf.cond_br %584, ^bb1(%c84_i8_343 : i8), ^bb198
-  ^bb198:  // pred: ^bb197
-    %585 = arith.addi %583, %156 : i64
-    %c0_i64_344 = arith.constant 0 : i64
-    %586 = arith.cmpi slt, %585, %c0_i64_344 : i64
-    %c84_i8_345 = arith.constant 84 : i8
-    cf.cond_br %586, ^bb1(%c84_i8_345 : i8), ^bb199
-  ^bb199:  // pred: ^bb198
-    %c31_i64_346 = arith.constant 31 : i64
-    %c32_i64_347 = arith.constant 32 : i64
-    %587 = arith.addi %585, %c31_i64_346 : i64
-    %588 = arith.divui %587, %c32_i64_347 : i64
-    %c32_i64_348 = arith.constant 32 : i64
-    %589 = arith.muli %588, %c32_i64_348 : i64
-    %590 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_349 = arith.constant 31 : i64
-    %c32_i64_350 = arith.constant 32 : i64
-    %591 = arith.addi %590, %c31_i64_349 : i64
-    %592 = arith.divui %591, %c32_i64_350 : i64
-    %593 = arith.muli %592, %c32_i64_348 : i64
-    %594 = arith.cmpi ult, %593, %589 : i64
-    cf.cond_br %594, ^bb201, ^bb200
-  ^bb200:  // 2 preds: ^bb199, ^bb203
-    cf.br ^bb58
-  ^bb201:  // pred: ^bb199
-    %c3_i64_351 = arith.constant 3 : i64
-    %c512_i64_352 = arith.constant 512 : i64
-    %595 = arith.muli %592, %592 : i64
-    %596 = arith.divui %595, %c512_i64_352 : i64
-    %597 = arith.muli %592, %c3_i64_351 : i64
-    %598 = arith.addi %596, %597 : i64
-    %c3_i64_353 = arith.constant 3 : i64
-    %c512_i64_354 = arith.constant 512 : i64
-    %599 = arith.muli %588, %588 : i64
-    %600 = arith.divui %599, %c512_i64_354 : i64
-    %601 = arith.muli %588, %c3_i64_353 : i64
-    %602 = arith.addi %600, %601 : i64
-    %603 = arith.subi %602, %598 : i64
-    %604 = llvm.load %arg1 : !llvm.ptr -> i64
-    %605 = arith.cmpi ult, %604, %603 : i64
-    scf.if %605 {
-    } else {
-      %778 = arith.subi %604, %603 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
-    }
-    %c80_i8_355 = arith.constant 80 : i8
-    cf.cond_br %605, ^bb1(%c80_i8_355 : i8), ^bb202
-  ^bb202:  // pred: ^bb201
-    %606 = call @dora_fn_extend_memory(%arg0, %589) : (!llvm.ptr, i64) -> !llvm.ptr
-    %607 = llvm.getelementptr %606[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %608 = llvm.load %607 : !llvm.ptr -> i8
-    %c0_i8_356 = arith.constant 0 : i8
-    %609 = arith.cmpi ne, %608, %c0_i8_356 : i8
-    cf.cond_br %609, ^bb1(%608 : i8), ^bb203
-  ^bb203:  // pred: ^bb202
-    cf.br ^bb200
-  ^bb204:  // pred: ^bb91
-    %c18446744073709551615_i256_357 = arith.constant 18446744073709551615 : i256
-    %610 = arith.cmpi sgt, %253, %c18446744073709551615_i256_357 : i256
-    %c84_i8_358 = arith.constant 84 : i8
-    cf.cond_br %610, ^bb1(%c84_i8_358 : i8), ^bb205
-  ^bb205:  // pred: ^bb204
-    %611 = arith.trunci %253 : i256 to i64
-    %c0_i64_359 = arith.constant 0 : i64
-    %612 = arith.cmpi slt, %611, %c0_i64_359 : i64
-    %c84_i8_360 = arith.constant 84 : i8
-    cf.cond_br %612, ^bb1(%c84_i8_360 : i8), ^bb206
-  ^bb206:  // pred: ^bb205
-    %613 = arith.addi %611, %267 : i64
-    %c0_i64_361 = arith.constant 0 : i64
-    %614 = arith.cmpi slt, %613, %c0_i64_361 : i64
-    %c84_i8_362 = arith.constant 84 : i8
-    cf.cond_br %614, ^bb1(%c84_i8_362 : i8), ^bb207
-  ^bb207:  // pred: ^bb206
-    %c31_i64_363 = arith.constant 31 : i64
-    %c32_i64_364 = arith.constant 32 : i64
-    %615 = arith.addi %613, %c31_i64_363 : i64
-    %616 = arith.divui %615, %c32_i64_364 : i64
-    %c32_i64_365 = arith.constant 32 : i64
-    %617 = arith.muli %616, %c32_i64_365 : i64
-    %618 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_366 = arith.constant 31 : i64
-    %c32_i64_367 = arith.constant 32 : i64
-    %619 = arith.addi %618, %c31_i64_366 : i64
-    %620 = arith.divui %619, %c32_i64_367 : i64
-    %621 = arith.muli %620, %c32_i64_365 : i64
-    %622 = arith.cmpi ult, %621, %617 : i64
-    cf.cond_br %622, ^bb209, ^bb208
-  ^bb208:  // 2 preds: ^bb207, ^bb211
-    cf.br ^bb92
-  ^bb209:  // pred: ^bb207
-    %c3_i64_368 = arith.constant 3 : i64
-    %c512_i64_369 = arith.constant 512 : i64
-    %623 = arith.muli %620, %620 : i64
-    %624 = arith.divui %623, %c512_i64_369 : i64
-    %625 = arith.muli %620, %c3_i64_368 : i64
-    %626 = arith.addi %624, %625 : i64
-    %c3_i64_370 = arith.constant 3 : i64
-    %c512_i64_371 = arith.constant 512 : i64
-    %627 = arith.muli %616, %616 : i64
-    %628 = arith.divui %627, %c512_i64_371 : i64
-    %629 = arith.muli %616, %c3_i64_370 : i64
-    %630 = arith.addi %628, %629 : i64
-    %631 = arith.subi %630, %626 : i64
-    %632 = llvm.load %arg1 : !llvm.ptr -> i64
-    %633 = arith.cmpi ult, %632, %631 : i64
-    scf.if %633 {
-    } else {
-      %778 = arith.subi %632, %631 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
-    }
-    %c80_i8_372 = arith.constant 80 : i8
-    cf.cond_br %633, ^bb1(%c80_i8_372 : i8), ^bb210
+    %c80_i8_321 = arith.constant 80 : i8
+    cf.cond_br %581, ^bb1(%c80_i8_321 : i8), ^bb210
   ^bb210:  // pred: ^bb209
-    %634 = call @dora_fn_extend_memory(%arg0, %617) : (!llvm.ptr, i64) -> !llvm.ptr
-    %635 = llvm.getelementptr %634[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %636 = llvm.load %635 : !llvm.ptr -> i8
-    %c0_i8_373 = arith.constant 0 : i8
-    %637 = arith.cmpi ne, %636, %c0_i8_373 : i8
-    cf.cond_br %637, ^bb1(%636 : i8), ^bb211
+    %582 = call @dora_fn_extend_memory(%arg0, %565) : (!llvm.ptr, i64) -> !llvm.ptr
+    %583 = llvm.getelementptr %582[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %584 = llvm.load %583 : !llvm.ptr -> i8
+    %c0_i8_322 = arith.constant 0 : i8
+    %585 = arith.cmpi ne, %584, %c0_i8_322 : i8
+    cf.cond_br %585, ^bb1(%584 : i8), ^bb211
   ^bb211:  // pred: ^bb210
     cf.br ^bb208
   ^bb212:  // pred: ^bb94
-    %c18446744073709551615_i256_374 = arith.constant 18446744073709551615 : i256
-    %638 = arith.cmpi sgt, %261, %c18446744073709551615_i256_374 : i256
-    %c84_i8_375 = arith.constant 84 : i8
-    cf.cond_br %638, ^bb1(%c84_i8_375 : i8), ^bb213
+    %c18446744073709551615_i256_323 = arith.constant 18446744073709551615 : i256
+    %586 = arith.cmpi sgt, %231, %c18446744073709551615_i256_323 : i256
+    %c84_i8_324 = arith.constant 84 : i8
+    cf.cond_br %586, ^bb1(%c84_i8_324 : i8), ^bb213
   ^bb213:  // pred: ^bb212
-    %639 = arith.trunci %261 : i256 to i64
-    %c0_i64_376 = arith.constant 0 : i64
-    %640 = arith.cmpi slt, %639, %c0_i64_376 : i64
-    %c84_i8_377 = arith.constant 84 : i8
-    cf.cond_br %640, ^bb1(%c84_i8_377 : i8), ^bb214
+    %587 = arith.trunci %231 : i256 to i64
+    %c0_i64_325 = arith.constant 0 : i64
+    %588 = arith.cmpi slt, %587, %c0_i64_325 : i64
+    %c84_i8_326 = arith.constant 84 : i8
+    cf.cond_br %588, ^bb1(%c84_i8_326 : i8), ^bb214
   ^bb214:  // pred: ^bb213
-    %641 = arith.addi %639, %271 : i64
-    %c0_i64_378 = arith.constant 0 : i64
-    %642 = arith.cmpi slt, %641, %c0_i64_378 : i64
-    %c84_i8_379 = arith.constant 84 : i8
-    cf.cond_br %642, ^bb1(%c84_i8_379 : i8), ^bb215
+    %589 = arith.addi %587, %240 : i64
+    %c0_i64_327 = arith.constant 0 : i64
+    %590 = arith.cmpi slt, %589, %c0_i64_327 : i64
+    %c84_i8_328 = arith.constant 84 : i8
+    cf.cond_br %590, ^bb1(%c84_i8_328 : i8), ^bb215
   ^bb215:  // pred: ^bb214
-    %c31_i64_380 = arith.constant 31 : i64
-    %c32_i64_381 = arith.constant 32 : i64
-    %643 = arith.addi %641, %c31_i64_380 : i64
-    %644 = arith.divui %643, %c32_i64_381 : i64
-    %c32_i64_382 = arith.constant 32 : i64
-    %645 = arith.muli %644, %c32_i64_382 : i64
-    %646 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_383 = arith.constant 31 : i64
-    %c32_i64_384 = arith.constant 32 : i64
-    %647 = arith.addi %646, %c31_i64_383 : i64
-    %648 = arith.divui %647, %c32_i64_384 : i64
-    %649 = arith.muli %648, %c32_i64_382 : i64
-    %650 = arith.cmpi ult, %649, %645 : i64
-    cf.cond_br %650, ^bb217, ^bb216
+    %c31_i64_329 = arith.constant 31 : i64
+    %c32_i64_330 = arith.constant 32 : i64
+    %591 = arith.addi %589, %c31_i64_329 : i64
+    %592 = arith.divui %591, %c32_i64_330 : i64
+    %c32_i64_331 = arith.constant 32 : i64
+    %593 = arith.muli %592, %c32_i64_331 : i64
+    %594 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_332 = arith.constant 31 : i64
+    %c32_i64_333 = arith.constant 32 : i64
+    %595 = arith.addi %594, %c31_i64_332 : i64
+    %596 = arith.divui %595, %c32_i64_333 : i64
+    %597 = arith.muli %596, %c32_i64_331 : i64
+    %598 = arith.cmpi ult, %597, %593 : i64
+    cf.cond_br %598, ^bb217, ^bb216
   ^bb216:  // 2 preds: ^bb215, ^bb219
     cf.br ^bb95
   ^bb217:  // pred: ^bb215
-    %c3_i64_385 = arith.constant 3 : i64
-    %c512_i64_386 = arith.constant 512 : i64
-    %651 = arith.muli %648, %648 : i64
-    %652 = arith.divui %651, %c512_i64_386 : i64
-    %653 = arith.muli %648, %c3_i64_385 : i64
-    %654 = arith.addi %652, %653 : i64
-    %c3_i64_387 = arith.constant 3 : i64
-    %c512_i64_388 = arith.constant 512 : i64
-    %655 = arith.muli %644, %644 : i64
-    %656 = arith.divui %655, %c512_i64_388 : i64
-    %657 = arith.muli %644, %c3_i64_387 : i64
-    %658 = arith.addi %656, %657 : i64
-    %659 = arith.subi %658, %654 : i64
-    %660 = llvm.load %arg1 : !llvm.ptr -> i64
-    %661 = arith.cmpi ult, %660, %659 : i64
-    scf.if %661 {
+    %c3_i64_334 = arith.constant 3 : i64
+    %c512_i64_335 = arith.constant 512 : i64
+    %599 = arith.muli %596, %596 : i64
+    %600 = arith.divui %599, %c512_i64_335 : i64
+    %601 = arith.muli %596, %c3_i64_334 : i64
+    %602 = arith.addi %600, %601 : i64
+    %c3_i64_336 = arith.constant 3 : i64
+    %c512_i64_337 = arith.constant 512 : i64
+    %603 = arith.muli %592, %592 : i64
+    %604 = arith.divui %603, %c512_i64_337 : i64
+    %605 = arith.muli %592, %c3_i64_336 : i64
+    %606 = arith.addi %604, %605 : i64
+    %607 = arith.subi %606, %602 : i64
+    %608 = llvm.load %arg1 : !llvm.ptr -> i64
+    %609 = arith.cmpi ult, %608, %607 : i64
+    scf.if %609 {
     } else {
-      %778 = arith.subi %660, %659 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %608, %607 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_389 = arith.constant 80 : i8
-    cf.cond_br %661, ^bb1(%c80_i8_389 : i8), ^bb218
+    %c80_i8_338 = arith.constant 80 : i8
+    cf.cond_br %609, ^bb1(%c80_i8_338 : i8), ^bb218
   ^bb218:  // pred: ^bb217
-    %662 = call @dora_fn_extend_memory(%arg0, %645) : (!llvm.ptr, i64) -> !llvm.ptr
-    %663 = llvm.getelementptr %662[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %664 = llvm.load %663 : !llvm.ptr -> i8
-    %c0_i8_390 = arith.constant 0 : i8
-    %665 = arith.cmpi ne, %664, %c0_i8_390 : i8
-    cf.cond_br %665, ^bb1(%664 : i8), ^bb219
+    %610 = call @dora_fn_extend_memory(%arg0, %593) : (!llvm.ptr, i64) -> !llvm.ptr
+    %611 = llvm.getelementptr %610[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %612 = llvm.load %611 : !llvm.ptr -> i8
+    %c0_i8_339 = arith.constant 0 : i8
+    %613 = arith.cmpi ne, %612, %c0_i8_339 : i8
+    cf.cond_br %613, ^bb1(%612 : i8), ^bb219
   ^bb219:  // pred: ^bb218
     cf.br ^bb216
   ^bb220:  // pred: ^bb117
-    %c18446744073709551615_i256_391 = arith.constant 18446744073709551615 : i256
-    %666 = arith.cmpi sgt, %341, %c18446744073709551615_i256_391 : i256
-    %c84_i8_392 = arith.constant 84 : i8
-    cf.cond_br %666, ^bb1(%c84_i8_392 : i8), ^bb221
+    %c18446744073709551615_i256_340 = arith.constant 18446744073709551615 : i256
+    %614 = arith.cmpi sgt, %304, %c18446744073709551615_i256_340 : i256
+    %c84_i8_341 = arith.constant 84 : i8
+    cf.cond_br %614, ^bb1(%c84_i8_341 : i8), ^bb221
   ^bb221:  // pred: ^bb220
-    %667 = arith.trunci %341 : i256 to i64
-    %c0_i64_393 = arith.constant 0 : i64
-    %668 = arith.cmpi slt, %667, %c0_i64_393 : i64
-    %c84_i8_394 = arith.constant 84 : i8
-    cf.cond_br %668, ^bb1(%c84_i8_394 : i8), ^bb222
+    %615 = arith.trunci %304 : i256 to i64
+    %c0_i64_342 = arith.constant 0 : i64
+    %616 = arith.cmpi slt, %615, %c0_i64_342 : i64
+    %c84_i8_343 = arith.constant 84 : i8
+    cf.cond_br %616, ^bb1(%c84_i8_343 : i8), ^bb222
   ^bb222:  // pred: ^bb221
-    %669 = arith.addi %667, %c32_i64_189 : i64
-    %c0_i64_395 = arith.constant 0 : i64
-    %670 = arith.cmpi slt, %669, %c0_i64_395 : i64
-    %c84_i8_396 = arith.constant 84 : i8
-    cf.cond_br %670, ^bb1(%c84_i8_396 : i8), ^bb223
+    %617 = arith.addi %615, %c32_i64_152 : i64
+    %c0_i64_344 = arith.constant 0 : i64
+    %618 = arith.cmpi slt, %617, %c0_i64_344 : i64
+    %c84_i8_345 = arith.constant 84 : i8
+    cf.cond_br %618, ^bb1(%c84_i8_345 : i8), ^bb223
   ^bb223:  // pred: ^bb222
-    %c31_i64_397 = arith.constant 31 : i64
-    %c32_i64_398 = arith.constant 32 : i64
-    %671 = arith.addi %669, %c31_i64_397 : i64
-    %672 = arith.divui %671, %c32_i64_398 : i64
-    %c32_i64_399 = arith.constant 32 : i64
-    %673 = arith.muli %672, %c32_i64_399 : i64
-    %674 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_400 = arith.constant 31 : i64
-    %c32_i64_401 = arith.constant 32 : i64
-    %675 = arith.addi %674, %c31_i64_400 : i64
-    %676 = arith.divui %675, %c32_i64_401 : i64
-    %677 = arith.muli %676, %c32_i64_399 : i64
-    %678 = arith.cmpi ult, %677, %673 : i64
-    cf.cond_br %678, ^bb225, ^bb224
+    %c31_i64_346 = arith.constant 31 : i64
+    %c32_i64_347 = arith.constant 32 : i64
+    %619 = arith.addi %617, %c31_i64_346 : i64
+    %620 = arith.divui %619, %c32_i64_347 : i64
+    %c32_i64_348 = arith.constant 32 : i64
+    %621 = arith.muli %620, %c32_i64_348 : i64
+    %622 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_349 = arith.constant 31 : i64
+    %c32_i64_350 = arith.constant 32 : i64
+    %623 = arith.addi %622, %c31_i64_349 : i64
+    %624 = arith.divui %623, %c32_i64_350 : i64
+    %625 = arith.muli %624, %c32_i64_348 : i64
+    %626 = arith.cmpi ult, %625, %621 : i64
+    cf.cond_br %626, ^bb225, ^bb224
   ^bb224:  // 2 preds: ^bb223, ^bb227
     cf.br ^bb118
   ^bb225:  // pred: ^bb223
-    %c3_i64_402 = arith.constant 3 : i64
-    %c512_i64_403 = arith.constant 512 : i64
-    %679 = arith.muli %676, %676 : i64
-    %680 = arith.divui %679, %c512_i64_403 : i64
-    %681 = arith.muli %676, %c3_i64_402 : i64
-    %682 = arith.addi %680, %681 : i64
-    %c3_i64_404 = arith.constant 3 : i64
-    %c512_i64_405 = arith.constant 512 : i64
-    %683 = arith.muli %672, %672 : i64
-    %684 = arith.divui %683, %c512_i64_405 : i64
-    %685 = arith.muli %672, %c3_i64_404 : i64
-    %686 = arith.addi %684, %685 : i64
-    %687 = arith.subi %686, %682 : i64
-    %688 = llvm.load %arg1 : !llvm.ptr -> i64
-    %689 = arith.cmpi ult, %688, %687 : i64
-    scf.if %689 {
+    %c3_i64_351 = arith.constant 3 : i64
+    %c512_i64_352 = arith.constant 512 : i64
+    %627 = arith.muli %624, %624 : i64
+    %628 = arith.divui %627, %c512_i64_352 : i64
+    %629 = arith.muli %624, %c3_i64_351 : i64
+    %630 = arith.addi %628, %629 : i64
+    %c3_i64_353 = arith.constant 3 : i64
+    %c512_i64_354 = arith.constant 512 : i64
+    %631 = arith.muli %620, %620 : i64
+    %632 = arith.divui %631, %c512_i64_354 : i64
+    %633 = arith.muli %620, %c3_i64_353 : i64
+    %634 = arith.addi %632, %633 : i64
+    %635 = arith.subi %634, %630 : i64
+    %636 = llvm.load %arg1 : !llvm.ptr -> i64
+    %637 = arith.cmpi ult, %636, %635 : i64
+    scf.if %637 {
     } else {
-      %778 = arith.subi %688, %687 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %636, %635 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_406 = arith.constant 80 : i8
-    cf.cond_br %689, ^bb1(%c80_i8_406 : i8), ^bb226
+    %c80_i8_355 = arith.constant 80 : i8
+    cf.cond_br %637, ^bb1(%c80_i8_355 : i8), ^bb226
   ^bb226:  // pred: ^bb225
-    %690 = call @dora_fn_extend_memory(%arg0, %673) : (!llvm.ptr, i64) -> !llvm.ptr
-    %691 = llvm.getelementptr %690[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %692 = llvm.load %691 : !llvm.ptr -> i8
-    %c0_i8_407 = arith.constant 0 : i8
-    %693 = arith.cmpi ne, %692, %c0_i8_407 : i8
-    cf.cond_br %693, ^bb1(%692 : i8), ^bb227
+    %638 = call @dora_fn_extend_memory(%arg0, %621) : (!llvm.ptr, i64) -> !llvm.ptr
+    %639 = llvm.getelementptr %638[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %640 = llvm.load %639 : !llvm.ptr -> i8
+    %c0_i8_356 = arith.constant 0 : i8
+    %641 = arith.cmpi ne, %640, %c0_i8_356 : i8
+    cf.cond_br %641, ^bb1(%640 : i8), ^bb227
   ^bb227:  // pred: ^bb226
     cf.br ^bb224
   ^bb228:  // pred: ^bb130
-    %c18446744073709551615_i256_408 = arith.constant 18446744073709551615 : i256
-    %694 = arith.cmpi sgt, %378, %c18446744073709551615_i256_408 : i256
-    %c84_i8_409 = arith.constant 84 : i8
-    cf.cond_br %694, ^bb1(%c84_i8_409 : i8), ^bb229
+    %c18446744073709551615_i256_357 = arith.constant 18446744073709551615 : i256
+    %642 = arith.cmpi sgt, %337, %c18446744073709551615_i256_357 : i256
+    %c84_i8_358 = arith.constant 84 : i8
+    cf.cond_br %642, ^bb1(%c84_i8_358 : i8), ^bb229
   ^bb229:  // pred: ^bb228
-    %695 = arith.trunci %378 : i256 to i64
-    %c0_i64_410 = arith.constant 0 : i64
-    %696 = arith.cmpi slt, %695, %c0_i64_410 : i64
-    %c84_i8_411 = arith.constant 84 : i8
-    cf.cond_br %696, ^bb1(%c84_i8_411 : i8), ^bb230
+    %643 = arith.trunci %337 : i256 to i64
+    %c0_i64_359 = arith.constant 0 : i64
+    %644 = arith.cmpi slt, %643, %c0_i64_359 : i64
+    %c84_i8_360 = arith.constant 84 : i8
+    cf.cond_br %644, ^bb1(%c84_i8_360 : i8), ^bb230
   ^bb230:  // pred: ^bb229
-    %697 = arith.addi %695, %c32_i64_213 : i64
-    %c0_i64_412 = arith.constant 0 : i64
-    %698 = arith.cmpi slt, %697, %c0_i64_412 : i64
-    %c84_i8_413 = arith.constant 84 : i8
-    cf.cond_br %698, ^bb1(%c84_i8_413 : i8), ^bb231
+    %645 = arith.addi %643, %c32_i64_172 : i64
+    %c0_i64_361 = arith.constant 0 : i64
+    %646 = arith.cmpi slt, %645, %c0_i64_361 : i64
+    %c84_i8_362 = arith.constant 84 : i8
+    cf.cond_br %646, ^bb1(%c84_i8_362 : i8), ^bb231
   ^bb231:  // pred: ^bb230
-    %c31_i64_414 = arith.constant 31 : i64
-    %c32_i64_415 = arith.constant 32 : i64
-    %699 = arith.addi %697, %c31_i64_414 : i64
-    %700 = arith.divui %699, %c32_i64_415 : i64
-    %c32_i64_416 = arith.constant 32 : i64
-    %701 = arith.muli %700, %c32_i64_416 : i64
-    %702 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_417 = arith.constant 31 : i64
-    %c32_i64_418 = arith.constant 32 : i64
-    %703 = arith.addi %702, %c31_i64_417 : i64
-    %704 = arith.divui %703, %c32_i64_418 : i64
-    %705 = arith.muli %704, %c32_i64_416 : i64
-    %706 = arith.cmpi ult, %705, %701 : i64
-    cf.cond_br %706, ^bb233, ^bb232
+    %c31_i64_363 = arith.constant 31 : i64
+    %c32_i64_364 = arith.constant 32 : i64
+    %647 = arith.addi %645, %c31_i64_363 : i64
+    %648 = arith.divui %647, %c32_i64_364 : i64
+    %c32_i64_365 = arith.constant 32 : i64
+    %649 = arith.muli %648, %c32_i64_365 : i64
+    %650 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_366 = arith.constant 31 : i64
+    %c32_i64_367 = arith.constant 32 : i64
+    %651 = arith.addi %650, %c31_i64_366 : i64
+    %652 = arith.divui %651, %c32_i64_367 : i64
+    %653 = arith.muli %652, %c32_i64_365 : i64
+    %654 = arith.cmpi ult, %653, %649 : i64
+    cf.cond_br %654, ^bb233, ^bb232
   ^bb232:  // 2 preds: ^bb231, ^bb235
     cf.br ^bb131
   ^bb233:  // pred: ^bb231
-    %c3_i64_419 = arith.constant 3 : i64
-    %c512_i64_420 = arith.constant 512 : i64
-    %707 = arith.muli %704, %704 : i64
-    %708 = arith.divui %707, %c512_i64_420 : i64
-    %709 = arith.muli %704, %c3_i64_419 : i64
-    %710 = arith.addi %708, %709 : i64
-    %c3_i64_421 = arith.constant 3 : i64
-    %c512_i64_422 = arith.constant 512 : i64
-    %711 = arith.muli %700, %700 : i64
-    %712 = arith.divui %711, %c512_i64_422 : i64
-    %713 = arith.muli %700, %c3_i64_421 : i64
-    %714 = arith.addi %712, %713 : i64
-    %715 = arith.subi %714, %710 : i64
-    %716 = llvm.load %arg1 : !llvm.ptr -> i64
-    %717 = arith.cmpi ult, %716, %715 : i64
-    scf.if %717 {
+    %c3_i64_368 = arith.constant 3 : i64
+    %c512_i64_369 = arith.constant 512 : i64
+    %655 = arith.muli %652, %652 : i64
+    %656 = arith.divui %655, %c512_i64_369 : i64
+    %657 = arith.muli %652, %c3_i64_368 : i64
+    %658 = arith.addi %656, %657 : i64
+    %c3_i64_370 = arith.constant 3 : i64
+    %c512_i64_371 = arith.constant 512 : i64
+    %659 = arith.muli %648, %648 : i64
+    %660 = arith.divui %659, %c512_i64_371 : i64
+    %661 = arith.muli %648, %c3_i64_370 : i64
+    %662 = arith.addi %660, %661 : i64
+    %663 = arith.subi %662, %658 : i64
+    %664 = llvm.load %arg1 : !llvm.ptr -> i64
+    %665 = arith.cmpi ult, %664, %663 : i64
+    scf.if %665 {
     } else {
-      %778 = arith.subi %716, %715 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %664, %663 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_423 = arith.constant 80 : i8
-    cf.cond_br %717, ^bb1(%c80_i8_423 : i8), ^bb234
+    %c80_i8_372 = arith.constant 80 : i8
+    cf.cond_br %665, ^bb1(%c80_i8_372 : i8), ^bb234
   ^bb234:  // pred: ^bb233
-    %718 = call @dora_fn_extend_memory(%arg0, %701) : (!llvm.ptr, i64) -> !llvm.ptr
-    %719 = llvm.getelementptr %718[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %720 = llvm.load %719 : !llvm.ptr -> i8
-    %c0_i8_424 = arith.constant 0 : i8
-    %721 = arith.cmpi ne, %720, %c0_i8_424 : i8
-    cf.cond_br %721, ^bb1(%720 : i8), ^bb235
+    %666 = call @dora_fn_extend_memory(%arg0, %649) : (!llvm.ptr, i64) -> !llvm.ptr
+    %667 = llvm.getelementptr %666[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %668 = llvm.load %667 : !llvm.ptr -> i8
+    %c0_i8_373 = arith.constant 0 : i8
+    %669 = arith.cmpi ne, %668, %c0_i8_373 : i8
+    cf.cond_br %669, ^bb1(%668 : i8), ^bb235
   ^bb235:  // pred: ^bb234
     cf.br ^bb232
   ^bb236:  // pred: ^bb143
-    %c18446744073709551615_i256_425 = arith.constant 18446744073709551615 : i256
-    %722 = arith.cmpi sgt, %415, %c18446744073709551615_i256_425 : i256
-    %c84_i8_426 = arith.constant 84 : i8
-    cf.cond_br %722, ^bb1(%c84_i8_426 : i8), ^bb237
+    %c18446744073709551615_i256_374 = arith.constant 18446744073709551615 : i256
+    %670 = arith.cmpi sgt, %370, %c18446744073709551615_i256_374 : i256
+    %c84_i8_375 = arith.constant 84 : i8
+    cf.cond_br %670, ^bb1(%c84_i8_375 : i8), ^bb237
   ^bb237:  // pred: ^bb236
-    %723 = arith.trunci %415 : i256 to i64
-    %c0_i64_427 = arith.constant 0 : i64
-    %724 = arith.cmpi slt, %723, %c0_i64_427 : i64
-    %c84_i8_428 = arith.constant 84 : i8
-    cf.cond_br %724, ^bb1(%c84_i8_428 : i8), ^bb238
+    %671 = arith.trunci %370 : i256 to i64
+    %c0_i64_376 = arith.constant 0 : i64
+    %672 = arith.cmpi slt, %671, %c0_i64_376 : i64
+    %c84_i8_377 = arith.constant 84 : i8
+    cf.cond_br %672, ^bb1(%c84_i8_377 : i8), ^bb238
   ^bb238:  // pred: ^bb237
-    %725 = arith.addi %723, %c32_i64_237 : i64
-    %c0_i64_429 = arith.constant 0 : i64
-    %726 = arith.cmpi slt, %725, %c0_i64_429 : i64
-    %c84_i8_430 = arith.constant 84 : i8
-    cf.cond_br %726, ^bb1(%c84_i8_430 : i8), ^bb239
+    %673 = arith.addi %671, %c32_i64_192 : i64
+    %c0_i64_378 = arith.constant 0 : i64
+    %674 = arith.cmpi slt, %673, %c0_i64_378 : i64
+    %c84_i8_379 = arith.constant 84 : i8
+    cf.cond_br %674, ^bb1(%c84_i8_379 : i8), ^bb239
   ^bb239:  // pred: ^bb238
-    %c31_i64_431 = arith.constant 31 : i64
-    %c32_i64_432 = arith.constant 32 : i64
-    %727 = arith.addi %725, %c31_i64_431 : i64
-    %728 = arith.divui %727, %c32_i64_432 : i64
-    %c32_i64_433 = arith.constant 32 : i64
-    %729 = arith.muli %728, %c32_i64_433 : i64
-    %730 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_434 = arith.constant 31 : i64
-    %c32_i64_435 = arith.constant 32 : i64
-    %731 = arith.addi %730, %c31_i64_434 : i64
-    %732 = arith.divui %731, %c32_i64_435 : i64
-    %733 = arith.muli %732, %c32_i64_433 : i64
-    %734 = arith.cmpi ult, %733, %729 : i64
-    cf.cond_br %734, ^bb241, ^bb240
+    %c31_i64_380 = arith.constant 31 : i64
+    %c32_i64_381 = arith.constant 32 : i64
+    %675 = arith.addi %673, %c31_i64_380 : i64
+    %676 = arith.divui %675, %c32_i64_381 : i64
+    %c32_i64_382 = arith.constant 32 : i64
+    %677 = arith.muli %676, %c32_i64_382 : i64
+    %678 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_383 = arith.constant 31 : i64
+    %c32_i64_384 = arith.constant 32 : i64
+    %679 = arith.addi %678, %c31_i64_383 : i64
+    %680 = arith.divui %679, %c32_i64_384 : i64
+    %681 = arith.muli %680, %c32_i64_382 : i64
+    %682 = arith.cmpi ult, %681, %677 : i64
+    cf.cond_br %682, ^bb241, ^bb240
   ^bb240:  // 2 preds: ^bb239, ^bb243
     cf.br ^bb144
   ^bb241:  // pred: ^bb239
-    %c3_i64_436 = arith.constant 3 : i64
-    %c512_i64_437 = arith.constant 512 : i64
-    %735 = arith.muli %732, %732 : i64
-    %736 = arith.divui %735, %c512_i64_437 : i64
-    %737 = arith.muli %732, %c3_i64_436 : i64
-    %738 = arith.addi %736, %737 : i64
-    %c3_i64_438 = arith.constant 3 : i64
-    %c512_i64_439 = arith.constant 512 : i64
-    %739 = arith.muli %728, %728 : i64
-    %740 = arith.divui %739, %c512_i64_439 : i64
-    %741 = arith.muli %728, %c3_i64_438 : i64
-    %742 = arith.addi %740, %741 : i64
-    %743 = arith.subi %742, %738 : i64
-    %744 = llvm.load %arg1 : !llvm.ptr -> i64
-    %745 = arith.cmpi ult, %744, %743 : i64
-    scf.if %745 {
+    %c3_i64_385 = arith.constant 3 : i64
+    %c512_i64_386 = arith.constant 512 : i64
+    %683 = arith.muli %680, %680 : i64
+    %684 = arith.divui %683, %c512_i64_386 : i64
+    %685 = arith.muli %680, %c3_i64_385 : i64
+    %686 = arith.addi %684, %685 : i64
+    %c3_i64_387 = arith.constant 3 : i64
+    %c512_i64_388 = arith.constant 512 : i64
+    %687 = arith.muli %676, %676 : i64
+    %688 = arith.divui %687, %c512_i64_388 : i64
+    %689 = arith.muli %676, %c3_i64_387 : i64
+    %690 = arith.addi %688, %689 : i64
+    %691 = arith.subi %690, %686 : i64
+    %692 = llvm.load %arg1 : !llvm.ptr -> i64
+    %693 = arith.cmpi ult, %692, %691 : i64
+    scf.if %693 {
     } else {
-      %778 = arith.subi %744, %743 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %692, %691 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_440 = arith.constant 80 : i8
-    cf.cond_br %745, ^bb1(%c80_i8_440 : i8), ^bb242
+    %c80_i8_389 = arith.constant 80 : i8
+    cf.cond_br %693, ^bb1(%c80_i8_389 : i8), ^bb242
   ^bb242:  // pred: ^bb241
-    %746 = call @dora_fn_extend_memory(%arg0, %729) : (!llvm.ptr, i64) -> !llvm.ptr
-    %747 = llvm.getelementptr %746[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %748 = llvm.load %747 : !llvm.ptr -> i8
-    %c0_i8_441 = arith.constant 0 : i8
-    %749 = arith.cmpi ne, %748, %c0_i8_441 : i8
-    cf.cond_br %749, ^bb1(%748 : i8), ^bb243
+    %694 = call @dora_fn_extend_memory(%arg0, %677) : (!llvm.ptr, i64) -> !llvm.ptr
+    %695 = llvm.getelementptr %694[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %696 = llvm.load %695 : !llvm.ptr -> i8
+    %c0_i8_390 = arith.constant 0 : i8
+    %697 = arith.cmpi ne, %696, %c0_i8_390 : i8
+    cf.cond_br %697, ^bb1(%696 : i8), ^bb243
   ^bb243:  // pred: ^bb242
     cf.br ^bb240
   ^bb244:  // pred: ^bb163
-    %c18446744073709551615_i256_442 = arith.constant 18446744073709551615 : i256
-    %750 = arith.cmpi sgt, %461, %c18446744073709551615_i256_442 : i256
-    %c84_i8_443 = arith.constant 84 : i8
-    cf.cond_br %750, ^bb1(%c84_i8_443 : i8), ^bb245
+    %c18446744073709551615_i256_391 = arith.constant 18446744073709551615 : i256
+    %698 = arith.cmpi sgt, %411, %c18446744073709551615_i256_391 : i256
+    %c84_i8_392 = arith.constant 84 : i8
+    cf.cond_br %698, ^bb1(%c84_i8_392 : i8), ^bb245
   ^bb245:  // pred: ^bb244
-    %751 = arith.trunci %461 : i256 to i64
-    %c0_i64_444 = arith.constant 0 : i64
-    %752 = arith.cmpi slt, %751, %c0_i64_444 : i64
-    %c84_i8_445 = arith.constant 84 : i8
-    cf.cond_br %752, ^bb1(%c84_i8_445 : i8), ^bb246
+    %699 = arith.trunci %411 : i256 to i64
+    %c0_i64_393 = arith.constant 0 : i64
+    %700 = arith.cmpi slt, %699, %c0_i64_393 : i64
+    %c84_i8_394 = arith.constant 84 : i8
+    cf.cond_br %700, ^bb1(%c84_i8_394 : i8), ^bb246
   ^bb246:  // pred: ^bb245
-    %753 = arith.addi %751, %471 : i64
-    %c0_i64_446 = arith.constant 0 : i64
-    %754 = arith.cmpi slt, %753, %c0_i64_446 : i64
-    %c84_i8_447 = arith.constant 84 : i8
-    cf.cond_br %754, ^bb1(%c84_i8_447 : i8), ^bb247
+    %701 = arith.addi %699, %419 : i64
+    %c0_i64_395 = arith.constant 0 : i64
+    %702 = arith.cmpi slt, %701, %c0_i64_395 : i64
+    %c84_i8_396 = arith.constant 84 : i8
+    cf.cond_br %702, ^bb1(%c84_i8_396 : i8), ^bb247
   ^bb247:  // pred: ^bb246
-    %c31_i64_448 = arith.constant 31 : i64
-    %c32_i64_449 = arith.constant 32 : i64
-    %755 = arith.addi %753, %c31_i64_448 : i64
-    %756 = arith.divui %755, %c32_i64_449 : i64
-    %c32_i64_450 = arith.constant 32 : i64
-    %757 = arith.muli %756, %c32_i64_450 : i64
-    %758 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_451 = arith.constant 31 : i64
-    %c32_i64_452 = arith.constant 32 : i64
-    %759 = arith.addi %758, %c31_i64_451 : i64
-    %760 = arith.divui %759, %c32_i64_452 : i64
-    %761 = arith.muli %760, %c32_i64_450 : i64
-    %762 = arith.cmpi ult, %761, %757 : i64
-    cf.cond_br %762, ^bb249, ^bb248
+    %c31_i64_397 = arith.constant 31 : i64
+    %c32_i64_398 = arith.constant 32 : i64
+    %703 = arith.addi %701, %c31_i64_397 : i64
+    %704 = arith.divui %703, %c32_i64_398 : i64
+    %c32_i64_399 = arith.constant 32 : i64
+    %705 = arith.muli %704, %c32_i64_399 : i64
+    %706 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_400 = arith.constant 31 : i64
+    %c32_i64_401 = arith.constant 32 : i64
+    %707 = arith.addi %706, %c31_i64_400 : i64
+    %708 = arith.divui %707, %c32_i64_401 : i64
+    %709 = arith.muli %708, %c32_i64_399 : i64
+    %710 = arith.cmpi ult, %709, %705 : i64
+    cf.cond_br %710, ^bb249, ^bb248
   ^bb248:  // 2 preds: ^bb247, ^bb251
     cf.br ^bb164
   ^bb249:  // pred: ^bb247
-    %c3_i64_453 = arith.constant 3 : i64
-    %c512_i64_454 = arith.constant 512 : i64
-    %763 = arith.muli %760, %760 : i64
-    %764 = arith.divui %763, %c512_i64_454 : i64
-    %765 = arith.muli %760, %c3_i64_453 : i64
-    %766 = arith.addi %764, %765 : i64
-    %c3_i64_455 = arith.constant 3 : i64
-    %c512_i64_456 = arith.constant 512 : i64
-    %767 = arith.muli %756, %756 : i64
-    %768 = arith.divui %767, %c512_i64_456 : i64
-    %769 = arith.muli %756, %c3_i64_455 : i64
-    %770 = arith.addi %768, %769 : i64
-    %771 = arith.subi %770, %766 : i64
-    %772 = llvm.load %arg1 : !llvm.ptr -> i64
-    %773 = arith.cmpi ult, %772, %771 : i64
-    scf.if %773 {
+    %c3_i64_402 = arith.constant 3 : i64
+    %c512_i64_403 = arith.constant 512 : i64
+    %711 = arith.muli %708, %708 : i64
+    %712 = arith.divui %711, %c512_i64_403 : i64
+    %713 = arith.muli %708, %c3_i64_402 : i64
+    %714 = arith.addi %712, %713 : i64
+    %c3_i64_404 = arith.constant 3 : i64
+    %c512_i64_405 = arith.constant 512 : i64
+    %715 = arith.muli %704, %704 : i64
+    %716 = arith.divui %715, %c512_i64_405 : i64
+    %717 = arith.muli %704, %c3_i64_404 : i64
+    %718 = arith.addi %716, %717 : i64
+    %719 = arith.subi %718, %714 : i64
+    %720 = llvm.load %arg1 : !llvm.ptr -> i64
+    %721 = arith.cmpi ult, %720, %719 : i64
+    scf.if %721 {
     } else {
-      %778 = arith.subi %772, %771 : i64
-      llvm.store %778, %arg1 : i64, !llvm.ptr
+      %726 = arith.subi %720, %719 : i64
+      llvm.store %726, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_457 = arith.constant 80 : i8
-    cf.cond_br %773, ^bb1(%c80_i8_457 : i8), ^bb250
+    %c80_i8_406 = arith.constant 80 : i8
+    cf.cond_br %721, ^bb1(%c80_i8_406 : i8), ^bb250
   ^bb250:  // pred: ^bb249
-    %774 = call @dora_fn_extend_memory(%arg0, %757) : (!llvm.ptr, i64) -> !llvm.ptr
-    %775 = llvm.getelementptr %774[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %776 = llvm.load %775 : !llvm.ptr -> i8
-    %c0_i8_458 = arith.constant 0 : i8
-    %777 = arith.cmpi ne, %776, %c0_i8_458 : i8
-    cf.cond_br %777, ^bb1(%776 : i8), ^bb251
+    %722 = call @dora_fn_extend_memory(%arg0, %705) : (!llvm.ptr, i64) -> !llvm.ptr
+    %723 = llvm.getelementptr %722[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %724 = llvm.load %723 : !llvm.ptr -> i8
+    %c0_i8_407 = arith.constant 0 : i8
+    %725 = arith.cmpi ne, %724, %c0_i8_407 : i8
+    cf.cond_br %725, ^bb1(%724 : i8), ^bb251
   ^bb251:  // pred: ^bb250
     cf.br ^bb248
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 87 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb39, ^bb40, ^bb43, ^bb44, ^bb47, ^bb48, ^bb51, ^bb52, ^bb54, ^bb55, ^bb56, ^bb58, ^bb59, ^bb60, ^bb62, ^bb63, ^bb66, ^bb67, ^bb70, ^bb71, ^bb74, ^bb75, ^bb78, ^bb79, ^bb82, ^bb83, ^bb86, ^bb87, ^bb89, ^bb90, ^bb92, ^bb93, ^bb95, ^bb96, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb108, ^bb111, ^bb112, ^bb114, ^bb115, ^bb116, ^bb119, ^bb120, ^bb122, ^bb123, ^bb124, ^bb127, ^bb128, ^bb130, ^bb131, ^bb132, ^bb133, ^bb134, ^bb137, ^bb138, ^bb140, ^bb141, ^bb142, ^bb145, ^bb146, ^bb148, ^bb149, ^bb150, ^bb153, ^bb154
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 87 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb26, ^bb27, ^bb30, ^bb31, ^bb34, ^bb35, ^bb39, ^bb40, ^bb43, ^bb44, ^bb47, ^bb48, ^bb51, ^bb52, ^bb54, ^bb55, ^bb56, ^bb58, ^bb59, ^bb60, ^bb62, ^bb63, ^bb66, ^bb67, ^bb70, ^bb71, ^bb74, ^bb75, ^bb78, ^bb79, ^bb82, ^bb83, ^bb86, ^bb87, ^bb89, ^bb90, ^bb92, ^bb93, ^bb95, ^bb96, ^bb98, ^bb99, ^bb102, ^bb103, ^bb106, ^bb107, ^bb108, ^bb111, ^bb112, ^bb114, ^bb115, ^bb116, ^bb119, ^bb120, ^bb122, ^bb123, ^bb124, ^bb127, ^bb128, ^bb130, ^bb131, ^bb132, ^bb133, ^bb134, ^bb137, ^bb138, ^bb140, ^bb141, ^bb142, ^bb145, ^bb146, ^bb148, ^bb149, ^bb150, ^bb153, ^bb154
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c57669888194366464517598830424248860356609074394020202793089226410191109488639_i256 = arith.constant 57669888194366464517598830424248860356609074394020202793089226410191109488639 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c57669888194366464517598830424248860356609074394020202793089226410191109488639_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,1217 +96,1172 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb106, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb106, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb110
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256 = arith.constant -282693306169198560872784742741978202424711039104693490077813924759764729856 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c-282693306169198560872784742741978202424711039104693490077813924759764729856_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c32_i256 = arith.constant 32 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_19 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_19 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %50 : i256, !llvm.ptr
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb21:  // pred: ^bb23
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_21 : i64
-    %54 = arith.cmpi ult, %c1024_i64_20, %53 : i64
-    %c92_i8_22 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_22 : i8), ^bb20
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_16 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_16 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_15, %48 : i64
+    %c92_i8_17 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_17 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_23 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_18 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb26
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_25 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_25 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_26 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
-    %c32_i64_27 = arith.constant 32 : i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %66 = arith.cmpi ne, %c32_i64_27, %c0_i64_28 : i64
-    cf.cond_br %66, ^bb114, ^bb25
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_20 = arith.constant 32 : i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %59 = arith.cmpi ne, %c32_i64_20, %c0_i64_21 : i64
+    cf.cond_br %59, ^bb114, ^bb25
   ^bb25:  // 2 preds: ^bb24, ^bb118
-    %67 = arith.trunci %61 : i256 to i64
-    %68 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %69 = llvm.getelementptr %68[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %70 = llvm.intr.bswap(%65)  : (i256) -> i256
-    llvm.store %70, %69 {alignment = 1 : i64} : i256, !llvm.ptr
+    %60 = arith.trunci %55 : i256 to i64
+    %61 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %62 = llvm.getelementptr %61[%60] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %63 = llvm.intr.bswap(%58)  : (i256) -> i256
+    llvm.store %63, %62 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb31
   ^bb26:  // pred: ^bb28
-    %c1024_i64_29 = arith.constant 1024 : i64
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_30 = arith.constant -2 : i64
-    %72 = arith.addi %71, %c-2_i64_30 : i64
-    %c2_i64_31 = arith.constant 2 : i64
-    %73 = arith.cmpi ult, %71, %c2_i64_31 : i64
-    %c91_i8_32 = arith.constant 91 : i8
-    cf.cond_br %73, ^bb1(%c91_i8_32 : i8), ^bb24
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_23 = arith.constant -2 : i64
+    %65 = arith.addi %64, %c-2_i64_23 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c2_i64_24 = arith.constant 2 : i64
+    %66 = arith.cmpi ult, %64, %c2_i64_24 : i64
+    %c91_i8_25 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_25 : i8), ^bb24
   ^bb27:  // pred: ^bb20
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_33 = arith.constant 3 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_26 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %75 = arith.cmpi uge, %74, %c3_i64_33 : i64
-    %c80_i8_34 = arith.constant 80 : i8
-    cf.cond_br %75, ^bb28, ^bb1(%c80_i8_34 : i8)
+    %68 = arith.cmpi uge, %67, %c3_i64_26 : i64
+    %c80_i8_27 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb28, ^bb1(%c80_i8_27 : i8)
   ^bb28:  // pred: ^bb27
-    %76 = arith.subi %74, %c3_i64_33 : i64
-    llvm.store %76, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c3_i64_26 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb26
   ^bb29:  // pred: ^bb30
     %c10123276409175967808859434475862811765392092841461775252157603250176_i256 = arith.constant 10123276409175967808859434475862811765392092841461775252157603250176 : i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %78 = llvm.getelementptr %arg2[%77] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_35 = arith.constant 1 : i64
-    %79 = arith.addi %77, %c1_i64_35 : i64
-    llvm.store %79, %arg3 : i64, !llvm.ptr
-    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %78 : i256, !llvm.ptr
+    %70 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10123276409175967808859434475862811765392092841461775252157603250176_i256, %70 : i256, !llvm.ptr
+    %71 = llvm.getelementptr %70[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %71, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb35
   ^bb30:  // pred: ^bb32
-    %c1024_i64_36 = arith.constant 1024 : i64
-    %80 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_37 = arith.constant 1 : i64
-    %81 = arith.addi %80, %c1_i64_37 : i64
-    %82 = arith.cmpi ult, %c1024_i64_36, %81 : i64
-    %c92_i8_38 = arith.constant 92 : i8
-    cf.cond_br %82, ^bb1(%c92_i8_38 : i8), ^bb29
+    %c1024_i64_28 = arith.constant 1024 : i64
+    %72 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_29 = arith.constant 1 : i64
+    %73 = arith.addi %72, %c1_i64_29 : i64
+    llvm.store %73, %arg3 : i64, !llvm.ptr
+    %74 = arith.cmpi ult, %c1024_i64_28, %73 : i64
+    %c92_i8_30 = arith.constant 92 : i8
+    cf.cond_br %74, ^bb1(%c92_i8_30 : i8), ^bb29
   ^bb31:  // pred: ^bb25
-    %83 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_39 = arith.constant 3 : i64
+    %75 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_31 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %84 = arith.cmpi uge, %83, %c3_i64_39 : i64
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %84, ^bb32, ^bb1(%c80_i8_40 : i8)
+    %76 = arith.cmpi uge, %75, %c3_i64_31 : i64
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %76, ^bb32, ^bb1(%c80_i8_32 : i8)
   ^bb32:  // pred: ^bb31
-    %85 = arith.subi %83, %c3_i64_39 : i64
-    llvm.store %85, %arg1 : i64, !llvm.ptr
+    %77 = arith.subi %75, %c3_i64_31 : i64
+    llvm.store %77, %arg1 : i64, !llvm.ptr
     cf.br ^bb30
   ^bb33:  // pred: ^bb34
     %c64_i256 = arith.constant 64 : i256
-    %86 = llvm.load %arg3 : !llvm.ptr -> i64
-    %87 = llvm.getelementptr %arg2[%86] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_41 = arith.constant 1 : i64
-    %88 = arith.addi %86, %c1_i64_41 : i64
-    llvm.store %88, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %87 : i256, !llvm.ptr
+    %78 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %78 : i256, !llvm.ptr
+    %79 = llvm.getelementptr %78[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %79, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb40
   ^bb34:  // pred: ^bb36
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %89 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_43 = arith.constant 1 : i64
-    %90 = arith.addi %89, %c1_i64_43 : i64
-    %91 = arith.cmpi ult, %c1024_i64_42, %90 : i64
-    %c92_i8_44 = arith.constant 92 : i8
-    cf.cond_br %91, ^bb1(%c92_i8_44 : i8), ^bb33
+    %c1024_i64_33 = arith.constant 1024 : i64
+    %80 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %81 = arith.addi %80, %c1_i64_34 : i64
+    llvm.store %81, %arg3 : i64, !llvm.ptr
+    %82 = arith.cmpi ult, %c1024_i64_33, %81 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %82, ^bb1(%c92_i8_35 : i8), ^bb33
   ^bb35:  // pred: ^bb29
-    %92 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_45 = arith.constant 3 : i64
+    %83 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_36 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %93 = arith.cmpi uge, %92, %c3_i64_45 : i64
-    %c80_i8_46 = arith.constant 80 : i8
-    cf.cond_br %93, ^bb36, ^bb1(%c80_i8_46 : i8)
+    %84 = arith.cmpi uge, %83, %c3_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %84, ^bb36, ^bb1(%c80_i8_37 : i8)
   ^bb36:  // pred: ^bb35
-    %94 = arith.subi %92, %c3_i64_45 : i64
-    llvm.store %94, %arg1 : i64, !llvm.ptr
+    %85 = arith.subi %83, %c3_i64_36 : i64
+    llvm.store %85, %arg1 : i64, !llvm.ptr
     cf.br ^bb34
   ^bb37:  // pred: ^bb39
-    %95 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_47 = arith.constant 1 : i64
-    %96 = arith.subi %95, %c1_i64_47 : i64
-    %97 = llvm.getelementptr %arg2[%96] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %96, %arg3 : i64, !llvm.ptr
-    %98 = llvm.load %97 : !llvm.ptr -> i256
-    %99 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_48 = arith.constant 1 : i64
-    %100 = arith.subi %99, %c1_i64_48 : i64
-    %101 = llvm.getelementptr %arg2[%100] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %100, %arg3 : i64, !llvm.ptr
-    %102 = llvm.load %101 : !llvm.ptr -> i256
-    %c32_i64_49 = arith.constant 32 : i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %103 = arith.cmpi ne, %c32_i64_49, %c0_i64_50 : i64
-    cf.cond_br %103, ^bb122, ^bb38
+    %86 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %87 = llvm.getelementptr %86[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %88 = llvm.load %87 : !llvm.ptr -> i256
+    llvm.store %87, %0 : !llvm.ptr, !llvm.ptr
+    %89 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %90 = llvm.getelementptr %89[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %91 = llvm.load %90 : !llvm.ptr -> i256
+    llvm.store %90, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_38 = arith.constant 32 : i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %92 = arith.cmpi ne, %c32_i64_38, %c0_i64_39 : i64
+    cf.cond_br %92, ^bb122, ^bb38
   ^bb38:  // 2 preds: ^bb37, ^bb126
-    %104 = arith.trunci %98 : i256 to i64
-    %105 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %106 = llvm.getelementptr %105[%104] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %107 = llvm.intr.bswap(%102)  : (i256) -> i256
-    llvm.store %107, %106 {alignment = 1 : i64} : i256, !llvm.ptr
+    %93 = arith.trunci %88 : i256 to i64
+    %94 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %95 = llvm.getelementptr %94[%93] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %96 = llvm.intr.bswap(%91)  : (i256) -> i256
+    llvm.store %96, %95 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb44
   ^bb39:  // pred: ^bb41
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %108 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_52 = arith.constant -2 : i64
-    %109 = arith.addi %108, %c-2_i64_52 : i64
-    %c2_i64_53 = arith.constant 2 : i64
-    %110 = arith.cmpi ult, %108, %c2_i64_53 : i64
-    %c91_i8_54 = arith.constant 91 : i8
-    cf.cond_br %110, ^bb1(%c91_i8_54 : i8), ^bb37
+    %c1024_i64_40 = arith.constant 1024 : i64
+    %97 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_41 = arith.constant -2 : i64
+    %98 = arith.addi %97, %c-2_i64_41 : i64
+    llvm.store %98, %arg3 : i64, !llvm.ptr
+    %c2_i64_42 = arith.constant 2 : i64
+    %99 = arith.cmpi ult, %97, %c2_i64_42 : i64
+    %c91_i8_43 = arith.constant 91 : i8
+    cf.cond_br %99, ^bb1(%c91_i8_43 : i8), ^bb37
   ^bb40:  // pred: ^bb33
-    %111 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_55 = arith.constant 3 : i64
+    %100 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_44 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %112 = arith.cmpi uge, %111, %c3_i64_55 : i64
-    %c80_i8_56 = arith.constant 80 : i8
-    cf.cond_br %112, ^bb41, ^bb1(%c80_i8_56 : i8)
+    %101 = arith.cmpi uge, %100, %c3_i64_44 : i64
+    %c80_i8_45 = arith.constant 80 : i8
+    cf.cond_br %101, ^bb41, ^bb1(%c80_i8_45 : i8)
   ^bb41:  // pred: ^bb40
-    %113 = arith.subi %111, %c3_i64_55 : i64
-    llvm.store %113, %arg1 : i64, !llvm.ptr
+    %102 = arith.subi %100, %c3_i64_44 : i64
+    llvm.store %102, %arg1 : i64, !llvm.ptr
     cf.br ^bb39
   ^bb42:  // pred: ^bb43
     %c77_i256 = arith.constant 77 : i256
-    %114 = llvm.load %arg3 : !llvm.ptr -> i64
-    %115 = llvm.getelementptr %arg2[%114] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_57 = arith.constant 1 : i64
-    %116 = arith.addi %114, %c1_i64_57 : i64
-    llvm.store %116, %arg3 : i64, !llvm.ptr
-    llvm.store %c77_i256, %115 : i256, !llvm.ptr
+    %103 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c77_i256, %103 : i256, !llvm.ptr
+    %104 = llvm.getelementptr %103[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %104, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb48
   ^bb43:  // pred: ^bb45
-    %c1024_i64_58 = arith.constant 1024 : i64
-    %117 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_59 = arith.constant 1 : i64
-    %118 = arith.addi %117, %c1_i64_59 : i64
-    %119 = arith.cmpi ult, %c1024_i64_58, %118 : i64
-    %c92_i8_60 = arith.constant 92 : i8
-    cf.cond_br %119, ^bb1(%c92_i8_60 : i8), ^bb42
+    %c1024_i64_46 = arith.constant 1024 : i64
+    %105 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_47 = arith.constant 1 : i64
+    %106 = arith.addi %105, %c1_i64_47 : i64
+    llvm.store %106, %arg3 : i64, !llvm.ptr
+    %107 = arith.cmpi ult, %c1024_i64_46, %106 : i64
+    %c92_i8_48 = arith.constant 92 : i8
+    cf.cond_br %107, ^bb1(%c92_i8_48 : i8), ^bb42
   ^bb44:  // pred: ^bb38
-    %120 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_61 = arith.constant 3 : i64
+    %108 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_49 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %121 = arith.cmpi uge, %120, %c3_i64_61 : i64
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %121, ^bb45, ^bb1(%c80_i8_62 : i8)
+    %109 = arith.cmpi uge, %108, %c3_i64_49 : i64
+    %c80_i8_50 = arith.constant 80 : i8
+    cf.cond_br %109, ^bb45, ^bb1(%c80_i8_50 : i8)
   ^bb45:  // pred: ^bb44
-    %122 = arith.subi %120, %c3_i64_61 : i64
-    llvm.store %122, %arg1 : i64, !llvm.ptr
+    %110 = arith.subi %108, %c3_i64_49 : i64
+    llvm.store %110, %arg1 : i64, !llvm.ptr
     cf.br ^bb43
   ^bb46:  // pred: ^bb47
-    %c0_i256_63 = arith.constant 0 : i256
-    %123 = llvm.load %arg3 : !llvm.ptr -> i64
-    %124 = llvm.getelementptr %arg2[%123] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_64 = arith.constant 1 : i64
-    %125 = arith.addi %123, %c1_i64_64 : i64
-    llvm.store %125, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_63, %124 : i256, !llvm.ptr
+    %c0_i256_51 = arith.constant 0 : i256
+    %111 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_51, %111 : i256, !llvm.ptr
+    %112 = llvm.getelementptr %111[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %112, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb52
   ^bb47:  // pred: ^bb49
-    %c1024_i64_65 = arith.constant 1024 : i64
-    %126 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_66 = arith.constant 1 : i64
-    %127 = arith.addi %126, %c1_i64_66 : i64
-    %128 = arith.cmpi ult, %c1024_i64_65, %127 : i64
-    %c92_i8_67 = arith.constant 92 : i8
-    cf.cond_br %128, ^bb1(%c92_i8_67 : i8), ^bb46
+    %c1024_i64_52 = arith.constant 1024 : i64
+    %113 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_53 = arith.constant 1 : i64
+    %114 = arith.addi %113, %c1_i64_53 : i64
+    llvm.store %114, %arg3 : i64, !llvm.ptr
+    %115 = arith.cmpi ult, %c1024_i64_52, %114 : i64
+    %c92_i8_54 = arith.constant 92 : i8
+    cf.cond_br %115, ^bb1(%c92_i8_54 : i8), ^bb46
   ^bb48:  // pred: ^bb42
-    %129 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_68 = arith.constant 3 : i64
+    %116 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_55 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %130 = arith.cmpi uge, %129, %c3_i64_68 : i64
-    %c80_i8_69 = arith.constant 80 : i8
-    cf.cond_br %130, ^bb49, ^bb1(%c80_i8_69 : i8)
+    %117 = arith.cmpi uge, %116, %c3_i64_55 : i64
+    %c80_i8_56 = arith.constant 80 : i8
+    cf.cond_br %117, ^bb49, ^bb1(%c80_i8_56 : i8)
   ^bb49:  // pred: ^bb48
-    %131 = arith.subi %129, %c3_i64_68 : i64
-    llvm.store %131, %arg1 : i64, !llvm.ptr
+    %118 = arith.subi %116, %c3_i64_55 : i64
+    llvm.store %118, %arg1 : i64, !llvm.ptr
     cf.br ^bb47
   ^bb50:  // pred: ^bb51
-    %c0_i256_70 = arith.constant 0 : i256
-    %132 = llvm.load %arg3 : !llvm.ptr -> i64
-    %133 = llvm.getelementptr %arg2[%132] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_71 = arith.constant 1 : i64
-    %134 = arith.addi %132, %c1_i64_71 : i64
-    llvm.store %134, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_70, %133 : i256, !llvm.ptr
+    %c0_i256_57 = arith.constant 0 : i256
+    %119 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_57, %119 : i256, !llvm.ptr
+    %120 = llvm.getelementptr %119[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %120, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb63
   ^bb51:  // pred: ^bb53
-    %c1024_i64_72 = arith.constant 1024 : i64
-    %135 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_73 = arith.constant 1 : i64
-    %136 = arith.addi %135, %c1_i64_73 : i64
-    %137 = arith.cmpi ult, %c1024_i64_72, %136 : i64
-    %c92_i8_74 = arith.constant 92 : i8
-    cf.cond_br %137, ^bb1(%c92_i8_74 : i8), ^bb50
+    %c1024_i64_58 = arith.constant 1024 : i64
+    %121 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_59 = arith.constant 1 : i64
+    %122 = arith.addi %121, %c1_i64_59 : i64
+    llvm.store %122, %arg3 : i64, !llvm.ptr
+    %123 = arith.cmpi ult, %c1024_i64_58, %122 : i64
+    %c92_i8_60 = arith.constant 92 : i8
+    cf.cond_br %123, ^bb1(%c92_i8_60 : i8), ^bb50
   ^bb52:  // pred: ^bb46
-    %138 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_75 = arith.constant 3 : i64
+    %124 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_61 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %139 = arith.cmpi uge, %138, %c3_i64_75 : i64
-    %c80_i8_76 = arith.constant 80 : i8
-    cf.cond_br %139, ^bb53, ^bb1(%c80_i8_76 : i8)
+    %125 = arith.cmpi uge, %124, %c3_i64_61 : i64
+    %c80_i8_62 = arith.constant 80 : i8
+    cf.cond_br %125, ^bb53, ^bb1(%c80_i8_62 : i8)
   ^bb53:  // pred: ^bb52
-    %140 = arith.subi %138, %c3_i64_75 : i64
-    llvm.store %140, %arg1 : i64, !llvm.ptr
+    %126 = arith.subi %124, %c3_i64_61 : i64
+    llvm.store %126, %arg1 : i64, !llvm.ptr
     cf.br ^bb51
   ^bb54:  // pred: ^bb62
-    %141 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_77 = arith.constant 1 : i64
-    %142 = arith.subi %141, %c1_i64_77 : i64
-    %143 = llvm.getelementptr %arg2[%142] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %142, %arg3 : i64, !llvm.ptr
-    %144 = llvm.load %143 : !llvm.ptr -> i256
-    %145 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_78 = arith.constant 1 : i64
-    %146 = arith.subi %145, %c1_i64_78 : i64
-    %147 = llvm.getelementptr %arg2[%146] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %146, %arg3 : i64, !llvm.ptr
-    %148 = llvm.load %147 : !llvm.ptr -> i256
-    %149 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_79 = arith.constant 1 : i64
-    %150 = arith.subi %149, %c1_i64_79 : i64
-    %151 = llvm.getelementptr %arg2[%150] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %150, %arg3 : i64, !llvm.ptr
-    %152 = llvm.load %151 : !llvm.ptr -> i256
-    %153 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %127 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %128 = llvm.getelementptr %127[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %129 = llvm.load %128 : !llvm.ptr -> i256
+    llvm.store %128, %0 : !llvm.ptr, !llvm.ptr
+    %130 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %131 = llvm.getelementptr %130[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %132 = llvm.load %131 : !llvm.ptr -> i256
+    llvm.store %131, %0 : !llvm.ptr, !llvm.ptr
+    %133 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %134 = llvm.getelementptr %133[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %135 = llvm.load %134 : !llvm.ptr -> i256
+    llvm.store %134, %0 : !llvm.ptr, !llvm.ptr
+    %136 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %154 = arith.cmpi ne, %153, %c0_i8 : i8
+    %137 = arith.cmpi ne, %136, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %154, ^bb1(%c87_i8 : i8), ^bb55
+    cf.cond_br %137, ^bb1(%c87_i8 : i8), ^bb55
   ^bb55:  // pred: ^bb54
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %155 = arith.cmpi sgt, %152, %c18446744073709551615_i256 : i256
+    %138 = arith.cmpi sgt, %135, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %155, ^bb1(%c84_i8 : i8), ^bb56
+    cf.cond_br %138, ^bb1(%c84_i8 : i8), ^bb56
   ^bb56:  // pred: ^bb55
-    %156 = arith.trunci %152 : i256 to i64
-    %c0_i64_80 = arith.constant 0 : i64
-    %157 = arith.cmpi slt, %156, %c0_i64_80 : i64
-    %c84_i8_81 = arith.constant 84 : i8
-    cf.cond_br %157, ^bb1(%c84_i8_81 : i8), ^bb57
+    %139 = arith.trunci %135 : i256 to i64
+    %c0_i64_63 = arith.constant 0 : i64
+    %140 = arith.cmpi slt, %139, %c0_i64_63 : i64
+    %c84_i8_64 = arith.constant 84 : i8
+    cf.cond_br %140, ^bb1(%c84_i8_64 : i8), ^bb57
   ^bb57:  // pred: ^bb56
-    %c0_i64_82 = arith.constant 0 : i64
-    %158 = arith.cmpi ne, %156, %c0_i64_82 : i64
-    cf.cond_br %158, ^bb130, ^bb58
+    %c0_i64_65 = arith.constant 0 : i64
+    %141 = arith.cmpi ne, %139, %c0_i64_65 : i64
+    cf.cond_br %141, ^bb130, ^bb58
   ^bb58:  // 2 preds: ^bb57, ^bb136
     %c32000_i64 = arith.constant 32000 : i64
-    %159 = llvm.load %arg1 : !llvm.ptr -> i64
-    %160 = arith.cmpi ult, %159, %c32000_i64 : i64
-    scf.if %160 {
+    %142 = llvm.load %arg1 : !llvm.ptr -> i64
+    %143 = arith.cmpi ult, %142, %c32000_i64 : i64
+    scf.if %143 {
     } else {
-      %486 = arith.subi %159, %c32000_i64 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %142, %c32000_i64 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_83 = arith.constant 80 : i8
-    cf.cond_br %160, ^bb1(%c80_i8_83 : i8), ^bb59
+    %c80_i8_66 = arith.constant 80 : i8
+    cf.cond_br %143, ^bb1(%c80_i8_66 : i8), ^bb59
   ^bb59:  // pred: ^bb58
     %c1_i256 = arith.constant 1 : i256
-    %161 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %144, %161 {alignment = 1 : i64} : i256, !llvm.ptr
-    %162 = llvm.load %arg1 : !llvm.ptr -> i64
-    %163 = arith.trunci %148 : i256 to i64
-    %164 = call @dora_fn_create(%arg0, %156, %163, %161, %162) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %165 = llvm.getelementptr %164[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %166 = llvm.load %165 : !llvm.ptr -> i8
-    %c0_i8_84 = arith.constant 0 : i8
-    %167 = arith.cmpi ne, %166, %c0_i8_84 : i8
-    cf.cond_br %167, ^bb1(%166 : i8), ^bb60
+    %144 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %129, %144 {alignment = 1 : i64} : i256, !llvm.ptr
+    %145 = llvm.load %arg1 : !llvm.ptr -> i64
+    %146 = arith.trunci %132 : i256 to i64
+    %147 = call @dora_fn_create(%arg0, %139, %146, %144, %145) : (!llvm.ptr, i64, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %148 = llvm.getelementptr %147[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %149 = llvm.load %148 : !llvm.ptr -> i8
+    %c0_i8_67 = arith.constant 0 : i8
+    %150 = arith.cmpi ne, %149, %c0_i8_67 : i8
+    cf.cond_br %150, ^bb1(%149 : i8), ^bb60
   ^bb60:  // pred: ^bb59
-    %168 = llvm.getelementptr %164[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %169 = llvm.load %168 : !llvm.ptr -> i64
-    %170 = llvm.load %arg1 : !llvm.ptr -> i64
-    %171 = arith.cmpi ult, %170, %169 : i64
-    scf.if %171 {
+    %151 = llvm.getelementptr %147[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %152 = llvm.load %151 : !llvm.ptr -> i64
+    %153 = llvm.load %arg1 : !llvm.ptr -> i64
+    %154 = arith.cmpi ult, %153, %152 : i64
+    scf.if %154 {
     } else {
-      %486 = arith.subi %170, %169 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %153, %152 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_85 = arith.constant 80 : i8
-    cf.cond_br %171, ^bb1(%c80_i8_85 : i8), ^bb61
+    %c80_i8_68 = arith.constant 80 : i8
+    cf.cond_br %154, ^bb1(%c80_i8_68 : i8), ^bb61
   ^bb61:  // pred: ^bb60
-    %172 = llvm.load %161 : !llvm.ptr -> i256
-    %173 = llvm.load %arg3 : !llvm.ptr -> i64
-    %174 = llvm.getelementptr %arg2[%173] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_86 = arith.constant 1 : i64
-    %175 = arith.addi %173, %c1_i64_86 : i64
-    llvm.store %175, %arg3 : i64, !llvm.ptr
-    llvm.store %172, %174 : i256, !llvm.ptr
+    %155 = llvm.load %144 : !llvm.ptr -> i256
+    %156 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %155, %156 : i256, !llvm.ptr
+    %157 = llvm.getelementptr %156[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %157, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb67
   ^bb62:  // pred: ^bb64
-    %c1024_i64_87 = arith.constant 1024 : i64
-    %176 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_88 = arith.constant -2 : i64
-    %177 = arith.addi %176, %c-2_i64_88 : i64
-    %c3_i64_89 = arith.constant 3 : i64
-    %178 = arith.cmpi ult, %176, %c3_i64_89 : i64
-    %c91_i8_90 = arith.constant 91 : i8
-    cf.cond_br %178, ^bb1(%c91_i8_90 : i8), ^bb54
+    %c1024_i64_69 = arith.constant 1024 : i64
+    %158 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_70 = arith.constant -2 : i64
+    %159 = arith.addi %158, %c-2_i64_70 : i64
+    llvm.store %159, %arg3 : i64, !llvm.ptr
+    %c3_i64_71 = arith.constant 3 : i64
+    %160 = arith.cmpi ult, %158, %c3_i64_71 : i64
+    %c91_i8_72 = arith.constant 91 : i8
+    cf.cond_br %160, ^bb1(%c91_i8_72 : i8), ^bb54
   ^bb63:  // pred: ^bb50
-    %179 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_91 = arith.constant 0 : i64
+    %161 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_73 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %180 = arith.cmpi uge, %179, %c0_i64_91 : i64
-    %c80_i8_92 = arith.constant 80 : i8
-    cf.cond_br %180, ^bb64, ^bb1(%c80_i8_92 : i8)
+    %162 = arith.cmpi uge, %161, %c0_i64_73 : i64
+    %c80_i8_74 = arith.constant 80 : i8
+    cf.cond_br %162, ^bb64, ^bb1(%c80_i8_74 : i8)
   ^bb64:  // pred: ^bb63
-    %181 = arith.subi %179, %c0_i64_91 : i64
-    llvm.store %181, %arg1 : i64, !llvm.ptr
+    %163 = arith.subi %161, %c0_i64_73 : i64
+    llvm.store %163, %arg1 : i64, !llvm.ptr
     cf.br ^bb62
   ^bb65:  // pred: ^bb66
-    %c0_i256_93 = arith.constant 0 : i256
-    %182 = llvm.load %arg3 : !llvm.ptr -> i64
-    %183 = llvm.getelementptr %arg2[%182] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_94 = arith.constant 1 : i64
-    %184 = arith.addi %182, %c1_i64_94 : i64
-    llvm.store %184, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_93, %183 : i256, !llvm.ptr
+    %c0_i256_75 = arith.constant 0 : i256
+    %164 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_75, %164 : i256, !llvm.ptr
+    %165 = llvm.getelementptr %164[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %165, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb71
   ^bb66:  // pred: ^bb68
-    %c1024_i64_95 = arith.constant 1024 : i64
-    %185 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_96 = arith.constant 1 : i64
-    %186 = arith.addi %185, %c1_i64_96 : i64
-    %187 = arith.cmpi ult, %c1024_i64_95, %186 : i64
-    %c92_i8_97 = arith.constant 92 : i8
-    cf.cond_br %187, ^bb1(%c92_i8_97 : i8), ^bb65
+    %c1024_i64_76 = arith.constant 1024 : i64
+    %166 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_77 = arith.constant 1 : i64
+    %167 = arith.addi %166, %c1_i64_77 : i64
+    llvm.store %167, %arg3 : i64, !llvm.ptr
+    %168 = arith.cmpi ult, %c1024_i64_76, %167 : i64
+    %c92_i8_78 = arith.constant 92 : i8
+    cf.cond_br %168, ^bb1(%c92_i8_78 : i8), ^bb65
   ^bb67:  // pred: ^bb61
-    %188 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_98 = arith.constant 3 : i64
+    %169 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_79 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %189 = arith.cmpi uge, %188, %c3_i64_98 : i64
-    %c80_i8_99 = arith.constant 80 : i8
-    cf.cond_br %189, ^bb68, ^bb1(%c80_i8_99 : i8)
+    %170 = arith.cmpi uge, %169, %c3_i64_79 : i64
+    %c80_i8_80 = arith.constant 80 : i8
+    cf.cond_br %170, ^bb68, ^bb1(%c80_i8_80 : i8)
   ^bb68:  // pred: ^bb67
-    %190 = arith.subi %188, %c3_i64_98 : i64
-    llvm.store %190, %arg1 : i64, !llvm.ptr
+    %171 = arith.subi %169, %c3_i64_79 : i64
+    llvm.store %171, %arg1 : i64, !llvm.ptr
     cf.br ^bb66
   ^bb69:  // pred: ^bb70
-    %c0_i256_100 = arith.constant 0 : i256
-    %191 = llvm.load %arg3 : !llvm.ptr -> i64
-    %192 = llvm.getelementptr %arg2[%191] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_101 = arith.constant 1 : i64
-    %193 = arith.addi %191, %c1_i64_101 : i64
-    llvm.store %193, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_100, %192 : i256, !llvm.ptr
+    %c0_i256_81 = arith.constant 0 : i256
+    %172 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_81, %172 : i256, !llvm.ptr
+    %173 = llvm.getelementptr %172[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %173, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb75
   ^bb70:  // pred: ^bb72
-    %c1024_i64_102 = arith.constant 1024 : i64
-    %194 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_103 = arith.constant 1 : i64
-    %195 = arith.addi %194, %c1_i64_103 : i64
-    %196 = arith.cmpi ult, %c1024_i64_102, %195 : i64
-    %c92_i8_104 = arith.constant 92 : i8
-    cf.cond_br %196, ^bb1(%c92_i8_104 : i8), ^bb69
+    %c1024_i64_82 = arith.constant 1024 : i64
+    %174 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_83 = arith.constant 1 : i64
+    %175 = arith.addi %174, %c1_i64_83 : i64
+    llvm.store %175, %arg3 : i64, !llvm.ptr
+    %176 = arith.cmpi ult, %c1024_i64_82, %175 : i64
+    %c92_i8_84 = arith.constant 92 : i8
+    cf.cond_br %176, ^bb1(%c92_i8_84 : i8), ^bb69
   ^bb71:  // pred: ^bb65
-    %197 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_105 = arith.constant 3 : i64
+    %177 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_85 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %198 = arith.cmpi uge, %197, %c3_i64_105 : i64
-    %c80_i8_106 = arith.constant 80 : i8
-    cf.cond_br %198, ^bb72, ^bb1(%c80_i8_106 : i8)
+    %178 = arith.cmpi uge, %177, %c3_i64_85 : i64
+    %c80_i8_86 = arith.constant 80 : i8
+    cf.cond_br %178, ^bb72, ^bb1(%c80_i8_86 : i8)
   ^bb72:  // pred: ^bb71
-    %199 = arith.subi %197, %c3_i64_105 : i64
-    llvm.store %199, %arg1 : i64, !llvm.ptr
+    %179 = arith.subi %177, %c3_i64_85 : i64
+    llvm.store %179, %arg1 : i64, !llvm.ptr
     cf.br ^bb70
   ^bb73:  // pred: ^bb74
-    %c0_i256_107 = arith.constant 0 : i256
-    %200 = llvm.load %arg3 : !llvm.ptr -> i64
-    %201 = llvm.getelementptr %arg2[%200] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_108 = arith.constant 1 : i64
-    %202 = arith.addi %200, %c1_i64_108 : i64
-    llvm.store %202, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_107, %201 : i256, !llvm.ptr
+    %c0_i256_87 = arith.constant 0 : i256
+    %180 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_87, %180 : i256, !llvm.ptr
+    %181 = llvm.getelementptr %180[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %181, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb79
   ^bb74:  // pred: ^bb76
-    %c1024_i64_109 = arith.constant 1024 : i64
-    %203 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_110 = arith.constant 1 : i64
-    %204 = arith.addi %203, %c1_i64_110 : i64
-    %205 = arith.cmpi ult, %c1024_i64_109, %204 : i64
-    %c92_i8_111 = arith.constant 92 : i8
-    cf.cond_br %205, ^bb1(%c92_i8_111 : i8), ^bb73
+    %c1024_i64_88 = arith.constant 1024 : i64
+    %182 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_89 = arith.constant 1 : i64
+    %183 = arith.addi %182, %c1_i64_89 : i64
+    llvm.store %183, %arg3 : i64, !llvm.ptr
+    %184 = arith.cmpi ult, %c1024_i64_88, %183 : i64
+    %c92_i8_90 = arith.constant 92 : i8
+    cf.cond_br %184, ^bb1(%c92_i8_90 : i8), ^bb73
   ^bb75:  // pred: ^bb69
-    %206 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_112 = arith.constant 3 : i64
+    %185 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_91 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %207 = arith.cmpi uge, %206, %c3_i64_112 : i64
-    %c80_i8_113 = arith.constant 80 : i8
-    cf.cond_br %207, ^bb76, ^bb1(%c80_i8_113 : i8)
+    %186 = arith.cmpi uge, %185, %c3_i64_91 : i64
+    %c80_i8_92 = arith.constant 80 : i8
+    cf.cond_br %186, ^bb76, ^bb1(%c80_i8_92 : i8)
   ^bb76:  // pred: ^bb75
-    %208 = arith.subi %206, %c3_i64_112 : i64
-    llvm.store %208, %arg1 : i64, !llvm.ptr
+    %187 = arith.subi %185, %c3_i64_91 : i64
+    llvm.store %187, %arg1 : i64, !llvm.ptr
     cf.br ^bb74
   ^bb77:  // pred: ^bb78
-    %c0_i256_114 = arith.constant 0 : i256
-    %209 = llvm.load %arg3 : !llvm.ptr -> i64
-    %210 = llvm.getelementptr %arg2[%209] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_115 = arith.constant 1 : i64
-    %211 = arith.addi %209, %c1_i64_115 : i64
-    llvm.store %211, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_114, %210 : i256, !llvm.ptr
+    %c0_i256_93 = arith.constant 0 : i256
+    %188 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_93, %188 : i256, !llvm.ptr
+    %189 = llvm.getelementptr %188[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %189, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb83
   ^bb78:  // pred: ^bb80
-    %c1024_i64_116 = arith.constant 1024 : i64
-    %212 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_117 = arith.constant 1 : i64
-    %213 = arith.addi %212, %c1_i64_117 : i64
-    %214 = arith.cmpi ult, %c1024_i64_116, %213 : i64
-    %c92_i8_118 = arith.constant 92 : i8
-    cf.cond_br %214, ^bb1(%c92_i8_118 : i8), ^bb77
+    %c1024_i64_94 = arith.constant 1024 : i64
+    %190 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_95 = arith.constant 1 : i64
+    %191 = arith.addi %190, %c1_i64_95 : i64
+    llvm.store %191, %arg3 : i64, !llvm.ptr
+    %192 = arith.cmpi ult, %c1024_i64_94, %191 : i64
+    %c92_i8_96 = arith.constant 92 : i8
+    cf.cond_br %192, ^bb1(%c92_i8_96 : i8), ^bb77
   ^bb79:  // pred: ^bb73
-    %215 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_119 = arith.constant 3 : i64
+    %193 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_97 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %216 = arith.cmpi uge, %215, %c3_i64_119 : i64
-    %c80_i8_120 = arith.constant 80 : i8
-    cf.cond_br %216, ^bb80, ^bb1(%c80_i8_120 : i8)
+    %194 = arith.cmpi uge, %193, %c3_i64_97 : i64
+    %c80_i8_98 = arith.constant 80 : i8
+    cf.cond_br %194, ^bb80, ^bb1(%c80_i8_98 : i8)
   ^bb80:  // pred: ^bb79
-    %217 = arith.subi %215, %c3_i64_119 : i64
-    llvm.store %217, %arg1 : i64, !llvm.ptr
+    %195 = arith.subi %193, %c3_i64_97 : i64
+    llvm.store %195, %arg1 : i64, !llvm.ptr
     cf.br ^bb78
   ^bb81:  // pred: ^bb82
-    %218 = llvm.load %arg3 : !llvm.ptr -> i64
-    %219 = llvm.getelementptr %arg2[%218] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %220 = llvm.getelementptr %219[-5] : (!llvm.ptr) -> !llvm.ptr, i256
-    %221 = llvm.load %220 : !llvm.ptr -> i256
-    %222 = llvm.load %arg3 : !llvm.ptr -> i64
-    %223 = llvm.getelementptr %arg2[%222] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_121 = arith.constant 1 : i64
-    %224 = arith.addi %222, %c1_i64_121 : i64
-    llvm.store %224, %arg3 : i64, !llvm.ptr
-    llvm.store %221, %223 : i256, !llvm.ptr
+    %196 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %197 = llvm.getelementptr %196[-5] : (!llvm.ptr) -> !llvm.ptr, i256
+    %198 = llvm.load %197 : !llvm.ptr -> i256
+    %199 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %198, %199 : i256, !llvm.ptr
+    %200 = llvm.getelementptr %199[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %200, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb87
   ^bb82:  // pred: ^bb84
-    %c1024_i64_122 = arith.constant 1024 : i64
-    %225 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_123 = arith.constant 1 : i64
-    %226 = arith.addi %225, %c1_i64_123 : i64
+    %c1024_i64_99 = arith.constant 1024 : i64
+    %201 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_100 = arith.constant 1 : i64
+    %202 = arith.addi %201, %c1_i64_100 : i64
+    llvm.store %202, %arg3 : i64, !llvm.ptr
     %c5_i64 = arith.constant 5 : i64
-    %227 = arith.cmpi ult, %225, %c5_i64 : i64
-    %228 = arith.cmpi ult, %c1024_i64_122, %226 : i64
-    %229 = arith.xori %227, %228 : i1
-    %c92_i8_124 = arith.constant 92 : i8
-    cf.cond_br %229, ^bb1(%c92_i8_124 : i8), ^bb81
+    %203 = arith.cmpi ult, %201, %c5_i64 : i64
+    %204 = arith.cmpi ult, %c1024_i64_99, %202 : i64
+    %205 = arith.xori %203, %204 : i1
+    %c92_i8_101 = arith.constant 92 : i8
+    cf.cond_br %205, ^bb1(%c92_i8_101 : i8), ^bb81
   ^bb83:  // pred: ^bb77
-    %230 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_125 = arith.constant 3 : i64
+    %206 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_102 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %231 = arith.cmpi uge, %230, %c3_i64_125 : i64
-    %c80_i8_126 = arith.constant 80 : i8
-    cf.cond_br %231, ^bb84, ^bb1(%c80_i8_126 : i8)
+    %207 = arith.cmpi uge, %206, %c3_i64_102 : i64
+    %c80_i8_103 = arith.constant 80 : i8
+    cf.cond_br %207, ^bb84, ^bb1(%c80_i8_103 : i8)
   ^bb84:  // pred: ^bb83
-    %232 = arith.subi %230, %c3_i64_125 : i64
-    llvm.store %232, %arg1 : i64, !llvm.ptr
+    %208 = arith.subi %206, %c3_i64_102 : i64
+    llvm.store %208, %arg1 : i64, !llvm.ptr
     cf.br ^bb82
   ^bb85:  // pred: ^bb86
     %c4294967295_i256 = arith.constant 4294967295 : i256
-    %233 = llvm.load %arg3 : !llvm.ptr -> i64
-    %234 = llvm.getelementptr %arg2[%233] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_127 = arith.constant 1 : i64
-    %235 = arith.addi %233, %c1_i64_127 : i64
-    llvm.store %235, %arg3 : i64, !llvm.ptr
-    llvm.store %c4294967295_i256, %234 : i256, !llvm.ptr
+    %209 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4294967295_i256, %209 : i256, !llvm.ptr
+    %210 = llvm.getelementptr %209[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %210, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb99
   ^bb86:  // pred: ^bb88
-    %c1024_i64_128 = arith.constant 1024 : i64
-    %236 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_129 = arith.constant 1 : i64
-    %237 = arith.addi %236, %c1_i64_129 : i64
-    %238 = arith.cmpi ult, %c1024_i64_128, %237 : i64
-    %c92_i8_130 = arith.constant 92 : i8
-    cf.cond_br %238, ^bb1(%c92_i8_130 : i8), ^bb85
+    %c1024_i64_104 = arith.constant 1024 : i64
+    %211 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_105 = arith.constant 1 : i64
+    %212 = arith.addi %211, %c1_i64_105 : i64
+    llvm.store %212, %arg3 : i64, !llvm.ptr
+    %213 = arith.cmpi ult, %c1024_i64_104, %212 : i64
+    %c92_i8_106 = arith.constant 92 : i8
+    cf.cond_br %213, ^bb1(%c92_i8_106 : i8), ^bb85
   ^bb87:  // pred: ^bb81
-    %239 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_131 = arith.constant 3 : i64
+    %214 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_107 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %240 = arith.cmpi uge, %239, %c3_i64_131 : i64
-    %c80_i8_132 = arith.constant 80 : i8
-    cf.cond_br %240, ^bb88, ^bb1(%c80_i8_132 : i8)
+    %215 = arith.cmpi uge, %214, %c3_i64_107 : i64
+    %c80_i8_108 = arith.constant 80 : i8
+    cf.cond_br %215, ^bb88, ^bb1(%c80_i8_108 : i8)
   ^bb88:  // pred: ^bb87
-    %241 = arith.subi %239, %c3_i64_131 : i64
-    llvm.store %241, %arg1 : i64, !llvm.ptr
+    %216 = arith.subi %214, %c3_i64_107 : i64
+    llvm.store %216, %arg1 : i64, !llvm.ptr
     cf.br ^bb86
   ^bb89:  // pred: ^bb98
-    %242 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_133 = arith.constant 1 : i64
-    %243 = arith.subi %242, %c1_i64_133 : i64
-    %244 = llvm.getelementptr %arg2[%243] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %243, %arg3 : i64, !llvm.ptr
-    %245 = llvm.load %244 : !llvm.ptr -> i256
-    %246 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_134 = arith.constant 1 : i64
-    %247 = arith.subi %246, %c1_i64_134 : i64
-    %248 = llvm.getelementptr %arg2[%247] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %247, %arg3 : i64, !llvm.ptr
-    %249 = llvm.load %248 : !llvm.ptr -> i256
-    %250 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_135 = arith.constant 1 : i64
-    %251 = arith.subi %250, %c1_i64_135 : i64
-    %252 = llvm.getelementptr %arg2[%251] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %251, %arg3 : i64, !llvm.ptr
-    %253 = llvm.load %252 : !llvm.ptr -> i256
-    %254 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_136 = arith.constant 1 : i64
-    %255 = arith.subi %254, %c1_i64_136 : i64
-    %256 = llvm.getelementptr %arg2[%255] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %255, %arg3 : i64, !llvm.ptr
-    %257 = llvm.load %256 : !llvm.ptr -> i256
-    %258 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_137 = arith.constant 1 : i64
-    %259 = arith.subi %258, %c1_i64_137 : i64
-    %260 = llvm.getelementptr %arg2[%259] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %259, %arg3 : i64, !llvm.ptr
-    %261 = llvm.load %260 : !llvm.ptr -> i256
-    %262 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_138 = arith.constant 1 : i64
-    %263 = arith.subi %262, %c1_i64_138 : i64
-    %264 = llvm.getelementptr %arg2[%263] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %263, %arg3 : i64, !llvm.ptr
-    %265 = llvm.load %264 : !llvm.ptr -> i256
-    %c0_i256_139 = arith.constant 0 : i256
-    %c18446744073709551615_i256_140 = arith.constant 18446744073709551615 : i256
-    %266 = arith.cmpi sgt, %257, %c18446744073709551615_i256_140 : i256
-    %c84_i8_141 = arith.constant 84 : i8
-    cf.cond_br %266, ^bb1(%c84_i8_141 : i8), ^bb90
+    %217 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %218 = llvm.getelementptr %217[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %219 = llvm.load %218 : !llvm.ptr -> i256
+    llvm.store %218, %0 : !llvm.ptr, !llvm.ptr
+    %220 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %221 = llvm.getelementptr %220[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %222 = llvm.load %221 : !llvm.ptr -> i256
+    llvm.store %221, %0 : !llvm.ptr, !llvm.ptr
+    %223 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %224 = llvm.getelementptr %223[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %225 = llvm.load %224 : !llvm.ptr -> i256
+    llvm.store %224, %0 : !llvm.ptr, !llvm.ptr
+    %226 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %227 = llvm.getelementptr %226[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %228 = llvm.load %227 : !llvm.ptr -> i256
+    llvm.store %227, %0 : !llvm.ptr, !llvm.ptr
+    %229 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %230 = llvm.getelementptr %229[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %231 = llvm.load %230 : !llvm.ptr -> i256
+    llvm.store %230, %0 : !llvm.ptr, !llvm.ptr
+    %232 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %233 = llvm.getelementptr %232[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %234 = llvm.load %233 : !llvm.ptr -> i256
+    llvm.store %233, %0 : !llvm.ptr, !llvm.ptr
+    %c0_i256_109 = arith.constant 0 : i256
+    %c18446744073709551615_i256_110 = arith.constant 18446744073709551615 : i256
+    %235 = arith.cmpi sgt, %228, %c18446744073709551615_i256_110 : i256
+    %c84_i8_111 = arith.constant 84 : i8
+    cf.cond_br %235, ^bb1(%c84_i8_111 : i8), ^bb90
   ^bb90:  // pred: ^bb89
-    %267 = arith.trunci %257 : i256 to i64
-    %c0_i64_142 = arith.constant 0 : i64
-    %268 = arith.cmpi slt, %267, %c0_i64_142 : i64
-    %c84_i8_143 = arith.constant 84 : i8
-    cf.cond_br %268, ^bb1(%c84_i8_143 : i8), ^bb91
+    %236 = arith.trunci %228 : i256 to i64
+    %c0_i64_112 = arith.constant 0 : i64
+    %237 = arith.cmpi slt, %236, %c0_i64_112 : i64
+    %c84_i8_113 = arith.constant 84 : i8
+    cf.cond_br %237, ^bb1(%c84_i8_113 : i8), ^bb91
   ^bb91:  // pred: ^bb90
-    %c0_i64_144 = arith.constant 0 : i64
-    %269 = arith.cmpi ne, %267, %c0_i64_144 : i64
-    cf.cond_br %269, ^bb140, ^bb92
+    %c0_i64_114 = arith.constant 0 : i64
+    %238 = arith.cmpi ne, %236, %c0_i64_114 : i64
+    cf.cond_br %238, ^bb140, ^bb92
   ^bb92:  // 2 preds: ^bb91, ^bb144
-    %c18446744073709551615_i256_145 = arith.constant 18446744073709551615 : i256
-    %270 = arith.cmpi sgt, %265, %c18446744073709551615_i256_145 : i256
-    %c84_i8_146 = arith.constant 84 : i8
-    cf.cond_br %270, ^bb1(%c84_i8_146 : i8), ^bb93
+    %c18446744073709551615_i256_115 = arith.constant 18446744073709551615 : i256
+    %239 = arith.cmpi sgt, %234, %c18446744073709551615_i256_115 : i256
+    %c84_i8_116 = arith.constant 84 : i8
+    cf.cond_br %239, ^bb1(%c84_i8_116 : i8), ^bb93
   ^bb93:  // pred: ^bb92
-    %271 = arith.trunci %265 : i256 to i64
-    %c0_i64_147 = arith.constant 0 : i64
-    %272 = arith.cmpi slt, %271, %c0_i64_147 : i64
-    %c84_i8_148 = arith.constant 84 : i8
-    cf.cond_br %272, ^bb1(%c84_i8_148 : i8), ^bb94
+    %240 = arith.trunci %234 : i256 to i64
+    %c0_i64_117 = arith.constant 0 : i64
+    %241 = arith.cmpi slt, %240, %c0_i64_117 : i64
+    %c84_i8_118 = arith.constant 84 : i8
+    cf.cond_br %241, ^bb1(%c84_i8_118 : i8), ^bb94
   ^bb94:  // pred: ^bb93
-    %c0_i64_149 = arith.constant 0 : i64
-    %273 = arith.cmpi ne, %271, %c0_i64_149 : i64
-    cf.cond_br %273, ^bb148, ^bb95
+    %c0_i64_119 = arith.constant 0 : i64
+    %242 = arith.cmpi ne, %240, %c0_i64_119 : i64
+    cf.cond_br %242, ^bb148, ^bb95
   ^bb95:  // 2 preds: ^bb94, ^bb152
-    %274 = arith.trunci %253 : i256 to i64
-    %275 = arith.trunci %261 : i256 to i64
-    %276 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i256_150 = arith.constant 1 : i256
-    %277 = llvm.alloca %c1_i256_150 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256_139, %277 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_151 = arith.constant 1 : i256
-    %278 = llvm.alloca %c1_i256_151 x i256 : (i256) -> !llvm.ptr
-    llvm.store %245, %278 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_152 = arith.constant 1 : i256
-    %279 = llvm.alloca %c1_i256_152 x i256 : (i256) -> !llvm.ptr
-    llvm.store %249, %279 {alignment = 1 : i64} : i256, !llvm.ptr
+    %243 = arith.trunci %225 : i256 to i64
+    %244 = arith.trunci %231 : i256 to i64
+    %245 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i256_120 = arith.constant 1 : i256
+    %246 = llvm.alloca %c1_i256_120 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256_109, %246 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_121 = arith.constant 1 : i256
+    %247 = llvm.alloca %c1_i256_121 x i256 : (i256) -> !llvm.ptr
+    llvm.store %219, %247 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_122 = arith.constant 1 : i256
+    %248 = llvm.alloca %c1_i256_122 x i256 : (i256) -> !llvm.ptr
+    llvm.store %222, %248 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i8 = arith.constant 1 : i8
-    %280 = call @dora_fn_call(%arg0, %278, %279, %277, %274, %267, %275, %271, %276, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %281 = llvm.getelementptr %280[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %282 = llvm.load %281 : !llvm.ptr -> i8
-    %283 = llvm.getelementptr %280[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %284 = llvm.load %283 : !llvm.ptr -> i8
-    %c0_i8_153 = arith.constant 0 : i8
-    %285 = arith.cmpi ne, %284, %c0_i8_153 : i8
-    cf.cond_br %285, ^bb1(%284 : i8), ^bb96
+    %249 = call @dora_fn_call(%arg0, %247, %248, %246, %243, %236, %244, %240, %245, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %250 = llvm.getelementptr %249[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %251 = llvm.load %250 : !llvm.ptr -> i8
+    %252 = llvm.getelementptr %249[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %253 = llvm.load %252 : !llvm.ptr -> i8
+    %c0_i8_123 = arith.constant 0 : i8
+    %254 = arith.cmpi ne, %253, %c0_i8_123 : i8
+    cf.cond_br %254, ^bb1(%253 : i8), ^bb96
   ^bb96:  // pred: ^bb95
-    %286 = llvm.getelementptr %280[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %287 = llvm.load %286 : !llvm.ptr -> i64
-    %288 = llvm.load %arg1 : !llvm.ptr -> i64
-    %289 = arith.cmpi ult, %288, %287 : i64
-    scf.if %289 {
+    %255 = llvm.getelementptr %249[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %256 = llvm.load %255 : !llvm.ptr -> i64
+    %257 = llvm.load %arg1 : !llvm.ptr -> i64
+    %258 = arith.cmpi ult, %257, %256 : i64
+    scf.if %258 {
     } else {
-      %486 = arith.subi %288, %287 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %257, %256 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_154 = arith.constant 80 : i8
-    cf.cond_br %289, ^bb1(%c80_i8_154 : i8), ^bb97
+    %c80_i8_124 = arith.constant 80 : i8
+    cf.cond_br %258, ^bb1(%c80_i8_124 : i8), ^bb97
   ^bb97:  // pred: ^bb96
-    %290 = arith.extui %282 : i8 to i256
-    %291 = llvm.load %arg3 : !llvm.ptr -> i64
-    %292 = llvm.getelementptr %arg2[%291] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_155 = arith.constant 1 : i64
-    %293 = arith.addi %291, %c1_i64_155 : i64
-    llvm.store %293, %arg3 : i64, !llvm.ptr
-    llvm.store %290, %292 : i256, !llvm.ptr
+    %259 = arith.extui %251 : i8 to i256
+    %260 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %259, %260 : i256, !llvm.ptr
+    %261 = llvm.getelementptr %260[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %261, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb103
   ^bb98:  // pred: ^bb100
-    %c1024_i64_156 = arith.constant 1024 : i64
-    %294 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_125 = arith.constant 1024 : i64
+    %262 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %295 = arith.addi %294, %c-5_i64 : i64
+    %263 = arith.addi %262, %c-5_i64 : i64
+    llvm.store %263, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %296 = arith.cmpi ult, %294, %c6_i64 : i64
-    %c91_i8_157 = arith.constant 91 : i8
-    cf.cond_br %296, ^bb1(%c91_i8_157 : i8), ^bb89
+    %264 = arith.cmpi ult, %262, %c6_i64 : i64
+    %c91_i8_126 = arith.constant 91 : i8
+    cf.cond_br %264, ^bb1(%c91_i8_126 : i8), ^bb89
   ^bb99:  // pred: ^bb85
-    %297 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_158 = arith.constant 0 : i64
+    %265 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_127 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %298 = arith.cmpi uge, %297, %c0_i64_158 : i64
-    %c80_i8_159 = arith.constant 80 : i8
-    cf.cond_br %298, ^bb100, ^bb1(%c80_i8_159 : i8)
+    %266 = arith.cmpi uge, %265, %c0_i64_127 : i64
+    %c80_i8_128 = arith.constant 80 : i8
+    cf.cond_br %266, ^bb100, ^bb1(%c80_i8_128 : i8)
   ^bb100:  // pred: ^bb99
-    %299 = arith.subi %297, %c0_i64_158 : i64
-    llvm.store %299, %arg1 : i64, !llvm.ptr
+    %267 = arith.subi %265, %c0_i64_127 : i64
+    llvm.store %267, %arg1 : i64, !llvm.ptr
     cf.br ^bb98
   ^bb101:  // pred: ^bb102
-    %300 = call @dora_fn_returndata_size(%arg0) : (!llvm.ptr) -> i64
-    %301 = arith.extui %300 : i64 to i256
-    %302 = llvm.load %arg3 : !llvm.ptr -> i64
-    %303 = llvm.getelementptr %arg2[%302] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_160 = arith.constant 1 : i64
-    %304 = arith.addi %302, %c1_i64_160 : i64
-    llvm.store %304, %arg3 : i64, !llvm.ptr
-    llvm.store %301, %303 : i256, !llvm.ptr
+    %268 = call @dora_fn_returndata_size(%arg0) : (!llvm.ptr) -> i64
+    %269 = arith.extui %268 : i64 to i256
+    %270 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %269, %270 : i256, !llvm.ptr
+    %271 = llvm.getelementptr %270[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %271, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb105
   ^bb102:  // pred: ^bb104
-    %c1024_i64_161 = arith.constant 1024 : i64
-    %305 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_162 = arith.constant 1 : i64
-    %306 = arith.addi %305, %c1_i64_162 : i64
-    %307 = arith.cmpi ult, %c1024_i64_161, %306 : i64
-    %c92_i8_163 = arith.constant 92 : i8
-    cf.cond_br %307, ^bb1(%c92_i8_163 : i8), ^bb101
+    %c1024_i64_129 = arith.constant 1024 : i64
+    %272 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_130 = arith.constant 1 : i64
+    %273 = arith.addi %272, %c1_i64_130 : i64
+    llvm.store %273, %arg3 : i64, !llvm.ptr
+    %274 = arith.cmpi ult, %c1024_i64_129, %273 : i64
+    %c92_i8_131 = arith.constant 92 : i8
+    cf.cond_br %274, ^bb1(%c92_i8_131 : i8), ^bb101
   ^bb103:  // pred: ^bb97
-    %308 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_164 = arith.constant 2 : i64
+    %275 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_132 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %309 = arith.cmpi uge, %308, %c2_i64_164 : i64
-    %c80_i8_165 = arith.constant 80 : i8
-    cf.cond_br %309, ^bb104, ^bb1(%c80_i8_165 : i8)
+    %276 = arith.cmpi uge, %275, %c2_i64_132 : i64
+    %c80_i8_133 = arith.constant 80 : i8
+    cf.cond_br %276, ^bb104, ^bb1(%c80_i8_133 : i8)
   ^bb104:  // pred: ^bb103
-    %310 = arith.subi %308, %c2_i64_164 : i64
-    llvm.store %310, %arg1 : i64, !llvm.ptr
+    %277 = arith.subi %275, %c2_i64_132 : i64
+    llvm.store %277, %arg1 : i64, !llvm.ptr
     cf.br ^bb102
   ^bb105:  // pred: ^bb101
-    %c0_i64_166 = arith.constant 0 : i64
-    %c1_i8_167 = arith.constant 1 : i8
-    %311 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_166, %c0_i64_166, %311, %c1_i8_167) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %c1_i8_167 : i8
+    %c0_i64_134 = arith.constant 0 : i64
+    %c1_i8_135 = arith.constant 1 : i8
+    %278 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_134, %c0_i64_134, %278, %c1_i8_135) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %c1_i8_135 : i8
   ^bb106:  // pred: ^bb11
-    %c18446744073709551615_i256_168 = arith.constant 18446744073709551615 : i256
-    %312 = arith.cmpi sgt, %24, %c18446744073709551615_i256_168 : i256
-    %c84_i8_169 = arith.constant 84 : i8
-    cf.cond_br %312, ^bb1(%c84_i8_169 : i8), ^bb107
+    %c18446744073709551615_i256_136 = arith.constant 18446744073709551615 : i256
+    %279 = arith.cmpi sgt, %22, %c18446744073709551615_i256_136 : i256
+    %c84_i8_137 = arith.constant 84 : i8
+    cf.cond_br %279, ^bb1(%c84_i8_137 : i8), ^bb107
   ^bb107:  // pred: ^bb106
-    %313 = arith.trunci %24 : i256 to i64
-    %c0_i64_170 = arith.constant 0 : i64
-    %314 = arith.cmpi slt, %313, %c0_i64_170 : i64
-    %c84_i8_171 = arith.constant 84 : i8
-    cf.cond_br %314, ^bb1(%c84_i8_171 : i8), ^bb108
+    %280 = arith.trunci %22 : i256 to i64
+    %c0_i64_138 = arith.constant 0 : i64
+    %281 = arith.cmpi slt, %280, %c0_i64_138 : i64
+    %c84_i8_139 = arith.constant 84 : i8
+    cf.cond_br %281, ^bb1(%c84_i8_139 : i8), ^bb108
   ^bb108:  // pred: ^bb107
-    %315 = arith.addi %313, %c32_i64 : i64
-    %c0_i64_172 = arith.constant 0 : i64
-    %316 = arith.cmpi slt, %315, %c0_i64_172 : i64
-    %c84_i8_173 = arith.constant 84 : i8
-    cf.cond_br %316, ^bb1(%c84_i8_173 : i8), ^bb109
+    %282 = arith.addi %280, %c32_i64 : i64
+    %c0_i64_140 = arith.constant 0 : i64
+    %283 = arith.cmpi slt, %282, %c0_i64_140 : i64
+    %c84_i8_141 = arith.constant 84 : i8
+    cf.cond_br %283, ^bb1(%c84_i8_141 : i8), ^bb109
   ^bb109:  // pred: ^bb108
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_174 = arith.constant 32 : i64
-    %317 = arith.addi %315, %c31_i64 : i64
-    %318 = arith.divui %317, %c32_i64_174 : i64
-    %c32_i64_175 = arith.constant 32 : i64
-    %319 = arith.muli %318, %c32_i64_175 : i64
-    %320 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_176 = arith.constant 31 : i64
-    %c32_i64_177 = arith.constant 32 : i64
-    %321 = arith.addi %320, %c31_i64_176 : i64
-    %322 = arith.divui %321, %c32_i64_177 : i64
-    %323 = arith.muli %322, %c32_i64_175 : i64
-    %324 = arith.cmpi ult, %323, %319 : i64
-    cf.cond_br %324, ^bb111, ^bb110
+    %c32_i64_142 = arith.constant 32 : i64
+    %284 = arith.addi %282, %c31_i64 : i64
+    %285 = arith.divui %284, %c32_i64_142 : i64
+    %c32_i64_143 = arith.constant 32 : i64
+    %286 = arith.muli %285, %c32_i64_143 : i64
+    %287 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_144 = arith.constant 31 : i64
+    %c32_i64_145 = arith.constant 32 : i64
+    %288 = arith.addi %287, %c31_i64_144 : i64
+    %289 = arith.divui %288, %c32_i64_145 : i64
+    %290 = arith.muli %289, %c32_i64_143 : i64
+    %291 = arith.cmpi ult, %290, %286 : i64
+    cf.cond_br %291, ^bb111, ^bb110
   ^bb110:  // 2 preds: ^bb109, ^bb113
     cf.br ^bb12
   ^bb111:  // pred: ^bb109
-    %c3_i64_178 = arith.constant 3 : i64
+    %c3_i64_146 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %325 = arith.muli %322, %322 : i64
-    %326 = arith.divui %325, %c512_i64 : i64
-    %327 = arith.muli %322, %c3_i64_178 : i64
-    %328 = arith.addi %326, %327 : i64
-    %c3_i64_179 = arith.constant 3 : i64
-    %c512_i64_180 = arith.constant 512 : i64
-    %329 = arith.muli %318, %318 : i64
-    %330 = arith.divui %329, %c512_i64_180 : i64
-    %331 = arith.muli %318, %c3_i64_179 : i64
-    %332 = arith.addi %330, %331 : i64
-    %333 = arith.subi %332, %328 : i64
-    %334 = llvm.load %arg1 : !llvm.ptr -> i64
-    %335 = arith.cmpi ult, %334, %333 : i64
-    scf.if %335 {
+    %292 = arith.muli %289, %289 : i64
+    %293 = arith.divui %292, %c512_i64 : i64
+    %294 = arith.muli %289, %c3_i64_146 : i64
+    %295 = arith.addi %293, %294 : i64
+    %c3_i64_147 = arith.constant 3 : i64
+    %c512_i64_148 = arith.constant 512 : i64
+    %296 = arith.muli %285, %285 : i64
+    %297 = arith.divui %296, %c512_i64_148 : i64
+    %298 = arith.muli %285, %c3_i64_147 : i64
+    %299 = arith.addi %297, %298 : i64
+    %300 = arith.subi %299, %295 : i64
+    %301 = llvm.load %arg1 : !llvm.ptr -> i64
+    %302 = arith.cmpi ult, %301, %300 : i64
+    scf.if %302 {
     } else {
-      %486 = arith.subi %334, %333 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %301, %300 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_181 = arith.constant 80 : i8
-    cf.cond_br %335, ^bb1(%c80_i8_181 : i8), ^bb112
+    %c80_i8_149 = arith.constant 80 : i8
+    cf.cond_br %302, ^bb1(%c80_i8_149 : i8), ^bb112
   ^bb112:  // pred: ^bb111
-    %336 = call @dora_fn_extend_memory(%arg0, %319) : (!llvm.ptr, i64) -> !llvm.ptr
-    %337 = llvm.getelementptr %336[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %338 = llvm.load %337 : !llvm.ptr -> i8
-    %c0_i8_182 = arith.constant 0 : i8
-    %339 = arith.cmpi ne, %338, %c0_i8_182 : i8
-    cf.cond_br %339, ^bb1(%338 : i8), ^bb113
+    %303 = call @dora_fn_extend_memory(%arg0, %286) : (!llvm.ptr, i64) -> !llvm.ptr
+    %304 = llvm.getelementptr %303[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %305 = llvm.load %304 : !llvm.ptr -> i8
+    %c0_i8_150 = arith.constant 0 : i8
+    %306 = arith.cmpi ne, %305, %c0_i8_150 : i8
+    cf.cond_br %306, ^bb1(%305 : i8), ^bb113
   ^bb113:  // pred: ^bb112
     cf.br ^bb110
   ^bb114:  // pred: ^bb24
-    %c18446744073709551615_i256_183 = arith.constant 18446744073709551615 : i256
-    %340 = arith.cmpi sgt, %61, %c18446744073709551615_i256_183 : i256
-    %c84_i8_184 = arith.constant 84 : i8
-    cf.cond_br %340, ^bb1(%c84_i8_184 : i8), ^bb115
+    %c18446744073709551615_i256_151 = arith.constant 18446744073709551615 : i256
+    %307 = arith.cmpi sgt, %55, %c18446744073709551615_i256_151 : i256
+    %c84_i8_152 = arith.constant 84 : i8
+    cf.cond_br %307, ^bb1(%c84_i8_152 : i8), ^bb115
   ^bb115:  // pred: ^bb114
-    %341 = arith.trunci %61 : i256 to i64
-    %c0_i64_185 = arith.constant 0 : i64
-    %342 = arith.cmpi slt, %341, %c0_i64_185 : i64
-    %c84_i8_186 = arith.constant 84 : i8
-    cf.cond_br %342, ^bb1(%c84_i8_186 : i8), ^bb116
+    %308 = arith.trunci %55 : i256 to i64
+    %c0_i64_153 = arith.constant 0 : i64
+    %309 = arith.cmpi slt, %308, %c0_i64_153 : i64
+    %c84_i8_154 = arith.constant 84 : i8
+    cf.cond_br %309, ^bb1(%c84_i8_154 : i8), ^bb116
   ^bb116:  // pred: ^bb115
-    %343 = arith.addi %341, %c32_i64_27 : i64
-    %c0_i64_187 = arith.constant 0 : i64
-    %344 = arith.cmpi slt, %343, %c0_i64_187 : i64
-    %c84_i8_188 = arith.constant 84 : i8
-    cf.cond_br %344, ^bb1(%c84_i8_188 : i8), ^bb117
+    %310 = arith.addi %308, %c32_i64_20 : i64
+    %c0_i64_155 = arith.constant 0 : i64
+    %311 = arith.cmpi slt, %310, %c0_i64_155 : i64
+    %c84_i8_156 = arith.constant 84 : i8
+    cf.cond_br %311, ^bb1(%c84_i8_156 : i8), ^bb117
   ^bb117:  // pred: ^bb116
-    %c31_i64_189 = arith.constant 31 : i64
-    %c32_i64_190 = arith.constant 32 : i64
-    %345 = arith.addi %343, %c31_i64_189 : i64
-    %346 = arith.divui %345, %c32_i64_190 : i64
-    %c32_i64_191 = arith.constant 32 : i64
-    %347 = arith.muli %346, %c32_i64_191 : i64
-    %348 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_192 = arith.constant 31 : i64
-    %c32_i64_193 = arith.constant 32 : i64
-    %349 = arith.addi %348, %c31_i64_192 : i64
-    %350 = arith.divui %349, %c32_i64_193 : i64
-    %351 = arith.muli %350, %c32_i64_191 : i64
-    %352 = arith.cmpi ult, %351, %347 : i64
-    cf.cond_br %352, ^bb119, ^bb118
+    %c31_i64_157 = arith.constant 31 : i64
+    %c32_i64_158 = arith.constant 32 : i64
+    %312 = arith.addi %310, %c31_i64_157 : i64
+    %313 = arith.divui %312, %c32_i64_158 : i64
+    %c32_i64_159 = arith.constant 32 : i64
+    %314 = arith.muli %313, %c32_i64_159 : i64
+    %315 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_160 = arith.constant 31 : i64
+    %c32_i64_161 = arith.constant 32 : i64
+    %316 = arith.addi %315, %c31_i64_160 : i64
+    %317 = arith.divui %316, %c32_i64_161 : i64
+    %318 = arith.muli %317, %c32_i64_159 : i64
+    %319 = arith.cmpi ult, %318, %314 : i64
+    cf.cond_br %319, ^bb119, ^bb118
   ^bb118:  // 2 preds: ^bb117, ^bb121
     cf.br ^bb25
   ^bb119:  // pred: ^bb117
-    %c3_i64_194 = arith.constant 3 : i64
-    %c512_i64_195 = arith.constant 512 : i64
-    %353 = arith.muli %350, %350 : i64
-    %354 = arith.divui %353, %c512_i64_195 : i64
-    %355 = arith.muli %350, %c3_i64_194 : i64
-    %356 = arith.addi %354, %355 : i64
-    %c3_i64_196 = arith.constant 3 : i64
-    %c512_i64_197 = arith.constant 512 : i64
-    %357 = arith.muli %346, %346 : i64
-    %358 = arith.divui %357, %c512_i64_197 : i64
-    %359 = arith.muli %346, %c3_i64_196 : i64
-    %360 = arith.addi %358, %359 : i64
-    %361 = arith.subi %360, %356 : i64
-    %362 = llvm.load %arg1 : !llvm.ptr -> i64
-    %363 = arith.cmpi ult, %362, %361 : i64
-    scf.if %363 {
+    %c3_i64_162 = arith.constant 3 : i64
+    %c512_i64_163 = arith.constant 512 : i64
+    %320 = arith.muli %317, %317 : i64
+    %321 = arith.divui %320, %c512_i64_163 : i64
+    %322 = arith.muli %317, %c3_i64_162 : i64
+    %323 = arith.addi %321, %322 : i64
+    %c3_i64_164 = arith.constant 3 : i64
+    %c512_i64_165 = arith.constant 512 : i64
+    %324 = arith.muli %313, %313 : i64
+    %325 = arith.divui %324, %c512_i64_165 : i64
+    %326 = arith.muli %313, %c3_i64_164 : i64
+    %327 = arith.addi %325, %326 : i64
+    %328 = arith.subi %327, %323 : i64
+    %329 = llvm.load %arg1 : !llvm.ptr -> i64
+    %330 = arith.cmpi ult, %329, %328 : i64
+    scf.if %330 {
     } else {
-      %486 = arith.subi %362, %361 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %329, %328 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_198 = arith.constant 80 : i8
-    cf.cond_br %363, ^bb1(%c80_i8_198 : i8), ^bb120
+    %c80_i8_166 = arith.constant 80 : i8
+    cf.cond_br %330, ^bb1(%c80_i8_166 : i8), ^bb120
   ^bb120:  // pred: ^bb119
-    %364 = call @dora_fn_extend_memory(%arg0, %347) : (!llvm.ptr, i64) -> !llvm.ptr
-    %365 = llvm.getelementptr %364[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %366 = llvm.load %365 : !llvm.ptr -> i8
-    %c0_i8_199 = arith.constant 0 : i8
-    %367 = arith.cmpi ne, %366, %c0_i8_199 : i8
-    cf.cond_br %367, ^bb1(%366 : i8), ^bb121
+    %331 = call @dora_fn_extend_memory(%arg0, %314) : (!llvm.ptr, i64) -> !llvm.ptr
+    %332 = llvm.getelementptr %331[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %333 = llvm.load %332 : !llvm.ptr -> i8
+    %c0_i8_167 = arith.constant 0 : i8
+    %334 = arith.cmpi ne, %333, %c0_i8_167 : i8
+    cf.cond_br %334, ^bb1(%333 : i8), ^bb121
   ^bb121:  // pred: ^bb120
     cf.br ^bb118
   ^bb122:  // pred: ^bb37
-    %c18446744073709551615_i256_200 = arith.constant 18446744073709551615 : i256
-    %368 = arith.cmpi sgt, %98, %c18446744073709551615_i256_200 : i256
-    %c84_i8_201 = arith.constant 84 : i8
-    cf.cond_br %368, ^bb1(%c84_i8_201 : i8), ^bb123
+    %c18446744073709551615_i256_168 = arith.constant 18446744073709551615 : i256
+    %335 = arith.cmpi sgt, %88, %c18446744073709551615_i256_168 : i256
+    %c84_i8_169 = arith.constant 84 : i8
+    cf.cond_br %335, ^bb1(%c84_i8_169 : i8), ^bb123
   ^bb123:  // pred: ^bb122
-    %369 = arith.trunci %98 : i256 to i64
-    %c0_i64_202 = arith.constant 0 : i64
-    %370 = arith.cmpi slt, %369, %c0_i64_202 : i64
-    %c84_i8_203 = arith.constant 84 : i8
-    cf.cond_br %370, ^bb1(%c84_i8_203 : i8), ^bb124
+    %336 = arith.trunci %88 : i256 to i64
+    %c0_i64_170 = arith.constant 0 : i64
+    %337 = arith.cmpi slt, %336, %c0_i64_170 : i64
+    %c84_i8_171 = arith.constant 84 : i8
+    cf.cond_br %337, ^bb1(%c84_i8_171 : i8), ^bb124
   ^bb124:  // pred: ^bb123
-    %371 = arith.addi %369, %c32_i64_49 : i64
-    %c0_i64_204 = arith.constant 0 : i64
-    %372 = arith.cmpi slt, %371, %c0_i64_204 : i64
-    %c84_i8_205 = arith.constant 84 : i8
-    cf.cond_br %372, ^bb1(%c84_i8_205 : i8), ^bb125
+    %338 = arith.addi %336, %c32_i64_38 : i64
+    %c0_i64_172 = arith.constant 0 : i64
+    %339 = arith.cmpi slt, %338, %c0_i64_172 : i64
+    %c84_i8_173 = arith.constant 84 : i8
+    cf.cond_br %339, ^bb1(%c84_i8_173 : i8), ^bb125
   ^bb125:  // pred: ^bb124
-    %c31_i64_206 = arith.constant 31 : i64
-    %c32_i64_207 = arith.constant 32 : i64
-    %373 = arith.addi %371, %c31_i64_206 : i64
-    %374 = arith.divui %373, %c32_i64_207 : i64
-    %c32_i64_208 = arith.constant 32 : i64
-    %375 = arith.muli %374, %c32_i64_208 : i64
-    %376 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_209 = arith.constant 31 : i64
-    %c32_i64_210 = arith.constant 32 : i64
-    %377 = arith.addi %376, %c31_i64_209 : i64
-    %378 = arith.divui %377, %c32_i64_210 : i64
-    %379 = arith.muli %378, %c32_i64_208 : i64
-    %380 = arith.cmpi ult, %379, %375 : i64
-    cf.cond_br %380, ^bb127, ^bb126
+    %c31_i64_174 = arith.constant 31 : i64
+    %c32_i64_175 = arith.constant 32 : i64
+    %340 = arith.addi %338, %c31_i64_174 : i64
+    %341 = arith.divui %340, %c32_i64_175 : i64
+    %c32_i64_176 = arith.constant 32 : i64
+    %342 = arith.muli %341, %c32_i64_176 : i64
+    %343 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_177 = arith.constant 31 : i64
+    %c32_i64_178 = arith.constant 32 : i64
+    %344 = arith.addi %343, %c31_i64_177 : i64
+    %345 = arith.divui %344, %c32_i64_178 : i64
+    %346 = arith.muli %345, %c32_i64_176 : i64
+    %347 = arith.cmpi ult, %346, %342 : i64
+    cf.cond_br %347, ^bb127, ^bb126
   ^bb126:  // 2 preds: ^bb125, ^bb129
     cf.br ^bb38
   ^bb127:  // pred: ^bb125
-    %c3_i64_211 = arith.constant 3 : i64
-    %c512_i64_212 = arith.constant 512 : i64
-    %381 = arith.muli %378, %378 : i64
-    %382 = arith.divui %381, %c512_i64_212 : i64
-    %383 = arith.muli %378, %c3_i64_211 : i64
-    %384 = arith.addi %382, %383 : i64
-    %c3_i64_213 = arith.constant 3 : i64
-    %c512_i64_214 = arith.constant 512 : i64
-    %385 = arith.muli %374, %374 : i64
-    %386 = arith.divui %385, %c512_i64_214 : i64
-    %387 = arith.muli %374, %c3_i64_213 : i64
-    %388 = arith.addi %386, %387 : i64
-    %389 = arith.subi %388, %384 : i64
-    %390 = llvm.load %arg1 : !llvm.ptr -> i64
-    %391 = arith.cmpi ult, %390, %389 : i64
-    scf.if %391 {
+    %c3_i64_179 = arith.constant 3 : i64
+    %c512_i64_180 = arith.constant 512 : i64
+    %348 = arith.muli %345, %345 : i64
+    %349 = arith.divui %348, %c512_i64_180 : i64
+    %350 = arith.muli %345, %c3_i64_179 : i64
+    %351 = arith.addi %349, %350 : i64
+    %c3_i64_181 = arith.constant 3 : i64
+    %c512_i64_182 = arith.constant 512 : i64
+    %352 = arith.muli %341, %341 : i64
+    %353 = arith.divui %352, %c512_i64_182 : i64
+    %354 = arith.muli %341, %c3_i64_181 : i64
+    %355 = arith.addi %353, %354 : i64
+    %356 = arith.subi %355, %351 : i64
+    %357 = llvm.load %arg1 : !llvm.ptr -> i64
+    %358 = arith.cmpi ult, %357, %356 : i64
+    scf.if %358 {
     } else {
-      %486 = arith.subi %390, %389 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %357, %356 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_215 = arith.constant 80 : i8
-    cf.cond_br %391, ^bb1(%c80_i8_215 : i8), ^bb128
+    %c80_i8_183 = arith.constant 80 : i8
+    cf.cond_br %358, ^bb1(%c80_i8_183 : i8), ^bb128
   ^bb128:  // pred: ^bb127
-    %392 = call @dora_fn_extend_memory(%arg0, %375) : (!llvm.ptr, i64) -> !llvm.ptr
-    %393 = llvm.getelementptr %392[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %394 = llvm.load %393 : !llvm.ptr -> i8
-    %c0_i8_216 = arith.constant 0 : i8
-    %395 = arith.cmpi ne, %394, %c0_i8_216 : i8
-    cf.cond_br %395, ^bb1(%394 : i8), ^bb129
+    %359 = call @dora_fn_extend_memory(%arg0, %342) : (!llvm.ptr, i64) -> !llvm.ptr
+    %360 = llvm.getelementptr %359[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %361 = llvm.load %360 : !llvm.ptr -> i8
+    %c0_i8_184 = arith.constant 0 : i8
+    %362 = arith.cmpi ne, %361, %c0_i8_184 : i8
+    cf.cond_br %362, ^bb1(%361 : i8), ^bb129
   ^bb129:  // pred: ^bb128
     cf.br ^bb126
   ^bb130:  // pred: ^bb57
     %c49152_i64 = arith.constant 49152 : i64
-    %396 = arith.cmpi ugt, %156, %c49152_i64 : i64
+    %363 = arith.cmpi ugt, %139, %c49152_i64 : i64
     %c100_i8 = arith.constant 100 : i8
-    cf.cond_br %396, ^bb1(%c100_i8 : i8), ^bb131
+    cf.cond_br %363, ^bb1(%c100_i8 : i8), ^bb131
   ^bb131:  // pred: ^bb130
-    %c31_i64_217 = arith.constant 31 : i64
-    %c32_i64_218 = arith.constant 32 : i64
-    %397 = arith.addi %156, %c31_i64_217 : i64
-    %398 = arith.divui %397, %c32_i64_218 : i64
-    %c2_i64_219 = arith.constant 2 : i64
-    %399 = arith.muli %398, %c2_i64_219 : i64
-    %400 = llvm.load %arg1 : !llvm.ptr -> i64
-    %401 = arith.cmpi ult, %400, %399 : i64
-    scf.if %401 {
+    %c31_i64_185 = arith.constant 31 : i64
+    %c32_i64_186 = arith.constant 32 : i64
+    %364 = arith.addi %139, %c31_i64_185 : i64
+    %365 = arith.divui %364, %c32_i64_186 : i64
+    %c2_i64_187 = arith.constant 2 : i64
+    %366 = arith.muli %365, %c2_i64_187 : i64
+    %367 = llvm.load %arg1 : !llvm.ptr -> i64
+    %368 = arith.cmpi ult, %367, %366 : i64
+    scf.if %368 {
     } else {
-      %486 = arith.subi %400, %399 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %367, %366 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_220 = arith.constant 80 : i8
-    cf.cond_br %401, ^bb1(%c80_i8_220 : i8), ^bb132
+    %c80_i8_188 = arith.constant 80 : i8
+    cf.cond_br %368, ^bb1(%c80_i8_188 : i8), ^bb132
   ^bb132:  // pred: ^bb131
-    %c18446744073709551615_i256_221 = arith.constant 18446744073709551615 : i256
-    %402 = arith.cmpi sgt, %148, %c18446744073709551615_i256_221 : i256
-    %c84_i8_222 = arith.constant 84 : i8
-    cf.cond_br %402, ^bb1(%c84_i8_222 : i8), ^bb133
+    %c18446744073709551615_i256_189 = arith.constant 18446744073709551615 : i256
+    %369 = arith.cmpi sgt, %132, %c18446744073709551615_i256_189 : i256
+    %c84_i8_190 = arith.constant 84 : i8
+    cf.cond_br %369, ^bb1(%c84_i8_190 : i8), ^bb133
   ^bb133:  // pred: ^bb132
-    %403 = arith.trunci %148 : i256 to i64
-    %c0_i64_223 = arith.constant 0 : i64
-    %404 = arith.cmpi slt, %403, %c0_i64_223 : i64
-    %c84_i8_224 = arith.constant 84 : i8
-    cf.cond_br %404, ^bb1(%c84_i8_224 : i8), ^bb134
+    %370 = arith.trunci %132 : i256 to i64
+    %c0_i64_191 = arith.constant 0 : i64
+    %371 = arith.cmpi slt, %370, %c0_i64_191 : i64
+    %c84_i8_192 = arith.constant 84 : i8
+    cf.cond_br %371, ^bb1(%c84_i8_192 : i8), ^bb134
   ^bb134:  // pred: ^bb133
-    %405 = arith.addi %403, %156 : i64
-    %c0_i64_225 = arith.constant 0 : i64
-    %406 = arith.cmpi slt, %405, %c0_i64_225 : i64
-    %c84_i8_226 = arith.constant 84 : i8
-    cf.cond_br %406, ^bb1(%c84_i8_226 : i8), ^bb135
+    %372 = arith.addi %370, %139 : i64
+    %c0_i64_193 = arith.constant 0 : i64
+    %373 = arith.cmpi slt, %372, %c0_i64_193 : i64
+    %c84_i8_194 = arith.constant 84 : i8
+    cf.cond_br %373, ^bb1(%c84_i8_194 : i8), ^bb135
   ^bb135:  // pred: ^bb134
-    %c31_i64_227 = arith.constant 31 : i64
-    %c32_i64_228 = arith.constant 32 : i64
-    %407 = arith.addi %405, %c31_i64_227 : i64
-    %408 = arith.divui %407, %c32_i64_228 : i64
-    %c32_i64_229 = arith.constant 32 : i64
-    %409 = arith.muli %408, %c32_i64_229 : i64
-    %410 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_230 = arith.constant 31 : i64
-    %c32_i64_231 = arith.constant 32 : i64
-    %411 = arith.addi %410, %c31_i64_230 : i64
-    %412 = arith.divui %411, %c32_i64_231 : i64
-    %413 = arith.muli %412, %c32_i64_229 : i64
-    %414 = arith.cmpi ult, %413, %409 : i64
-    cf.cond_br %414, ^bb137, ^bb136
+    %c31_i64_195 = arith.constant 31 : i64
+    %c32_i64_196 = arith.constant 32 : i64
+    %374 = arith.addi %372, %c31_i64_195 : i64
+    %375 = arith.divui %374, %c32_i64_196 : i64
+    %c32_i64_197 = arith.constant 32 : i64
+    %376 = arith.muli %375, %c32_i64_197 : i64
+    %377 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_198 = arith.constant 31 : i64
+    %c32_i64_199 = arith.constant 32 : i64
+    %378 = arith.addi %377, %c31_i64_198 : i64
+    %379 = arith.divui %378, %c32_i64_199 : i64
+    %380 = arith.muli %379, %c32_i64_197 : i64
+    %381 = arith.cmpi ult, %380, %376 : i64
+    cf.cond_br %381, ^bb137, ^bb136
   ^bb136:  // 2 preds: ^bb135, ^bb139
     cf.br ^bb58
   ^bb137:  // pred: ^bb135
-    %c3_i64_232 = arith.constant 3 : i64
-    %c512_i64_233 = arith.constant 512 : i64
-    %415 = arith.muli %412, %412 : i64
-    %416 = arith.divui %415, %c512_i64_233 : i64
-    %417 = arith.muli %412, %c3_i64_232 : i64
-    %418 = arith.addi %416, %417 : i64
-    %c3_i64_234 = arith.constant 3 : i64
-    %c512_i64_235 = arith.constant 512 : i64
-    %419 = arith.muli %408, %408 : i64
-    %420 = arith.divui %419, %c512_i64_235 : i64
-    %421 = arith.muli %408, %c3_i64_234 : i64
-    %422 = arith.addi %420, %421 : i64
-    %423 = arith.subi %422, %418 : i64
-    %424 = llvm.load %arg1 : !llvm.ptr -> i64
-    %425 = arith.cmpi ult, %424, %423 : i64
-    scf.if %425 {
+    %c3_i64_200 = arith.constant 3 : i64
+    %c512_i64_201 = arith.constant 512 : i64
+    %382 = arith.muli %379, %379 : i64
+    %383 = arith.divui %382, %c512_i64_201 : i64
+    %384 = arith.muli %379, %c3_i64_200 : i64
+    %385 = arith.addi %383, %384 : i64
+    %c3_i64_202 = arith.constant 3 : i64
+    %c512_i64_203 = arith.constant 512 : i64
+    %386 = arith.muli %375, %375 : i64
+    %387 = arith.divui %386, %c512_i64_203 : i64
+    %388 = arith.muli %375, %c3_i64_202 : i64
+    %389 = arith.addi %387, %388 : i64
+    %390 = arith.subi %389, %385 : i64
+    %391 = llvm.load %arg1 : !llvm.ptr -> i64
+    %392 = arith.cmpi ult, %391, %390 : i64
+    scf.if %392 {
     } else {
-      %486 = arith.subi %424, %423 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %391, %390 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_236 = arith.constant 80 : i8
-    cf.cond_br %425, ^bb1(%c80_i8_236 : i8), ^bb138
+    %c80_i8_204 = arith.constant 80 : i8
+    cf.cond_br %392, ^bb1(%c80_i8_204 : i8), ^bb138
   ^bb138:  // pred: ^bb137
-    %426 = call @dora_fn_extend_memory(%arg0, %409) : (!llvm.ptr, i64) -> !llvm.ptr
-    %427 = llvm.getelementptr %426[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %428 = llvm.load %427 : !llvm.ptr -> i8
-    %c0_i8_237 = arith.constant 0 : i8
-    %429 = arith.cmpi ne, %428, %c0_i8_237 : i8
-    cf.cond_br %429, ^bb1(%428 : i8), ^bb139
+    %393 = call @dora_fn_extend_memory(%arg0, %376) : (!llvm.ptr, i64) -> !llvm.ptr
+    %394 = llvm.getelementptr %393[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %395 = llvm.load %394 : !llvm.ptr -> i8
+    %c0_i8_205 = arith.constant 0 : i8
+    %396 = arith.cmpi ne, %395, %c0_i8_205 : i8
+    cf.cond_br %396, ^bb1(%395 : i8), ^bb139
   ^bb139:  // pred: ^bb138
     cf.br ^bb136
   ^bb140:  // pred: ^bb91
-    %c18446744073709551615_i256_238 = arith.constant 18446744073709551615 : i256
-    %430 = arith.cmpi sgt, %253, %c18446744073709551615_i256_238 : i256
-    %c84_i8_239 = arith.constant 84 : i8
-    cf.cond_br %430, ^bb1(%c84_i8_239 : i8), ^bb141
+    %c18446744073709551615_i256_206 = arith.constant 18446744073709551615 : i256
+    %397 = arith.cmpi sgt, %225, %c18446744073709551615_i256_206 : i256
+    %c84_i8_207 = arith.constant 84 : i8
+    cf.cond_br %397, ^bb1(%c84_i8_207 : i8), ^bb141
   ^bb141:  // pred: ^bb140
-    %431 = arith.trunci %253 : i256 to i64
-    %c0_i64_240 = arith.constant 0 : i64
-    %432 = arith.cmpi slt, %431, %c0_i64_240 : i64
-    %c84_i8_241 = arith.constant 84 : i8
-    cf.cond_br %432, ^bb1(%c84_i8_241 : i8), ^bb142
+    %398 = arith.trunci %225 : i256 to i64
+    %c0_i64_208 = arith.constant 0 : i64
+    %399 = arith.cmpi slt, %398, %c0_i64_208 : i64
+    %c84_i8_209 = arith.constant 84 : i8
+    cf.cond_br %399, ^bb1(%c84_i8_209 : i8), ^bb142
   ^bb142:  // pred: ^bb141
-    %433 = arith.addi %431, %267 : i64
-    %c0_i64_242 = arith.constant 0 : i64
-    %434 = arith.cmpi slt, %433, %c0_i64_242 : i64
-    %c84_i8_243 = arith.constant 84 : i8
-    cf.cond_br %434, ^bb1(%c84_i8_243 : i8), ^bb143
+    %400 = arith.addi %398, %236 : i64
+    %c0_i64_210 = arith.constant 0 : i64
+    %401 = arith.cmpi slt, %400, %c0_i64_210 : i64
+    %c84_i8_211 = arith.constant 84 : i8
+    cf.cond_br %401, ^bb1(%c84_i8_211 : i8), ^bb143
   ^bb143:  // pred: ^bb142
-    %c31_i64_244 = arith.constant 31 : i64
-    %c32_i64_245 = arith.constant 32 : i64
-    %435 = arith.addi %433, %c31_i64_244 : i64
-    %436 = arith.divui %435, %c32_i64_245 : i64
-    %c32_i64_246 = arith.constant 32 : i64
-    %437 = arith.muli %436, %c32_i64_246 : i64
-    %438 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_247 = arith.constant 31 : i64
-    %c32_i64_248 = arith.constant 32 : i64
-    %439 = arith.addi %438, %c31_i64_247 : i64
-    %440 = arith.divui %439, %c32_i64_248 : i64
-    %441 = arith.muli %440, %c32_i64_246 : i64
-    %442 = arith.cmpi ult, %441, %437 : i64
-    cf.cond_br %442, ^bb145, ^bb144
+    %c31_i64_212 = arith.constant 31 : i64
+    %c32_i64_213 = arith.constant 32 : i64
+    %402 = arith.addi %400, %c31_i64_212 : i64
+    %403 = arith.divui %402, %c32_i64_213 : i64
+    %c32_i64_214 = arith.constant 32 : i64
+    %404 = arith.muli %403, %c32_i64_214 : i64
+    %405 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_215 = arith.constant 31 : i64
+    %c32_i64_216 = arith.constant 32 : i64
+    %406 = arith.addi %405, %c31_i64_215 : i64
+    %407 = arith.divui %406, %c32_i64_216 : i64
+    %408 = arith.muli %407, %c32_i64_214 : i64
+    %409 = arith.cmpi ult, %408, %404 : i64
+    cf.cond_br %409, ^bb145, ^bb144
   ^bb144:  // 2 preds: ^bb143, ^bb147
     cf.br ^bb92
   ^bb145:  // pred: ^bb143
-    %c3_i64_249 = arith.constant 3 : i64
-    %c512_i64_250 = arith.constant 512 : i64
-    %443 = arith.muli %440, %440 : i64
-    %444 = arith.divui %443, %c512_i64_250 : i64
-    %445 = arith.muli %440, %c3_i64_249 : i64
-    %446 = arith.addi %444, %445 : i64
-    %c3_i64_251 = arith.constant 3 : i64
-    %c512_i64_252 = arith.constant 512 : i64
-    %447 = arith.muli %436, %436 : i64
-    %448 = arith.divui %447, %c512_i64_252 : i64
-    %449 = arith.muli %436, %c3_i64_251 : i64
-    %450 = arith.addi %448, %449 : i64
-    %451 = arith.subi %450, %446 : i64
-    %452 = llvm.load %arg1 : !llvm.ptr -> i64
-    %453 = arith.cmpi ult, %452, %451 : i64
-    scf.if %453 {
+    %c3_i64_217 = arith.constant 3 : i64
+    %c512_i64_218 = arith.constant 512 : i64
+    %410 = arith.muli %407, %407 : i64
+    %411 = arith.divui %410, %c512_i64_218 : i64
+    %412 = arith.muli %407, %c3_i64_217 : i64
+    %413 = arith.addi %411, %412 : i64
+    %c3_i64_219 = arith.constant 3 : i64
+    %c512_i64_220 = arith.constant 512 : i64
+    %414 = arith.muli %403, %403 : i64
+    %415 = arith.divui %414, %c512_i64_220 : i64
+    %416 = arith.muli %403, %c3_i64_219 : i64
+    %417 = arith.addi %415, %416 : i64
+    %418 = arith.subi %417, %413 : i64
+    %419 = llvm.load %arg1 : !llvm.ptr -> i64
+    %420 = arith.cmpi ult, %419, %418 : i64
+    scf.if %420 {
     } else {
-      %486 = arith.subi %452, %451 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %419, %418 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_253 = arith.constant 80 : i8
-    cf.cond_br %453, ^bb1(%c80_i8_253 : i8), ^bb146
+    %c80_i8_221 = arith.constant 80 : i8
+    cf.cond_br %420, ^bb1(%c80_i8_221 : i8), ^bb146
   ^bb146:  // pred: ^bb145
-    %454 = call @dora_fn_extend_memory(%arg0, %437) : (!llvm.ptr, i64) -> !llvm.ptr
-    %455 = llvm.getelementptr %454[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %456 = llvm.load %455 : !llvm.ptr -> i8
-    %c0_i8_254 = arith.constant 0 : i8
-    %457 = arith.cmpi ne, %456, %c0_i8_254 : i8
-    cf.cond_br %457, ^bb1(%456 : i8), ^bb147
+    %421 = call @dora_fn_extend_memory(%arg0, %404) : (!llvm.ptr, i64) -> !llvm.ptr
+    %422 = llvm.getelementptr %421[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %423 = llvm.load %422 : !llvm.ptr -> i8
+    %c0_i8_222 = arith.constant 0 : i8
+    %424 = arith.cmpi ne, %423, %c0_i8_222 : i8
+    cf.cond_br %424, ^bb1(%423 : i8), ^bb147
   ^bb147:  // pred: ^bb146
     cf.br ^bb144
   ^bb148:  // pred: ^bb94
-    %c18446744073709551615_i256_255 = arith.constant 18446744073709551615 : i256
-    %458 = arith.cmpi sgt, %261, %c18446744073709551615_i256_255 : i256
-    %c84_i8_256 = arith.constant 84 : i8
-    cf.cond_br %458, ^bb1(%c84_i8_256 : i8), ^bb149
+    %c18446744073709551615_i256_223 = arith.constant 18446744073709551615 : i256
+    %425 = arith.cmpi sgt, %231, %c18446744073709551615_i256_223 : i256
+    %c84_i8_224 = arith.constant 84 : i8
+    cf.cond_br %425, ^bb1(%c84_i8_224 : i8), ^bb149
   ^bb149:  // pred: ^bb148
-    %459 = arith.trunci %261 : i256 to i64
-    %c0_i64_257 = arith.constant 0 : i64
-    %460 = arith.cmpi slt, %459, %c0_i64_257 : i64
-    %c84_i8_258 = arith.constant 84 : i8
-    cf.cond_br %460, ^bb1(%c84_i8_258 : i8), ^bb150
+    %426 = arith.trunci %231 : i256 to i64
+    %c0_i64_225 = arith.constant 0 : i64
+    %427 = arith.cmpi slt, %426, %c0_i64_225 : i64
+    %c84_i8_226 = arith.constant 84 : i8
+    cf.cond_br %427, ^bb1(%c84_i8_226 : i8), ^bb150
   ^bb150:  // pred: ^bb149
-    %461 = arith.addi %459, %271 : i64
-    %c0_i64_259 = arith.constant 0 : i64
-    %462 = arith.cmpi slt, %461, %c0_i64_259 : i64
-    %c84_i8_260 = arith.constant 84 : i8
-    cf.cond_br %462, ^bb1(%c84_i8_260 : i8), ^bb151
+    %428 = arith.addi %426, %240 : i64
+    %c0_i64_227 = arith.constant 0 : i64
+    %429 = arith.cmpi slt, %428, %c0_i64_227 : i64
+    %c84_i8_228 = arith.constant 84 : i8
+    cf.cond_br %429, ^bb1(%c84_i8_228 : i8), ^bb151
   ^bb151:  // pred: ^bb150
-    %c31_i64_261 = arith.constant 31 : i64
-    %c32_i64_262 = arith.constant 32 : i64
-    %463 = arith.addi %461, %c31_i64_261 : i64
-    %464 = arith.divui %463, %c32_i64_262 : i64
-    %c32_i64_263 = arith.constant 32 : i64
-    %465 = arith.muli %464, %c32_i64_263 : i64
-    %466 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_264 = arith.constant 31 : i64
-    %c32_i64_265 = arith.constant 32 : i64
-    %467 = arith.addi %466, %c31_i64_264 : i64
-    %468 = arith.divui %467, %c32_i64_265 : i64
-    %469 = arith.muli %468, %c32_i64_263 : i64
-    %470 = arith.cmpi ult, %469, %465 : i64
-    cf.cond_br %470, ^bb153, ^bb152
+    %c31_i64_229 = arith.constant 31 : i64
+    %c32_i64_230 = arith.constant 32 : i64
+    %430 = arith.addi %428, %c31_i64_229 : i64
+    %431 = arith.divui %430, %c32_i64_230 : i64
+    %c32_i64_231 = arith.constant 32 : i64
+    %432 = arith.muli %431, %c32_i64_231 : i64
+    %433 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_232 = arith.constant 31 : i64
+    %c32_i64_233 = arith.constant 32 : i64
+    %434 = arith.addi %433, %c31_i64_232 : i64
+    %435 = arith.divui %434, %c32_i64_233 : i64
+    %436 = arith.muli %435, %c32_i64_231 : i64
+    %437 = arith.cmpi ult, %436, %432 : i64
+    cf.cond_br %437, ^bb153, ^bb152
   ^bb152:  // 2 preds: ^bb151, ^bb155
     cf.br ^bb95
   ^bb153:  // pred: ^bb151
-    %c3_i64_266 = arith.constant 3 : i64
-    %c512_i64_267 = arith.constant 512 : i64
-    %471 = arith.muli %468, %468 : i64
-    %472 = arith.divui %471, %c512_i64_267 : i64
-    %473 = arith.muli %468, %c3_i64_266 : i64
-    %474 = arith.addi %472, %473 : i64
-    %c3_i64_268 = arith.constant 3 : i64
-    %c512_i64_269 = arith.constant 512 : i64
-    %475 = arith.muli %464, %464 : i64
-    %476 = arith.divui %475, %c512_i64_269 : i64
-    %477 = arith.muli %464, %c3_i64_268 : i64
-    %478 = arith.addi %476, %477 : i64
-    %479 = arith.subi %478, %474 : i64
-    %480 = llvm.load %arg1 : !llvm.ptr -> i64
-    %481 = arith.cmpi ult, %480, %479 : i64
-    scf.if %481 {
+    %c3_i64_234 = arith.constant 3 : i64
+    %c512_i64_235 = arith.constant 512 : i64
+    %438 = arith.muli %435, %435 : i64
+    %439 = arith.divui %438, %c512_i64_235 : i64
+    %440 = arith.muli %435, %c3_i64_234 : i64
+    %441 = arith.addi %439, %440 : i64
+    %c3_i64_236 = arith.constant 3 : i64
+    %c512_i64_237 = arith.constant 512 : i64
+    %442 = arith.muli %431, %431 : i64
+    %443 = arith.divui %442, %c512_i64_237 : i64
+    %444 = arith.muli %431, %c3_i64_236 : i64
+    %445 = arith.addi %443, %444 : i64
+    %446 = arith.subi %445, %441 : i64
+    %447 = llvm.load %arg1 : !llvm.ptr -> i64
+    %448 = arith.cmpi ult, %447, %446 : i64
+    scf.if %448 {
     } else {
-      %486 = arith.subi %480, %479 : i64
-      llvm.store %486, %arg1 : i64, !llvm.ptr
+      %453 = arith.subi %447, %446 : i64
+      llvm.store %453, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_270 = arith.constant 80 : i8
-    cf.cond_br %481, ^bb1(%c80_i8_270 : i8), ^bb154
+    %c80_i8_238 = arith.constant 80 : i8
+    cf.cond_br %448, ^bb1(%c80_i8_238 : i8), ^bb154
   ^bb154:  // pred: ^bb153
-    %482 = call @dora_fn_extend_memory(%arg0, %465) : (!llvm.ptr, i64) -> !llvm.ptr
-    %483 = llvm.getelementptr %482[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %484 = llvm.load %483 : !llvm.ptr -> i8
-    %c0_i8_271 = arith.constant 0 : i8
-    %485 = arith.cmpi ne, %484, %c0_i8_271 : i8
-    cf.cond_br %485, ^bb1(%484 : i8), ^bb155
+    %449 = call @dora_fn_extend_memory(%arg0, %432) : (!llvm.ptr, i64) -> !llvm.ptr
+    %450 = llvm.getelementptr %449[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %451 = llvm.load %450 : !llvm.ptr -> i8
+    %c0_i8_239 = arith.constant 0 : i8
+    %452 = arith.cmpi ne, %451, %c0_i8_239 : i8
+    cf.cond_br %452, ^bb1(%451 : i8), ^bb155
   ^bb155:  // pred: ^bb154
     cf.br ^bb152
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_keccak256.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_keccak256.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 26 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb24, ^bb25, ^bb28, ^bb29, ^bb32, ^bb33, ^bb34, ^bb37, ^bb38, ^bb40, ^bb41, ^bb42, ^bb43, ^bb46, ^bb47
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 26 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb24, ^bb25, ^bb28, ^bb29, ^bb32, ^bb33, ^bb34, ^bb37, ^bb38, ^bb40, ^bb41, ^bb42, ^bb43, ^bb46, ^bb47
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1329227995475430863082461991555563520_i256 = arith.constant 1329227995475430863082461991555563520 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1329227995475430863082461991555563520_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,344 +96,333 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb32, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb32, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb36
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c4_i256 = arith.constant 4 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c4_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c4_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %c0_i256_19 = arith.constant 0 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_19, %50 : i256, !llvm.ptr
+    %c0_i256_15 = arith.constant 0 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_15, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb28
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %66 = arith.cmpi sgt, %65, %c18446744073709551615_i256 : i256
+    %59 = arith.cmpi sgt, %58, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %66, ^bb1(%c84_i8 : i8), ^bb25
+    cf.cond_br %59, ^bb1(%c84_i8 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %67 = arith.trunci %65 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %68 = arith.cmpi slt, %67, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %68, ^bb1(%c84_i8_29 : i8), ^bb26
+    %60 = arith.trunci %58 : i256 to i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_21 : i64
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i64_30 = arith.constant 0 : i64
-    %69 = arith.cmpi ne, %67, %c0_i64_30 : i64
-    cf.cond_br %69, ^bb40, ^bb27
+    %c0_i64_23 = arith.constant 0 : i64
+    %62 = arith.cmpi ne, %60, %c0_i64_23 : i64
+    cf.cond_br %62, ^bb40, ^bb27
   ^bb27:  // 2 preds: ^bb26, ^bb45
-    %70 = arith.trunci %61 : i256 to i64
+    %63 = arith.trunci %55 : i256 to i64
     %c1_i256 = arith.constant 1 : i256
-    %71 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_keccak256_hasher(%arg0, %70, %67, %71) : (!llvm.ptr, i64, i64, !llvm.ptr) -> ()
-    %72 = llvm.load %71 : !llvm.ptr -> i256
-    %73 = llvm.load %arg3 : !llvm.ptr -> i64
-    %74 = llvm.getelementptr %arg2[%73] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_31 = arith.constant 1 : i64
-    %75 = arith.addi %73, %c1_i64_31 : i64
-    llvm.store %75, %arg3 : i64, !llvm.ptr
-    llvm.store %72, %74 : i256, !llvm.ptr
+    %64 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_keccak256_hasher(%arg0, %63, %60, %64) : (!llvm.ptr, i64, i64, !llvm.ptr) -> ()
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    %66 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %65, %66 : i256, !llvm.ptr
+    %67 = llvm.getelementptr %66[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %67, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb31
   ^bb28:  // pred: ^bb30
-    %c1024_i64_32 = arith.constant 1024 : i64
-    %76 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_24 = arith.constant 1024 : i64
+    %68 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %77 = arith.addi %76, %c-1_i64 : i64
-    %c2_i64_33 = arith.constant 2 : i64
-    %78 = arith.cmpi ult, %76, %c2_i64_33 : i64
-    %c91_i8_34 = arith.constant 91 : i8
-    cf.cond_br %78, ^bb1(%c91_i8_34 : i8), ^bb24
+    %69 = arith.addi %68, %c-1_i64 : i64
+    llvm.store %69, %arg3 : i64, !llvm.ptr
+    %c2_i64_25 = arith.constant 2 : i64
+    %70 = arith.cmpi ult, %68, %c2_i64_25 : i64
+    %c91_i8_26 = arith.constant 91 : i8
+    cf.cond_br %70, ^bb1(%c91_i8_26 : i8), ^bb24
   ^bb29:  // pred: ^bb20
-    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %71 = llvm.load %arg1 : !llvm.ptr -> i64
     %c30_i64 = arith.constant 30 : i64
     call @dora_fn_nop() : () -> ()
-    %80 = arith.cmpi uge, %79, %c30_i64 : i64
-    %c80_i8_35 = arith.constant 80 : i8
-    cf.cond_br %80, ^bb30, ^bb1(%c80_i8_35 : i8)
+    %72 = arith.cmpi uge, %71, %c30_i64 : i64
+    %c80_i8_27 = arith.constant 80 : i8
+    cf.cond_br %72, ^bb30, ^bb1(%c80_i8_27 : i8)
   ^bb30:  // pred: ^bb29
-    %81 = arith.subi %79, %c30_i64 : i64
-    llvm.store %81, %arg1 : i64, !llvm.ptr
+    %73 = arith.subi %71, %c30_i64 : i64
+    llvm.store %73, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb27
-    %c0_i64_36 = arith.constant 0 : i64
+    %c0_i64_28 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %82 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_36, %c0_i64_36, %82, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %74 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_28, %c0_i64_28, %74, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb32:  // pred: ^bb11
-    %c18446744073709551615_i256_37 = arith.constant 18446744073709551615 : i256
-    %83 = arith.cmpi sgt, %24, %c18446744073709551615_i256_37 : i256
-    %c84_i8_38 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_38 : i8), ^bb33
+    %c18446744073709551615_i256_29 = arith.constant 18446744073709551615 : i256
+    %75 = arith.cmpi sgt, %22, %c18446744073709551615_i256_29 : i256
+    %c84_i8_30 = arith.constant 84 : i8
+    cf.cond_br %75, ^bb1(%c84_i8_30 : i8), ^bb33
   ^bb33:  // pred: ^bb32
-    %84 = arith.trunci %24 : i256 to i64
-    %c0_i64_39 = arith.constant 0 : i64
-    %85 = arith.cmpi slt, %84, %c0_i64_39 : i64
-    %c84_i8_40 = arith.constant 84 : i8
-    cf.cond_br %85, ^bb1(%c84_i8_40 : i8), ^bb34
+    %76 = arith.trunci %22 : i256 to i64
+    %c0_i64_31 = arith.constant 0 : i64
+    %77 = arith.cmpi slt, %76, %c0_i64_31 : i64
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %77, ^bb1(%c84_i8_32 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %86 = arith.addi %84, %c32_i64 : i64
-    %c0_i64_41 = arith.constant 0 : i64
-    %87 = arith.cmpi slt, %86, %c0_i64_41 : i64
-    %c84_i8_42 = arith.constant 84 : i8
-    cf.cond_br %87, ^bb1(%c84_i8_42 : i8), ^bb35
+    %78 = arith.addi %76, %c32_i64 : i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %79 = arith.cmpi slt, %78, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %79, ^bb1(%c84_i8_34 : i8), ^bb35
   ^bb35:  // pred: ^bb34
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_43 = arith.constant 32 : i64
-    %88 = arith.addi %86, %c31_i64 : i64
-    %89 = arith.divui %88, %c32_i64_43 : i64
-    %c32_i64_44 = arith.constant 32 : i64
-    %90 = arith.muli %89, %c32_i64_44 : i64
-    %91 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_45 = arith.constant 31 : i64
-    %c32_i64_46 = arith.constant 32 : i64
-    %92 = arith.addi %91, %c31_i64_45 : i64
-    %93 = arith.divui %92, %c32_i64_46 : i64
-    %94 = arith.muli %93, %c32_i64_44 : i64
-    %95 = arith.cmpi ult, %94, %90 : i64
-    cf.cond_br %95, ^bb37, ^bb36
+    %c32_i64_35 = arith.constant 32 : i64
+    %80 = arith.addi %78, %c31_i64 : i64
+    %81 = arith.divui %80, %c32_i64_35 : i64
+    %c32_i64_36 = arith.constant 32 : i64
+    %82 = arith.muli %81, %c32_i64_36 : i64
+    %83 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_37 = arith.constant 31 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %84 = arith.addi %83, %c31_i64_37 : i64
+    %85 = arith.divui %84, %c32_i64_38 : i64
+    %86 = arith.muli %85, %c32_i64_36 : i64
+    %87 = arith.cmpi ult, %86, %82 : i64
+    cf.cond_br %87, ^bb37, ^bb36
   ^bb36:  // 2 preds: ^bb35, ^bb39
     cf.br ^bb12
   ^bb37:  // pred: ^bb35
-    %c3_i64_47 = arith.constant 3 : i64
+    %c3_i64_39 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %96 = arith.muli %93, %93 : i64
-    %97 = arith.divui %96, %c512_i64 : i64
-    %98 = arith.muli %93, %c3_i64_47 : i64
-    %99 = arith.addi %97, %98 : i64
-    %c3_i64_48 = arith.constant 3 : i64
-    %c512_i64_49 = arith.constant 512 : i64
-    %100 = arith.muli %89, %89 : i64
-    %101 = arith.divui %100, %c512_i64_49 : i64
-    %102 = arith.muli %89, %c3_i64_48 : i64
-    %103 = arith.addi %101, %102 : i64
-    %104 = arith.subi %103, %99 : i64
-    %105 = llvm.load %arg1 : !llvm.ptr -> i64
-    %106 = arith.cmpi ult, %105, %104 : i64
-    scf.if %106 {
+    %88 = arith.muli %85, %85 : i64
+    %89 = arith.divui %88, %c512_i64 : i64
+    %90 = arith.muli %85, %c3_i64_39 : i64
+    %91 = arith.addi %89, %90 : i64
+    %c3_i64_40 = arith.constant 3 : i64
+    %c512_i64_41 = arith.constant 512 : i64
+    %92 = arith.muli %81, %81 : i64
+    %93 = arith.divui %92, %c512_i64_41 : i64
+    %94 = arith.muli %81, %c3_i64_40 : i64
+    %95 = arith.addi %93, %94 : i64
+    %96 = arith.subi %95, %91 : i64
+    %97 = llvm.load %arg1 : !llvm.ptr -> i64
+    %98 = arith.cmpi ult, %97, %96 : i64
+    scf.if %98 {
     } else {
-      %144 = arith.subi %105, %104 : i64
-      llvm.store %144, %arg1 : i64, !llvm.ptr
+      %136 = arith.subi %97, %96 : i64
+      llvm.store %136, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_50 = arith.constant 80 : i8
-    cf.cond_br %106, ^bb1(%c80_i8_50 : i8), ^bb38
+    %c80_i8_42 = arith.constant 80 : i8
+    cf.cond_br %98, ^bb1(%c80_i8_42 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %107 = call @dora_fn_extend_memory(%arg0, %90) : (!llvm.ptr, i64) -> !llvm.ptr
-    %108 = llvm.getelementptr %107[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %109 = llvm.load %108 : !llvm.ptr -> i8
+    %99 = call @dora_fn_extend_memory(%arg0, %82) : (!llvm.ptr, i64) -> !llvm.ptr
+    %100 = llvm.getelementptr %99[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %101 = llvm.load %100 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %110 = arith.cmpi ne, %109, %c0_i8 : i8
-    cf.cond_br %110, ^bb1(%109 : i8), ^bb39
+    %102 = arith.cmpi ne, %101, %c0_i8 : i8
+    cf.cond_br %102, ^bb1(%101 : i8), ^bb39
   ^bb39:  // pred: ^bb38
     cf.br ^bb36
   ^bb40:  // pred: ^bb26
-    %c31_i64_51 = arith.constant 31 : i64
-    %c32_i64_52 = arith.constant 32 : i64
-    %111 = arith.addi %67, %c31_i64_51 : i64
-    %112 = arith.divui %111, %c32_i64_52 : i64
+    %c31_i64_43 = arith.constant 31 : i64
+    %c32_i64_44 = arith.constant 32 : i64
+    %103 = arith.addi %60, %c31_i64_43 : i64
+    %104 = arith.divui %103, %c32_i64_44 : i64
     %c6_i64 = arith.constant 6 : i64
-    %113 = arith.muli %112, %c6_i64 : i64
-    %114 = llvm.load %arg1 : !llvm.ptr -> i64
-    %115 = arith.cmpi ult, %114, %113 : i64
-    scf.if %115 {
+    %105 = arith.muli %104, %c6_i64 : i64
+    %106 = llvm.load %arg1 : !llvm.ptr -> i64
+    %107 = arith.cmpi ult, %106, %105 : i64
+    scf.if %107 {
     } else {
-      %144 = arith.subi %114, %113 : i64
-      llvm.store %144, %arg1 : i64, !llvm.ptr
+      %136 = arith.subi %106, %105 : i64
+      llvm.store %136, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_53 = arith.constant 80 : i8
-    cf.cond_br %115, ^bb1(%c80_i8_53 : i8), ^bb41
+    %c80_i8_45 = arith.constant 80 : i8
+    cf.cond_br %107, ^bb1(%c80_i8_45 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %c18446744073709551615_i256_54 = arith.constant 18446744073709551615 : i256
-    %116 = arith.cmpi sgt, %61, %c18446744073709551615_i256_54 : i256
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %116, ^bb1(%c84_i8_55 : i8), ^bb42
+    %c18446744073709551615_i256_46 = arith.constant 18446744073709551615 : i256
+    %108 = arith.cmpi sgt, %55, %c18446744073709551615_i256_46 : i256
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %108, ^bb1(%c84_i8_47 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %117 = arith.trunci %61 : i256 to i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %118 = arith.cmpi slt, %117, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8_57 : i8), ^bb43
+    %109 = arith.trunci %55 : i256 to i64
+    %c0_i64_48 = arith.constant 0 : i64
+    %110 = arith.cmpi slt, %109, %c0_i64_48 : i64
+    %c84_i8_49 = arith.constant 84 : i8
+    cf.cond_br %110, ^bb1(%c84_i8_49 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %119 = arith.addi %117, %67 : i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %120 = arith.cmpi slt, %119, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %120, ^bb1(%c84_i8_59 : i8), ^bb44
+    %111 = arith.addi %109, %60 : i64
+    %c0_i64_50 = arith.constant 0 : i64
+    %112 = arith.cmpi slt, %111, %c0_i64_50 : i64
+    %c84_i8_51 = arith.constant 84 : i8
+    cf.cond_br %112, ^bb1(%c84_i8_51 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c31_i64_60 = arith.constant 31 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %121 = arith.addi %119, %c31_i64_60 : i64
-    %122 = arith.divui %121, %c32_i64_61 : i64
-    %c32_i64_62 = arith.constant 32 : i64
-    %123 = arith.muli %122, %c32_i64_62 : i64
-    %124 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_63 = arith.constant 31 : i64
-    %c32_i64_64 = arith.constant 32 : i64
-    %125 = arith.addi %124, %c31_i64_63 : i64
-    %126 = arith.divui %125, %c32_i64_64 : i64
-    %127 = arith.muli %126, %c32_i64_62 : i64
-    %128 = arith.cmpi ult, %127, %123 : i64
-    cf.cond_br %128, ^bb46, ^bb45
+    %c31_i64_52 = arith.constant 31 : i64
+    %c32_i64_53 = arith.constant 32 : i64
+    %113 = arith.addi %111, %c31_i64_52 : i64
+    %114 = arith.divui %113, %c32_i64_53 : i64
+    %c32_i64_54 = arith.constant 32 : i64
+    %115 = arith.muli %114, %c32_i64_54 : i64
+    %116 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_55 = arith.constant 31 : i64
+    %c32_i64_56 = arith.constant 32 : i64
+    %117 = arith.addi %116, %c31_i64_55 : i64
+    %118 = arith.divui %117, %c32_i64_56 : i64
+    %119 = arith.muli %118, %c32_i64_54 : i64
+    %120 = arith.cmpi ult, %119, %115 : i64
+    cf.cond_br %120, ^bb46, ^bb45
   ^bb45:  // 2 preds: ^bb44, ^bb48
     cf.br ^bb27
   ^bb46:  // pred: ^bb44
-    %c3_i64_65 = arith.constant 3 : i64
-    %c512_i64_66 = arith.constant 512 : i64
-    %129 = arith.muli %126, %126 : i64
-    %130 = arith.divui %129, %c512_i64_66 : i64
-    %131 = arith.muli %126, %c3_i64_65 : i64
-    %132 = arith.addi %130, %131 : i64
-    %c3_i64_67 = arith.constant 3 : i64
-    %c512_i64_68 = arith.constant 512 : i64
-    %133 = arith.muli %122, %122 : i64
-    %134 = arith.divui %133, %c512_i64_68 : i64
-    %135 = arith.muli %122, %c3_i64_67 : i64
-    %136 = arith.addi %134, %135 : i64
-    %137 = arith.subi %136, %132 : i64
-    %138 = llvm.load %arg1 : !llvm.ptr -> i64
-    %139 = arith.cmpi ult, %138, %137 : i64
-    scf.if %139 {
+    %c3_i64_57 = arith.constant 3 : i64
+    %c512_i64_58 = arith.constant 512 : i64
+    %121 = arith.muli %118, %118 : i64
+    %122 = arith.divui %121, %c512_i64_58 : i64
+    %123 = arith.muli %118, %c3_i64_57 : i64
+    %124 = arith.addi %122, %123 : i64
+    %c3_i64_59 = arith.constant 3 : i64
+    %c512_i64_60 = arith.constant 512 : i64
+    %125 = arith.muli %114, %114 : i64
+    %126 = arith.divui %125, %c512_i64_60 : i64
+    %127 = arith.muli %114, %c3_i64_59 : i64
+    %128 = arith.addi %126, %127 : i64
+    %129 = arith.subi %128, %124 : i64
+    %130 = llvm.load %arg1 : !llvm.ptr -> i64
+    %131 = arith.cmpi ult, %130, %129 : i64
+    scf.if %131 {
     } else {
-      %144 = arith.subi %138, %137 : i64
-      llvm.store %144, %arg1 : i64, !llvm.ptr
+      %136 = arith.subi %130, %129 : i64
+      llvm.store %136, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_69 = arith.constant 80 : i8
-    cf.cond_br %139, ^bb1(%c80_i8_69 : i8), ^bb47
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %131, ^bb1(%c80_i8_61 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %140 = call @dora_fn_extend_memory(%arg0, %123) : (!llvm.ptr, i64) -> !llvm.ptr
-    %141 = llvm.getelementptr %140[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %142 = llvm.load %141 : !llvm.ptr -> i8
-    %c0_i8_70 = arith.constant 0 : i8
-    %143 = arith.cmpi ne, %142, %c0_i8_70 : i8
-    cf.cond_br %143, ^bb1(%142 : i8), ^bb48
+    %132 = call @dora_fn_extend_memory(%arg0, %115) : (!llvm.ptr, i64) -> !llvm.ptr
+    %133 = llvm.getelementptr %132[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %134 = llvm.load %133 : !llvm.ptr -> i8
+    %c0_i8_62 = arith.constant 0 : i8
+    %135 = arith.cmpi ne, %134, %c0_i8_62 : i8
+    cf.cond_br %135, ^bb1(%134 : i8), ^bb48
   ^bb48:  // pred: ^bb47
     cf.br ^bb45
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mcopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mcopy.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 30 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb33, ^bb34, ^bb37, ^bb38, ^bb39, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49, ^bb52, ^bb53
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 30 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26, ^bb28, ^bb29, ^bb30, ^bb33, ^bb34, ^bb37, ^bb38, ^bb39, ^bb42, ^bb43, ^bb45, ^bb46, ^bb47, ^bb48, ^bb49, ^bb52, ^bb53
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c255_i256 = arith.constant 255 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c255_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,383 +96,371 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c32_i256 = arith.constant 32 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb37, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb37, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb41
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c32_i256_13 = arith.constant 32 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_13, %41 : i256, !llvm.ptr
+    %c32_i256_10 = arith.constant 32 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %c32_i256_20 = arith.constant 32 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_21 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_20, %50 : i256, !llvm.ptr
+    %c32_i256_16 = arith.constant 32 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_16, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_23 : i64
-    %54 = arith.cmpi ult, %c1024_i64_22, %53 : i64
-    %c92_i8_24 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_24 : i8), ^bb20
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_18 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_17, %48 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_19 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_25 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_26 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_21 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_25 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_20 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
     %c0_i256 = arith.constant 0 : i256
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_27 = arith.constant 1 : i64
-    %60 = arith.addi %58, %c1_i64_27 : i64
-    llvm.store %60, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %59 : i256, !llvm.ptr
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %53 : i256, !llvm.ptr
+    %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb34
   ^bb25:  // pred: ^bb27
-    %c1024_i64_28 = arith.constant 1024 : i64
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %62 = arith.addi %61, %c1_i64_29 : i64
-    %63 = arith.cmpi ult, %c1024_i64_28, %62 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %63, ^bb1(%c92_i8_30 : i8), ^bb24
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %55 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_23 = arith.constant 1 : i64
+    %56 = arith.addi %55, %c1_i64_23 : i64
+    llvm.store %56, %arg3 : i64, !llvm.ptr
+    %57 = arith.cmpi ult, %c1024_i64_22, %56 : i64
+    %c92_i8_24 = arith.constant 92 : i8
+    cf.cond_br %57, ^bb1(%c92_i8_24 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_31 = arith.constant 3 : i64
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_25 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %65 = arith.cmpi uge, %64, %c3_i64_31 : i64
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb27, ^bb1(%c80_i8_32 : i8)
+    %59 = arith.cmpi uge, %58, %c3_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %59, ^bb27, ^bb1(%c80_i8_26 : i8)
   ^bb27:  // pred: ^bb26
-    %66 = arith.subi %64, %c3_i64_31 : i64
-    llvm.store %66, %arg1 : i64, !llvm.ptr
+    %60 = arith.subi %58, %c3_i64_25 : i64
+    llvm.store %60, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb33
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %68 = arith.subi %67, %c1_i64_33 : i64
-    %69 = llvm.getelementptr %arg2[%68] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %68, %arg3 : i64, !llvm.ptr
-    %70 = llvm.load %69 : !llvm.ptr -> i256
-    %71 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %72 = arith.subi %71, %c1_i64_34 : i64
-    %73 = llvm.getelementptr %arg2[%72] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %72, %arg3 : i64, !llvm.ptr
-    %74 = llvm.load %73 : !llvm.ptr -> i256
-    %75 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %76 = arith.subi %75, %c1_i64_35 : i64
-    %77 = llvm.getelementptr %arg2[%76] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %76, %arg3 : i64, !llvm.ptr
-    %78 = llvm.load %77 : !llvm.ptr -> i256
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %79 = arith.cmpi sgt, %78, %c18446744073709551615_i256 : i256
+    %70 = arith.cmpi sgt, %69, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %79, ^bb1(%c84_i8 : i8), ^bb29
+    cf.cond_br %70, ^bb1(%c84_i8 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %80 = arith.trunci %78 : i256 to i64
-    %c0_i64_36 = arith.constant 0 : i64
-    %81 = arith.cmpi slt, %80, %c0_i64_36 : i64
-    %c84_i8_37 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8_37 : i8), ^bb30
+    %71 = arith.trunci %69 : i256 to i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %72 = arith.cmpi slt, %71, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_28 : i8), ^bb30
   ^bb30:  // pred: ^bb29
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %82 = arith.addi %80, %c31_i64 : i64
-    %83 = arith.divui %82, %c32_i64_38 : i64
-    %c3_i64_39 = arith.constant 3 : i64
-    %84 = arith.muli %83, %c3_i64_39 : i64
-    %85 = llvm.load %arg1 : !llvm.ptr -> i64
-    %86 = arith.cmpi ult, %85, %84 : i64
-    scf.if %86 {
+    %c32_i64_29 = arith.constant 32 : i64
+    %73 = arith.addi %71, %c31_i64 : i64
+    %74 = arith.divui %73, %c32_i64_29 : i64
+    %c3_i64_30 = arith.constant 3 : i64
+    %75 = arith.muli %74, %c3_i64_30 : i64
+    %76 = llvm.load %arg1 : !llvm.ptr -> i64
+    %77 = arith.cmpi ult, %76, %75 : i64
+    scf.if %77 {
     } else {
-      %158 = arith.subi %85, %84 : i64
-      llvm.store %158, %arg1 : i64, !llvm.ptr
+      %149 = arith.subi %76, %75 : i64
+      llvm.store %149, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %86, ^bb1(%c80_i8_40 : i8), ^bb31
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %77, ^bb1(%c80_i8_31 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %87 = arith.maxui %70, %74 : i256
-    %c0_i64_41 = arith.constant 0 : i64
-    %88 = arith.cmpi ne, %80, %c0_i64_41 : i64
-    cf.cond_br %88, ^bb45, ^bb32
+    %78 = arith.maxui %63, %66 : i256
+    %c0_i64_32 = arith.constant 0 : i64
+    %79 = arith.cmpi ne, %71, %c0_i64_32 : i64
+    cf.cond_br %79, ^bb45, ^bb32
   ^bb32:  // 2 preds: ^bb31, ^bb51
-    %89 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %90 = llvm.getelementptr %89[%87] : (!llvm.ptr, i256) -> !llvm.ptr, i8
-    %91 = llvm.getelementptr %89[%70] : (!llvm.ptr, i256) -> !llvm.ptr, i8
-    "llvm.intr.memmove"(%91, %90, %80) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    %80 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %81 = llvm.getelementptr %80[%78] : (!llvm.ptr, i256) -> !llvm.ptr, i8
+    %82 = llvm.getelementptr %80[%63] : (!llvm.ptr, i256) -> !llvm.ptr, i8
+    "llvm.intr.memmove"(%82, %81, %71) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
     cf.br ^bb36
   ^bb33:  // pred: ^bb35
-    %c1024_i64_42 = arith.constant 1024 : i64
-    %92 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_33 = arith.constant 1024 : i64
+    %83 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %93 = arith.addi %92, %c-3_i64 : i64
-    %c3_i64_43 = arith.constant 3 : i64
-    %94 = arith.cmpi ult, %92, %c3_i64_43 : i64
-    %c91_i8_44 = arith.constant 91 : i8
-    cf.cond_br %94, ^bb1(%c91_i8_44 : i8), ^bb28
+    %84 = arith.addi %83, %c-3_i64 : i64
+    llvm.store %84, %arg3 : i64, !llvm.ptr
+    %c3_i64_34 = arith.constant 3 : i64
+    %85 = arith.cmpi ult, %83, %c3_i64_34 : i64
+    %c91_i8_35 = arith.constant 91 : i8
+    cf.cond_br %85, ^bb1(%c91_i8_35 : i8), ^bb28
   ^bb34:  // pred: ^bb24
-    %95 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_45 = arith.constant 3 : i64
+    %86 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_36 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %96 = arith.cmpi uge, %95, %c3_i64_45 : i64
-    %c80_i8_46 = arith.constant 80 : i8
-    cf.cond_br %96, ^bb35, ^bb1(%c80_i8_46 : i8)
+    %87 = arith.cmpi uge, %86, %c3_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %87, ^bb35, ^bb1(%c80_i8_37 : i8)
   ^bb35:  // pred: ^bb34
-    %97 = arith.subi %95, %c3_i64_45 : i64
-    llvm.store %97, %arg1 : i64, !llvm.ptr
+    %88 = arith.subi %86, %c3_i64_36 : i64
+    llvm.store %88, %arg1 : i64, !llvm.ptr
     cf.br ^bb33
   ^bb36:  // pred: ^bb32
-    %c0_i64_47 = arith.constant 0 : i64
+    %c0_i64_38 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %98 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_47, %c0_i64_47, %98, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %89 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_38, %c0_i64_38, %89, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb37:  // pred: ^bb11
-    %c18446744073709551615_i256_48 = arith.constant 18446744073709551615 : i256
-    %99 = arith.cmpi sgt, %24, %c18446744073709551615_i256_48 : i256
-    %c84_i8_49 = arith.constant 84 : i8
-    cf.cond_br %99, ^bb1(%c84_i8_49 : i8), ^bb38
+    %c18446744073709551615_i256_39 = arith.constant 18446744073709551615 : i256
+    %90 = arith.cmpi sgt, %22, %c18446744073709551615_i256_39 : i256
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %90, ^bb1(%c84_i8_40 : i8), ^bb38
   ^bb38:  // pred: ^bb37
-    %100 = arith.trunci %24 : i256 to i64
-    %c0_i64_50 = arith.constant 0 : i64
-    %101 = arith.cmpi slt, %100, %c0_i64_50 : i64
-    %c84_i8_51 = arith.constant 84 : i8
-    cf.cond_br %101, ^bb1(%c84_i8_51 : i8), ^bb39
+    %91 = arith.trunci %22 : i256 to i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %92 = arith.cmpi slt, %91, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %92, ^bb1(%c84_i8_42 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %102 = arith.addi %100, %c32_i64 : i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %103 = arith.cmpi slt, %102, %c0_i64_52 : i64
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %103, ^bb1(%c84_i8_53 : i8), ^bb40
+    %93 = arith.addi %91, %c32_i64 : i64
+    %c0_i64_43 = arith.constant 0 : i64
+    %94 = arith.cmpi slt, %93, %c0_i64_43 : i64
+    %c84_i8_44 = arith.constant 84 : i8
+    cf.cond_br %94, ^bb1(%c84_i8_44 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %c31_i64_54 = arith.constant 31 : i64
-    %c32_i64_55 = arith.constant 32 : i64
-    %104 = arith.addi %102, %c31_i64_54 : i64
-    %105 = arith.divui %104, %c32_i64_55 : i64
-    %c32_i64_56 = arith.constant 32 : i64
-    %106 = arith.muli %105, %c32_i64_56 : i64
-    %107 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_57 = arith.constant 31 : i64
-    %c32_i64_58 = arith.constant 32 : i64
-    %108 = arith.addi %107, %c31_i64_57 : i64
-    %109 = arith.divui %108, %c32_i64_58 : i64
-    %110 = arith.muli %109, %c32_i64_56 : i64
-    %111 = arith.cmpi ult, %110, %106 : i64
-    cf.cond_br %111, ^bb42, ^bb41
+    %c31_i64_45 = arith.constant 31 : i64
+    %c32_i64_46 = arith.constant 32 : i64
+    %95 = arith.addi %93, %c31_i64_45 : i64
+    %96 = arith.divui %95, %c32_i64_46 : i64
+    %c32_i64_47 = arith.constant 32 : i64
+    %97 = arith.muli %96, %c32_i64_47 : i64
+    %98 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_48 = arith.constant 31 : i64
+    %c32_i64_49 = arith.constant 32 : i64
+    %99 = arith.addi %98, %c31_i64_48 : i64
+    %100 = arith.divui %99, %c32_i64_49 : i64
+    %101 = arith.muli %100, %c32_i64_47 : i64
+    %102 = arith.cmpi ult, %101, %97 : i64
+    cf.cond_br %102, ^bb42, ^bb41
   ^bb41:  // 2 preds: ^bb40, ^bb44
     cf.br ^bb12
   ^bb42:  // pred: ^bb40
-    %c3_i64_59 = arith.constant 3 : i64
+    %c3_i64_50 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %112 = arith.muli %109, %109 : i64
-    %113 = arith.divui %112, %c512_i64 : i64
-    %114 = arith.muli %109, %c3_i64_59 : i64
-    %115 = arith.addi %113, %114 : i64
-    %c3_i64_60 = arith.constant 3 : i64
-    %c512_i64_61 = arith.constant 512 : i64
-    %116 = arith.muli %105, %105 : i64
-    %117 = arith.divui %116, %c512_i64_61 : i64
-    %118 = arith.muli %105, %c3_i64_60 : i64
-    %119 = arith.addi %117, %118 : i64
-    %120 = arith.subi %119, %115 : i64
-    %121 = llvm.load %arg1 : !llvm.ptr -> i64
-    %122 = arith.cmpi ult, %121, %120 : i64
-    scf.if %122 {
+    %103 = arith.muli %100, %100 : i64
+    %104 = arith.divui %103, %c512_i64 : i64
+    %105 = arith.muli %100, %c3_i64_50 : i64
+    %106 = arith.addi %104, %105 : i64
+    %c3_i64_51 = arith.constant 3 : i64
+    %c512_i64_52 = arith.constant 512 : i64
+    %107 = arith.muli %96, %96 : i64
+    %108 = arith.divui %107, %c512_i64_52 : i64
+    %109 = arith.muli %96, %c3_i64_51 : i64
+    %110 = arith.addi %108, %109 : i64
+    %111 = arith.subi %110, %106 : i64
+    %112 = llvm.load %arg1 : !llvm.ptr -> i64
+    %113 = arith.cmpi ult, %112, %111 : i64
+    scf.if %113 {
     } else {
-      %158 = arith.subi %121, %120 : i64
-      llvm.store %158, %arg1 : i64, !llvm.ptr
+      %149 = arith.subi %112, %111 : i64
+      llvm.store %149, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %122, ^bb1(%c80_i8_62 : i8), ^bb43
+    %c80_i8_53 = arith.constant 80 : i8
+    cf.cond_br %113, ^bb1(%c80_i8_53 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %123 = call @dora_fn_extend_memory(%arg0, %106) : (!llvm.ptr, i64) -> !llvm.ptr
-    %124 = llvm.getelementptr %123[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %125 = llvm.load %124 : !llvm.ptr -> i8
+    %114 = call @dora_fn_extend_memory(%arg0, %97) : (!llvm.ptr, i64) -> !llvm.ptr
+    %115 = llvm.getelementptr %114[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %116 = llvm.load %115 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %126 = arith.cmpi ne, %125, %c0_i8 : i8
-    cf.cond_br %126, ^bb1(%125 : i8), ^bb44
+    %117 = arith.cmpi ne, %116, %c0_i8 : i8
+    cf.cond_br %117, ^bb1(%116 : i8), ^bb44
   ^bb44:  // pred: ^bb43
     cf.br ^bb41
   ^bb45:  // pred: ^bb31
-    %c18446744073709551615_i256_63 = arith.constant 18446744073709551615 : i256
-    %127 = arith.cmpi sgt, %70, %c18446744073709551615_i256_63 : i256
-    %c84_i8_64 = arith.constant 84 : i8
-    cf.cond_br %127, ^bb1(%c84_i8_64 : i8), ^bb46
+    %c18446744073709551615_i256_54 = arith.constant 18446744073709551615 : i256
+    %118 = arith.cmpi sgt, %63, %c18446744073709551615_i256_54 : i256
+    %c84_i8_55 = arith.constant 84 : i8
+    cf.cond_br %118, ^bb1(%c84_i8_55 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %128 = arith.trunci %70 : i256 to i64
-    %c0_i64_65 = arith.constant 0 : i64
-    %129 = arith.cmpi slt, %128, %c0_i64_65 : i64
-    %c84_i8_66 = arith.constant 84 : i8
-    cf.cond_br %129, ^bb1(%c84_i8_66 : i8), ^bb47
+    %119 = arith.trunci %63 : i256 to i64
+    %c0_i64_56 = arith.constant 0 : i64
+    %120 = arith.cmpi slt, %119, %c0_i64_56 : i64
+    %c84_i8_57 = arith.constant 84 : i8
+    cf.cond_br %120, ^bb1(%c84_i8_57 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %c18446744073709551615_i256_67 = arith.constant 18446744073709551615 : i256
-    %130 = arith.cmpi sgt, %87, %c18446744073709551615_i256_67 : i256
-    %c84_i8_68 = arith.constant 84 : i8
-    cf.cond_br %130, ^bb1(%c84_i8_68 : i8), ^bb48
+    %c18446744073709551615_i256_58 = arith.constant 18446744073709551615 : i256
+    %121 = arith.cmpi sgt, %78, %c18446744073709551615_i256_58 : i256
+    %c84_i8_59 = arith.constant 84 : i8
+    cf.cond_br %121, ^bb1(%c84_i8_59 : i8), ^bb48
   ^bb48:  // pred: ^bb47
-    %131 = arith.trunci %87 : i256 to i64
-    %c0_i64_69 = arith.constant 0 : i64
-    %132 = arith.cmpi slt, %131, %c0_i64_69 : i64
-    %c84_i8_70 = arith.constant 84 : i8
-    cf.cond_br %132, ^bb1(%c84_i8_70 : i8), ^bb49
+    %122 = arith.trunci %78 : i256 to i64
+    %c0_i64_60 = arith.constant 0 : i64
+    %123 = arith.cmpi slt, %122, %c0_i64_60 : i64
+    %c84_i8_61 = arith.constant 84 : i8
+    cf.cond_br %123, ^bb1(%c84_i8_61 : i8), ^bb49
   ^bb49:  // pred: ^bb48
-    %133 = arith.addi %128, %80 : i64
-    %c0_i64_71 = arith.constant 0 : i64
-    %134 = arith.cmpi slt, %133, %c0_i64_71 : i64
-    %c84_i8_72 = arith.constant 84 : i8
-    cf.cond_br %134, ^bb1(%c84_i8_72 : i8), ^bb50
+    %124 = arith.addi %119, %71 : i64
+    %c0_i64_62 = arith.constant 0 : i64
+    %125 = arith.cmpi slt, %124, %c0_i64_62 : i64
+    %c84_i8_63 = arith.constant 84 : i8
+    cf.cond_br %125, ^bb1(%c84_i8_63 : i8), ^bb50
   ^bb50:  // pred: ^bb49
-    %c31_i64_73 = arith.constant 31 : i64
-    %c32_i64_74 = arith.constant 32 : i64
-    %135 = arith.addi %133, %c31_i64_73 : i64
-    %136 = arith.divui %135, %c32_i64_74 : i64
-    %c32_i64_75 = arith.constant 32 : i64
-    %137 = arith.muli %136, %c32_i64_75 : i64
-    %138 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_76 = arith.constant 31 : i64
-    %c32_i64_77 = arith.constant 32 : i64
-    %139 = arith.addi %138, %c31_i64_76 : i64
-    %140 = arith.divui %139, %c32_i64_77 : i64
-    %141 = arith.muli %140, %c32_i64_75 : i64
-    %142 = arith.cmpi ult, %141, %137 : i64
-    cf.cond_br %142, ^bb52, ^bb51
+    %c31_i64_64 = arith.constant 31 : i64
+    %c32_i64_65 = arith.constant 32 : i64
+    %126 = arith.addi %124, %c31_i64_64 : i64
+    %127 = arith.divui %126, %c32_i64_65 : i64
+    %c32_i64_66 = arith.constant 32 : i64
+    %128 = arith.muli %127, %c32_i64_66 : i64
+    %129 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_67 = arith.constant 31 : i64
+    %c32_i64_68 = arith.constant 32 : i64
+    %130 = arith.addi %129, %c31_i64_67 : i64
+    %131 = arith.divui %130, %c32_i64_68 : i64
+    %132 = arith.muli %131, %c32_i64_66 : i64
+    %133 = arith.cmpi ult, %132, %128 : i64
+    cf.cond_br %133, ^bb52, ^bb51
   ^bb51:  // 2 preds: ^bb50, ^bb54
     cf.br ^bb32
   ^bb52:  // pred: ^bb50
-    %c3_i64_78 = arith.constant 3 : i64
-    %c512_i64_79 = arith.constant 512 : i64
-    %143 = arith.muli %140, %140 : i64
-    %144 = arith.divui %143, %c512_i64_79 : i64
-    %145 = arith.muli %140, %c3_i64_78 : i64
-    %146 = arith.addi %144, %145 : i64
-    %c3_i64_80 = arith.constant 3 : i64
-    %c512_i64_81 = arith.constant 512 : i64
-    %147 = arith.muli %136, %136 : i64
-    %148 = arith.divui %147, %c512_i64_81 : i64
-    %149 = arith.muli %136, %c3_i64_80 : i64
-    %150 = arith.addi %148, %149 : i64
-    %151 = arith.subi %150, %146 : i64
-    %152 = llvm.load %arg1 : !llvm.ptr -> i64
-    %153 = arith.cmpi ult, %152, %151 : i64
-    scf.if %153 {
+    %c3_i64_69 = arith.constant 3 : i64
+    %c512_i64_70 = arith.constant 512 : i64
+    %134 = arith.muli %131, %131 : i64
+    %135 = arith.divui %134, %c512_i64_70 : i64
+    %136 = arith.muli %131, %c3_i64_69 : i64
+    %137 = arith.addi %135, %136 : i64
+    %c3_i64_71 = arith.constant 3 : i64
+    %c512_i64_72 = arith.constant 512 : i64
+    %138 = arith.muli %127, %127 : i64
+    %139 = arith.divui %138, %c512_i64_72 : i64
+    %140 = arith.muli %127, %c3_i64_71 : i64
+    %141 = arith.addi %139, %140 : i64
+    %142 = arith.subi %141, %137 : i64
+    %143 = llvm.load %arg1 : !llvm.ptr -> i64
+    %144 = arith.cmpi ult, %143, %142 : i64
+    scf.if %144 {
     } else {
-      %158 = arith.subi %152, %151 : i64
-      llvm.store %158, %arg1 : i64, !llvm.ptr
+      %149 = arith.subi %143, %142 : i64
+      llvm.store %149, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_82 = arith.constant 80 : i8
-    cf.cond_br %153, ^bb1(%c80_i8_82 : i8), ^bb53
+    %c80_i8_73 = arith.constant 80 : i8
+    cf.cond_br %144, ^bb1(%c80_i8_73 : i8), ^bb53
   ^bb53:  // pred: ^bb52
-    %154 = call @dora_fn_extend_memory(%arg0, %137) : (!llvm.ptr, i64) -> !llvm.ptr
-    %155 = llvm.getelementptr %154[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %156 = llvm.load %155 : !llvm.ptr -> i8
-    %c0_i8_83 = arith.constant 0 : i8
-    %157 = arith.cmpi ne, %156, %c0_i8_83 : i8
-    cf.cond_br %157, ^bb1(%156 : i8), ^bb54
+    %145 = call @dora_fn_extend_memory(%arg0, %128) : (!llvm.ptr, i64) -> !llvm.ptr
+    %146 = llvm.getelementptr %145[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %147 = llvm.load %146 : !llvm.ptr -> i8
+    %c0_i8_74 = arith.constant 0 : i8
+    %148 = arith.cmpi ne, %147, %c0_i8_74 : i8
+    cf.cond_br %148, ^bb1(%147 : i8), ^bb54
   ^bb54:  // pred: ^bb53
     cf.br ^bb51
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_mload.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb23, ^bb26, ^bb27, ^bb28, ^bb31, ^bb32, ^bb34, ^bb35, ^bb36, ^bb39, ^bb40
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb22, ^bb23, ^bb26, ^bb27, ^bb28, ^bb31, ^bb32, ^bb34, ^bb35, ^bb36, ^bb39, ^bb40
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c255_i256 = arith.constant 255 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c255_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,284 +96,276 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb26, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb26, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb30
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c0_i256_13 = arith.constant 0 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_14 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_13, %41 : i256, !llvm.ptr
+    %c0_i256_10 = arith.constant 0 : i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_10, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb17:  // pred: ^bb19
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_16 : i64
-    %45 = arith.cmpi ult, %c1024_i64_15, %44 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_17 : i8), ^bb16
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_12 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_11, %40 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_13 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_19 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_15 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_18 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_14 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb22
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %50 = arith.subi %49, %c1_i64_20 : i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    %52 = llvm.load %51 : !llvm.ptr -> i256
-    %c32_i64_21 = arith.constant 32 : i64
-    %c0_i64_22 = arith.constant 0 : i64
-    %53 = arith.cmpi ne, %c32_i64_21, %c0_i64_22 : i64
-    cf.cond_br %53, ^bb34, ^bb21
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
+    %c32_i64_16 = arith.constant 32 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %48 = arith.cmpi ne, %c32_i64_16, %c0_i64_17 : i64
+    cf.cond_br %48, ^bb34, ^bb21
   ^bb21:  // 2 preds: ^bb20, ^bb38
-    %54 = arith.trunci %52 : i256 to i64
-    %55 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %56 = llvm.getelementptr %55[%54] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %57 = llvm.load %56 {alignment = 1 : i64} : !llvm.ptr -> i256
-    %58 = llvm.intr.bswap(%57)  : (i256) -> i256
-    %59 = llvm.load %arg3 : !llvm.ptr -> i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_23 = arith.constant 1 : i64
-    %61 = arith.addi %59, %c1_i64_23 : i64
-    llvm.store %61, %arg3 : i64, !llvm.ptr
-    llvm.store %58, %60 : i256, !llvm.ptr
+    %49 = arith.trunci %47 : i256 to i64
+    %50 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %51 = llvm.getelementptr %50[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %52 = llvm.load %51 {alignment = 1 : i64} : !llvm.ptr -> i256
+    %53 = llvm.intr.bswap(%52)  : (i256) -> i256
+    %54 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %53, %54 : i256, !llvm.ptr
+    %55 = llvm.getelementptr %54[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %55, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb22:  // pred: ^bb24
-    %c1024_i64_24 = arith.constant 1024 : i64
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
-    %63 = arith.addi %62, %c0_i64_25 : i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %64 = arith.cmpi ult, %62, %c1_i64_26 : i64
-    %c91_i8_27 = arith.constant 91 : i8
-    cf.cond_br %64, ^bb1(%c91_i8_27 : i8), ^bb20
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %56 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_19 = arith.constant 0 : i64
+    %57 = arith.addi %56, %c0_i64_19 : i64
+    llvm.store %57, %arg3 : i64, !llvm.ptr
+    %c1_i64_20 = arith.constant 1 : i64
+    %58 = arith.cmpi ult, %56, %c1_i64_20 : i64
+    %c91_i8_21 = arith.constant 91 : i8
+    cf.cond_br %58, ^bb1(%c91_i8_21 : i8), ^bb20
   ^bb23:  // pred: ^bb16
-    %65 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_28 = arith.constant 3 : i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_22 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %66 = arith.cmpi uge, %65, %c3_i64_28 : i64
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %66, ^bb24, ^bb1(%c80_i8_29 : i8)
+    %60 = arith.cmpi uge, %59, %c3_i64_22 : i64
+    %c80_i8_23 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb24, ^bb1(%c80_i8_23 : i8)
   ^bb24:  // pred: ^bb23
-    %67 = arith.subi %65, %c3_i64_28 : i64
-    llvm.store %67, %arg1 : i64, !llvm.ptr
+    %61 = arith.subi %59, %c3_i64_22 : i64
+    llvm.store %61, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb21
-    %c0_i64_30 = arith.constant 0 : i64
+    %c0_i64_24 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %68 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %68, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %62 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_24, %c0_i64_24, %62, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb26:  // pred: ^bb11
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %69 = arith.cmpi sgt, %24, %c18446744073709551615_i256 : i256
+    %63 = arith.cmpi sgt, %22, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %69, ^bb1(%c84_i8 : i8), ^bb27
+    cf.cond_br %63, ^bb1(%c84_i8 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %70 = arith.trunci %24 : i256 to i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %71 = arith.cmpi slt, %70, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %71, ^bb1(%c84_i8_32 : i8), ^bb28
+    %64 = arith.trunci %22 : i256 to i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %65 = arith.cmpi slt, %64, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %65, ^bb1(%c84_i8_26 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %72 = arith.addi %70, %c32_i64 : i64
-    %c0_i64_33 = arith.constant 0 : i64
-    %73 = arith.cmpi slt, %72, %c0_i64_33 : i64
-    %c84_i8_34 = arith.constant 84 : i8
-    cf.cond_br %73, ^bb1(%c84_i8_34 : i8), ^bb29
+    %66 = arith.addi %64, %c32_i64 : i64
+    %c0_i64_27 = arith.constant 0 : i64
+    %67 = arith.cmpi slt, %66, %c0_i64_27 : i64
+    %c84_i8_28 = arith.constant 84 : i8
+    cf.cond_br %67, ^bb1(%c84_i8_28 : i8), ^bb29
   ^bb29:  // pred: ^bb28
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %74 = arith.addi %72, %c31_i64 : i64
-    %75 = arith.divui %74, %c32_i64_35 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %76 = arith.muli %75, %c32_i64_36 : i64
-    %77 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_37 = arith.constant 31 : i64
-    %c32_i64_38 = arith.constant 32 : i64
-    %78 = arith.addi %77, %c31_i64_37 : i64
-    %79 = arith.divui %78, %c32_i64_38 : i64
-    %80 = arith.muli %79, %c32_i64_36 : i64
-    %81 = arith.cmpi ult, %80, %76 : i64
-    cf.cond_br %81, ^bb31, ^bb30
+    %c32_i64_29 = arith.constant 32 : i64
+    %68 = arith.addi %66, %c31_i64 : i64
+    %69 = arith.divui %68, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %70 = arith.muli %69, %c32_i64_30 : i64
+    %71 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %72 = arith.addi %71, %c31_i64_31 : i64
+    %73 = arith.divui %72, %c32_i64_32 : i64
+    %74 = arith.muli %73, %c32_i64_30 : i64
+    %75 = arith.cmpi ult, %74, %70 : i64
+    cf.cond_br %75, ^bb31, ^bb30
   ^bb30:  // 2 preds: ^bb29, ^bb33
     cf.br ^bb12
   ^bb31:  // pred: ^bb29
-    %c3_i64_39 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %82 = arith.muli %79, %79 : i64
-    %83 = arith.divui %82, %c512_i64 : i64
-    %84 = arith.muli %79, %c3_i64_39 : i64
-    %85 = arith.addi %83, %84 : i64
-    %c3_i64_40 = arith.constant 3 : i64
-    %c512_i64_41 = arith.constant 512 : i64
-    %86 = arith.muli %75, %75 : i64
-    %87 = arith.divui %86, %c512_i64_41 : i64
-    %88 = arith.muli %75, %c3_i64_40 : i64
-    %89 = arith.addi %87, %88 : i64
-    %90 = arith.subi %89, %85 : i64
-    %91 = llvm.load %arg1 : !llvm.ptr -> i64
-    %92 = arith.cmpi ult, %91, %90 : i64
-    scf.if %92 {
+    %76 = arith.muli %73, %73 : i64
+    %77 = arith.divui %76, %c512_i64 : i64
+    %78 = arith.muli %73, %c3_i64_33 : i64
+    %79 = arith.addi %77, %78 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %80 = arith.muli %69, %69 : i64
+    %81 = arith.divui %80, %c512_i64_35 : i64
+    %82 = arith.muli %69, %c3_i64_34 : i64
+    %83 = arith.addi %81, %82 : i64
+    %84 = arith.subi %83, %79 : i64
+    %85 = llvm.load %arg1 : !llvm.ptr -> i64
+    %86 = arith.cmpi ult, %85, %84 : i64
+    scf.if %86 {
     } else {
-      %125 = arith.subi %91, %90 : i64
-      llvm.store %125, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %85, %84 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_42 = arith.constant 80 : i8
-    cf.cond_br %92, ^bb1(%c80_i8_42 : i8), ^bb32
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %86, ^bb1(%c80_i8_36 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %93 = call @dora_fn_extend_memory(%arg0, %76) : (!llvm.ptr, i64) -> !llvm.ptr
-    %94 = llvm.getelementptr %93[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %95 = llvm.load %94 : !llvm.ptr -> i8
+    %87 = call @dora_fn_extend_memory(%arg0, %70) : (!llvm.ptr, i64) -> !llvm.ptr
+    %88 = llvm.getelementptr %87[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %89 = llvm.load %88 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %96 = arith.cmpi ne, %95, %c0_i8 : i8
-    cf.cond_br %96, ^bb1(%95 : i8), ^bb33
+    %90 = arith.cmpi ne, %89, %c0_i8 : i8
+    cf.cond_br %90, ^bb1(%89 : i8), ^bb33
   ^bb33:  // pred: ^bb32
     cf.br ^bb30
   ^bb34:  // pred: ^bb20
-    %c18446744073709551615_i256_43 = arith.constant 18446744073709551615 : i256
-    %97 = arith.cmpi sgt, %52, %c18446744073709551615_i256_43 : i256
-    %c84_i8_44 = arith.constant 84 : i8
-    cf.cond_br %97, ^bb1(%c84_i8_44 : i8), ^bb35
+    %c18446744073709551615_i256_37 = arith.constant 18446744073709551615 : i256
+    %91 = arith.cmpi sgt, %47, %c18446744073709551615_i256_37 : i256
+    %c84_i8_38 = arith.constant 84 : i8
+    cf.cond_br %91, ^bb1(%c84_i8_38 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %98 = arith.trunci %52 : i256 to i64
-    %c0_i64_45 = arith.constant 0 : i64
-    %99 = arith.cmpi slt, %98, %c0_i64_45 : i64
-    %c84_i8_46 = arith.constant 84 : i8
-    cf.cond_br %99, ^bb1(%c84_i8_46 : i8), ^bb36
+    %92 = arith.trunci %47 : i256 to i64
+    %c0_i64_39 = arith.constant 0 : i64
+    %93 = arith.cmpi slt, %92, %c0_i64_39 : i64
+    %c84_i8_40 = arith.constant 84 : i8
+    cf.cond_br %93, ^bb1(%c84_i8_40 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %100 = arith.addi %98, %c32_i64_21 : i64
-    %c0_i64_47 = arith.constant 0 : i64
-    %101 = arith.cmpi slt, %100, %c0_i64_47 : i64
-    %c84_i8_48 = arith.constant 84 : i8
-    cf.cond_br %101, ^bb1(%c84_i8_48 : i8), ^bb37
+    %94 = arith.addi %92, %c32_i64_16 : i64
+    %c0_i64_41 = arith.constant 0 : i64
+    %95 = arith.cmpi slt, %94, %c0_i64_41 : i64
+    %c84_i8_42 = arith.constant 84 : i8
+    cf.cond_br %95, ^bb1(%c84_i8_42 : i8), ^bb37
   ^bb37:  // pred: ^bb36
-    %c31_i64_49 = arith.constant 31 : i64
-    %c32_i64_50 = arith.constant 32 : i64
-    %102 = arith.addi %100, %c31_i64_49 : i64
-    %103 = arith.divui %102, %c32_i64_50 : i64
-    %c32_i64_51 = arith.constant 32 : i64
-    %104 = arith.muli %103, %c32_i64_51 : i64
-    %105 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_52 = arith.constant 31 : i64
-    %c32_i64_53 = arith.constant 32 : i64
-    %106 = arith.addi %105, %c31_i64_52 : i64
-    %107 = arith.divui %106, %c32_i64_53 : i64
-    %108 = arith.muli %107, %c32_i64_51 : i64
-    %109 = arith.cmpi ult, %108, %104 : i64
-    cf.cond_br %109, ^bb39, ^bb38
+    %c31_i64_43 = arith.constant 31 : i64
+    %c32_i64_44 = arith.constant 32 : i64
+    %96 = arith.addi %94, %c31_i64_43 : i64
+    %97 = arith.divui %96, %c32_i64_44 : i64
+    %c32_i64_45 = arith.constant 32 : i64
+    %98 = arith.muli %97, %c32_i64_45 : i64
+    %99 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_46 = arith.constant 31 : i64
+    %c32_i64_47 = arith.constant 32 : i64
+    %100 = arith.addi %99, %c31_i64_46 : i64
+    %101 = arith.divui %100, %c32_i64_47 : i64
+    %102 = arith.muli %101, %c32_i64_45 : i64
+    %103 = arith.cmpi ult, %102, %98 : i64
+    cf.cond_br %103, ^bb39, ^bb38
   ^bb38:  // 2 preds: ^bb37, ^bb41
     cf.br ^bb21
   ^bb39:  // pred: ^bb37
-    %c3_i64_54 = arith.constant 3 : i64
-    %c512_i64_55 = arith.constant 512 : i64
-    %110 = arith.muli %107, %107 : i64
-    %111 = arith.divui %110, %c512_i64_55 : i64
-    %112 = arith.muli %107, %c3_i64_54 : i64
-    %113 = arith.addi %111, %112 : i64
-    %c3_i64_56 = arith.constant 3 : i64
-    %c512_i64_57 = arith.constant 512 : i64
-    %114 = arith.muli %103, %103 : i64
-    %115 = arith.divui %114, %c512_i64_57 : i64
-    %116 = arith.muli %103, %c3_i64_56 : i64
-    %117 = arith.addi %115, %116 : i64
-    %118 = arith.subi %117, %113 : i64
-    %119 = llvm.load %arg1 : !llvm.ptr -> i64
-    %120 = arith.cmpi ult, %119, %118 : i64
-    scf.if %120 {
+    %c3_i64_48 = arith.constant 3 : i64
+    %c512_i64_49 = arith.constant 512 : i64
+    %104 = arith.muli %101, %101 : i64
+    %105 = arith.divui %104, %c512_i64_49 : i64
+    %106 = arith.muli %101, %c3_i64_48 : i64
+    %107 = arith.addi %105, %106 : i64
+    %c3_i64_50 = arith.constant 3 : i64
+    %c512_i64_51 = arith.constant 512 : i64
+    %108 = arith.muli %97, %97 : i64
+    %109 = arith.divui %108, %c512_i64_51 : i64
+    %110 = arith.muli %97, %c3_i64_50 : i64
+    %111 = arith.addi %109, %110 : i64
+    %112 = arith.subi %111, %107 : i64
+    %113 = llvm.load %arg1 : !llvm.ptr -> i64
+    %114 = arith.cmpi ult, %113, %112 : i64
+    scf.if %114 {
     } else {
-      %125 = arith.subi %119, %118 : i64
-      llvm.store %125, %arg1 : i64, !llvm.ptr
+      %119 = arith.subi %113, %112 : i64
+      llvm.store %119, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_58 = arith.constant 80 : i8
-    cf.cond_br %120, ^bb1(%c80_i8_58 : i8), ^bb40
+    %c80_i8_52 = arith.constant 80 : i8
+    cf.cond_br %114, ^bb1(%c80_i8_52 : i8), ^bb40
   ^bb40:  // pred: ^bb39
-    %121 = call @dora_fn_extend_memory(%arg0, %104) : (!llvm.ptr, i64) -> !llvm.ptr
-    %122 = llvm.getelementptr %121[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %123 = llvm.load %122 : !llvm.ptr -> i8
-    %c0_i8_59 = arith.constant 0 : i8
-    %124 = arith.cmpi ne, %123, %c0_i8_59 : i8
-    cf.cond_br %124, ^bb1(%123 : i8), ^bb41
+    %115 = call @dora_fn_extend_memory(%arg0, %98) : (!llvm.ptr, i64) -> !llvm.ptr
+    %116 = llvm.getelementptr %115[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %117 = llvm.load %116 : !llvm.ptr -> i8
+    %c0_i8_53 = arith.constant 0 : i8
+    %118 = arith.cmpi ne, %117, %c0_i8_53 : i8
+    cf.cond_br %118, ^bb1(%117 : i8), ^bb41
   ^bb41:  // pred: ^bb40
     cf.br ^bb38
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_revert.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_revert.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 25 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb24, ^bb25, ^bb29, ^bb30, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb46, ^bb47
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 25 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb24, ^bb25, ^bb29, ^bb30, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb46, ^bb47
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c26855045751621412909479635801631599578944495011106431764815136423936_i256 = arith.constant 26855045751621412909479635801631599578944495011106431764815136423936 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c26855045751621412909479635801631599578944495011106431764815136423936_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,323 +96,314 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb33, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb33, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb37
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c2_i256 = arith.constant 2 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %c0_i256_19 = arith.constant 0 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_19, %50 : i256, !llvm.ptr
+    %c0_i256_15 = arith.constant 0 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_15, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb29
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %66 = arith.cmpi sgt, %65, %c18446744073709551615_i256 : i256
+    %59 = arith.cmpi sgt, %58, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %66, ^bb1(%c84_i8 : i8), ^bb25
+    cf.cond_br %59, ^bb1(%c84_i8 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %67 = arith.trunci %65 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %68 = arith.cmpi slt, %67, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %68, ^bb1(%c84_i8_29 : i8), ^bb26
+    %60 = arith.trunci %58 : i256 to i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_21 : i64
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i64_30 = arith.constant 0 : i64
-    %69 = arith.cmpi ne, %67, %c0_i64_30 : i64
-    cf.cond_br %69, ^bb41, ^bb27
+    %c0_i64_23 = arith.constant 0 : i64
+    %62 = arith.cmpi ne, %60, %c0_i64_23 : i64
+    cf.cond_br %62, ^bb41, ^bb27
   ^bb27:  // 2 preds: ^bb26, ^bb45
-    %70 = arith.trunci %61 : i256 to i64
-    %71 = llvm.load %arg1 : !llvm.ptr -> i64
+    %63 = arith.trunci %55 : i256 to i64
+    %64 = llvm.load %arg1 : !llvm.ptr -> i64
     %c16_i8 = arith.constant 16 : i8
-    call @dora_fn_write_result(%arg0, %70, %67, %71, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    call @dora_fn_write_result(%arg0, %63, %60, %64, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c16_i8 : i8
   ^bb28:  // no predecessors
     cf.br ^bb32
   ^bb29:  // pred: ^bb31
-    %c1024_i64_31 = arith.constant 1024 : i64
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_32 = arith.constant -2 : i64
-    %73 = arith.addi %72, %c-2_i64_32 : i64
-    %c2_i64_33 = arith.constant 2 : i64
-    %74 = arith.cmpi ult, %72, %c2_i64_33 : i64
-    %c91_i8_34 = arith.constant 91 : i8
-    cf.cond_br %74, ^bb1(%c91_i8_34 : i8), ^bb24
+    %c1024_i64_24 = arith.constant 1024 : i64
+    %65 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_25 = arith.constant -2 : i64
+    %66 = arith.addi %65, %c-2_i64_25 : i64
+    llvm.store %66, %arg3 : i64, !llvm.ptr
+    %c2_i64_26 = arith.constant 2 : i64
+    %67 = arith.cmpi ult, %65, %c2_i64_26 : i64
+    %c91_i8_27 = arith.constant 91 : i8
+    cf.cond_br %67, ^bb1(%c91_i8_27 : i8), ^bb24
   ^bb30:  // pred: ^bb20
-    %75 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_35 = arith.constant 0 : i64
+    %68 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_28 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %76 = arith.cmpi uge, %75, %c0_i64_35 : i64
-    %c80_i8_36 = arith.constant 80 : i8
-    cf.cond_br %76, ^bb31, ^bb1(%c80_i8_36 : i8)
+    %69 = arith.cmpi uge, %68, %c0_i64_28 : i64
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %69, ^bb31, ^bb1(%c80_i8_29 : i8)
   ^bb31:  // pred: ^bb30
-    %77 = arith.subi %75, %c0_i64_35 : i64
-    llvm.store %77, %arg1 : i64, !llvm.ptr
+    %70 = arith.subi %68, %c0_i64_28 : i64
+    llvm.store %70, %arg1 : i64, !llvm.ptr
     cf.br ^bb29
   ^bb32:  // pred: ^bb28
-    %c0_i64_37 = arith.constant 0 : i64
+    %c0_i64_30 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_37, %c0_i64_37, %78, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %71 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb33:  // pred: ^bb11
-    %c18446744073709551615_i256_38 = arith.constant 18446744073709551615 : i256
-    %79 = arith.cmpi sgt, %24, %c18446744073709551615_i256_38 : i256
-    %c84_i8_39 = arith.constant 84 : i8
-    cf.cond_br %79, ^bb1(%c84_i8_39 : i8), ^bb34
+    %c18446744073709551615_i256_31 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %22, %c18446744073709551615_i256_31 : i256
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_32 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %80 = arith.trunci %24 : i256 to i64
-    %c0_i64_40 = arith.constant 0 : i64
-    %81 = arith.cmpi slt, %80, %c0_i64_40 : i64
-    %c84_i8_41 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8_41 : i8), ^bb35
+    %73 = arith.trunci %22 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_34 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %82 = arith.addi %80, %c32_i64 : i64
-    %c0_i64_42 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_42 : i64
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_43 : i8), ^bb36
+    %75 = arith.addi %73, %c32_i64 : i64
+    %c0_i64_35 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_35 : i64
+    %c84_i8_36 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_36 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_44 = arith.constant 32 : i64
-    %84 = arith.addi %82, %c31_i64 : i64
-    %85 = arith.divui %84, %c32_i64_44 : i64
-    %c32_i64_45 = arith.constant 32 : i64
-    %86 = arith.muli %85, %c32_i64_45 : i64
-    %87 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_46 = arith.constant 31 : i64
-    %c32_i64_47 = arith.constant 32 : i64
-    %88 = arith.addi %87, %c31_i64_46 : i64
-    %89 = arith.divui %88, %c32_i64_47 : i64
-    %90 = arith.muli %89, %c32_i64_45 : i64
-    %91 = arith.cmpi ult, %90, %86 : i64
-    cf.cond_br %91, ^bb38, ^bb37
+    %c32_i64_37 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64 : i64
+    %78 = arith.divui %77, %c32_i64_37 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_38 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_39 = arith.constant 31 : i64
+    %c32_i64_40 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_39 : i64
+    %82 = arith.divui %81, %c32_i64_40 : i64
+    %83 = arith.muli %82, %c32_i64_38 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb38, ^bb37
   ^bb37:  // 2 preds: ^bb36, ^bb40
     cf.br ^bb12
   ^bb38:  // pred: ^bb36
-    %c3_i64_48 = arith.constant 3 : i64
+    %c3_i64_41 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %92 = arith.muli %89, %89 : i64
-    %93 = arith.divui %92, %c512_i64 : i64
-    %94 = arith.muli %89, %c3_i64_48 : i64
-    %95 = arith.addi %93, %94 : i64
-    %c3_i64_49 = arith.constant 3 : i64
-    %c512_i64_50 = arith.constant 512 : i64
-    %96 = arith.muli %85, %85 : i64
-    %97 = arith.divui %96, %c512_i64_50 : i64
-    %98 = arith.muli %85, %c3_i64_49 : i64
-    %99 = arith.addi %97, %98 : i64
-    %100 = arith.subi %99, %95 : i64
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %102 = arith.cmpi ult, %101, %100 : i64
-    scf.if %102 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_41 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_42 = arith.constant 3 : i64
+    %c512_i64_43 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_43 : i64
+    %91 = arith.muli %78, %c3_i64_42 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %135 = arith.subi %101, %100 : i64
-      llvm.store %135, %arg1 : i64, !llvm.ptr
+      %128 = arith.subi %94, %93 : i64
+      llvm.store %128, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_51 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb1(%c80_i8_51 : i8), ^bb39
+    %c80_i8_44 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_44 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %103 = call @dora_fn_extend_memory(%arg0, %86) : (!llvm.ptr, i64) -> !llvm.ptr
-    %104 = llvm.getelementptr %103[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %105 = llvm.load %104 : !llvm.ptr -> i8
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %106 = arith.cmpi ne, %105, %c0_i8 : i8
-    cf.cond_br %106, ^bb1(%105 : i8), ^bb40
+    %99 = arith.cmpi ne, %98, %c0_i8 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb40
   ^bb40:  // pred: ^bb39
     cf.br ^bb37
   ^bb41:  // pred: ^bb26
-    %c18446744073709551615_i256_52 = arith.constant 18446744073709551615 : i256
-    %107 = arith.cmpi sgt, %61, %c18446744073709551615_i256_52 : i256
-    %c84_i8_53 = arith.constant 84 : i8
-    cf.cond_br %107, ^bb1(%c84_i8_53 : i8), ^bb42
+    %c18446744073709551615_i256_45 = arith.constant 18446744073709551615 : i256
+    %100 = arith.cmpi sgt, %55, %c18446744073709551615_i256_45 : i256
+    %c84_i8_46 = arith.constant 84 : i8
+    cf.cond_br %100, ^bb1(%c84_i8_46 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %108 = arith.trunci %61 : i256 to i64
-    %c0_i64_54 = arith.constant 0 : i64
-    %109 = arith.cmpi slt, %108, %c0_i64_54 : i64
-    %c84_i8_55 = arith.constant 84 : i8
-    cf.cond_br %109, ^bb1(%c84_i8_55 : i8), ^bb43
+    %101 = arith.trunci %55 : i256 to i64
+    %c0_i64_47 = arith.constant 0 : i64
+    %102 = arith.cmpi slt, %101, %c0_i64_47 : i64
+    %c84_i8_48 = arith.constant 84 : i8
+    cf.cond_br %102, ^bb1(%c84_i8_48 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %110 = arith.addi %108, %67 : i64
-    %c0_i64_56 = arith.constant 0 : i64
-    %111 = arith.cmpi slt, %110, %c0_i64_56 : i64
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %111, ^bb1(%c84_i8_57 : i8), ^bb44
+    %103 = arith.addi %101, %60 : i64
+    %c0_i64_49 = arith.constant 0 : i64
+    %104 = arith.cmpi slt, %103, %c0_i64_49 : i64
+    %c84_i8_50 = arith.constant 84 : i8
+    cf.cond_br %104, ^bb1(%c84_i8_50 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c31_i64_58 = arith.constant 31 : i64
-    %c32_i64_59 = arith.constant 32 : i64
-    %112 = arith.addi %110, %c31_i64_58 : i64
-    %113 = arith.divui %112, %c32_i64_59 : i64
-    %c32_i64_60 = arith.constant 32 : i64
-    %114 = arith.muli %113, %c32_i64_60 : i64
-    %115 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_61 = arith.constant 31 : i64
-    %c32_i64_62 = arith.constant 32 : i64
-    %116 = arith.addi %115, %c31_i64_61 : i64
-    %117 = arith.divui %116, %c32_i64_62 : i64
-    %118 = arith.muli %117, %c32_i64_60 : i64
-    %119 = arith.cmpi ult, %118, %114 : i64
-    cf.cond_br %119, ^bb46, ^bb45
+    %c31_i64_51 = arith.constant 31 : i64
+    %c32_i64_52 = arith.constant 32 : i64
+    %105 = arith.addi %103, %c31_i64_51 : i64
+    %106 = arith.divui %105, %c32_i64_52 : i64
+    %c32_i64_53 = arith.constant 32 : i64
+    %107 = arith.muli %106, %c32_i64_53 : i64
+    %108 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_54 = arith.constant 31 : i64
+    %c32_i64_55 = arith.constant 32 : i64
+    %109 = arith.addi %108, %c31_i64_54 : i64
+    %110 = arith.divui %109, %c32_i64_55 : i64
+    %111 = arith.muli %110, %c32_i64_53 : i64
+    %112 = arith.cmpi ult, %111, %107 : i64
+    cf.cond_br %112, ^bb46, ^bb45
   ^bb45:  // 2 preds: ^bb44, ^bb48
     cf.br ^bb27
   ^bb46:  // pred: ^bb44
-    %c3_i64_63 = arith.constant 3 : i64
-    %c512_i64_64 = arith.constant 512 : i64
-    %120 = arith.muli %117, %117 : i64
-    %121 = arith.divui %120, %c512_i64_64 : i64
-    %122 = arith.muli %117, %c3_i64_63 : i64
-    %123 = arith.addi %121, %122 : i64
-    %c3_i64_65 = arith.constant 3 : i64
-    %c512_i64_66 = arith.constant 512 : i64
-    %124 = arith.muli %113, %113 : i64
-    %125 = arith.divui %124, %c512_i64_66 : i64
-    %126 = arith.muli %113, %c3_i64_65 : i64
-    %127 = arith.addi %125, %126 : i64
-    %128 = arith.subi %127, %123 : i64
-    %129 = llvm.load %arg1 : !llvm.ptr -> i64
-    %130 = arith.cmpi ult, %129, %128 : i64
-    scf.if %130 {
+    %c3_i64_56 = arith.constant 3 : i64
+    %c512_i64_57 = arith.constant 512 : i64
+    %113 = arith.muli %110, %110 : i64
+    %114 = arith.divui %113, %c512_i64_57 : i64
+    %115 = arith.muli %110, %c3_i64_56 : i64
+    %116 = arith.addi %114, %115 : i64
+    %c3_i64_58 = arith.constant 3 : i64
+    %c512_i64_59 = arith.constant 512 : i64
+    %117 = arith.muli %106, %106 : i64
+    %118 = arith.divui %117, %c512_i64_59 : i64
+    %119 = arith.muli %106, %c3_i64_58 : i64
+    %120 = arith.addi %118, %119 : i64
+    %121 = arith.subi %120, %116 : i64
+    %122 = llvm.load %arg1 : !llvm.ptr -> i64
+    %123 = arith.cmpi ult, %122, %121 : i64
+    scf.if %123 {
     } else {
-      %135 = arith.subi %129, %128 : i64
-      llvm.store %135, %arg1 : i64, !llvm.ptr
+      %128 = arith.subi %122, %121 : i64
+      llvm.store %128, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_67 = arith.constant 80 : i8
-    cf.cond_br %130, ^bb1(%c80_i8_67 : i8), ^bb47
+    %c80_i8_60 = arith.constant 80 : i8
+    cf.cond_br %123, ^bb1(%c80_i8_60 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %131 = call @dora_fn_extend_memory(%arg0, %114) : (!llvm.ptr, i64) -> !llvm.ptr
-    %132 = llvm.getelementptr %131[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %133 = llvm.load %132 : !llvm.ptr -> i8
-    %c0_i8_68 = arith.constant 0 : i8
-    %134 = arith.cmpi ne, %133, %c0_i8_68 : i8
-    cf.cond_br %134, ^bb1(%133 : i8), ^bb48
+    %124 = call @dora_fn_extend_memory(%arg0, %107) : (!llvm.ptr, i64) -> !llvm.ptr
+    %125 = llvm.getelementptr %124[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %126 = llvm.load %125 : !llvm.ptr -> i8
+    %c0_i8_61 = arith.constant 0 : i8
+    %127 = arith.cmpi ne, %126, %c0_i8_61 : i8
+    cf.cond_br %127, ^bb1(%126 : i8), ^bb48
   ^bb48:  // pred: ^bb47
     cf.br ^bb45
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_multiple_pop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_multiple_pop.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 13 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 13 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,149 +96,144 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c2_i256 = arith.constant 2 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c3_i256 = arith.constant 3 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c3_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
-    %33 = llvm.load %32 : !llvm.ptr -> i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %36 = arith.cmpi ult, %34, %c1_i64_15 : i64
+    %32 = arith.addi %31, %c-1_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
+    %c1_i64_12 = arith.constant 1 : i64
+    %33 = arith.cmpi ult, %31, %c1_i64_12 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c2_i64 : i64
-    %c80_i8_16 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb18, ^bb1(%c80_i8_16 : i8)
+    %35 = arith.cmpi uge, %34, %c2_i64 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb18, ^bb1(%c80_i8_13 : i8)
   ^bb18:  // pred: ^bb17
-    %39 = arith.subi %37, %c2_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c2_i64 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %41 = arith.subi %40, %c1_i64_17 : i64
-    %42 = llvm.getelementptr %arg2[%41] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    %43 = llvm.load %42 : !llvm.ptr -> i256
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %38 = llvm.getelementptr %37[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %39 = llvm.load %38 : !llvm.ptr -> i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_18 = arith.constant 1024 : i64
-    %44 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_19 = arith.constant -1 : i64
-    %45 = arith.addi %44, %c-1_i64_19 : i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %46 = arith.cmpi ult, %44, %c1_i64_20 : i64
-    %c91_i8_21 = arith.constant 91 : i8
-    cf.cond_br %46, ^bb1(%c91_i8_21 : i8), ^bb19
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_15 = arith.constant -1 : i64
+    %41 = arith.addi %40, %c-1_i64_15 : i64
+    llvm.store %41, %arg3 : i64, !llvm.ptr
+    %c1_i64_16 = arith.constant 1 : i64
+    %42 = arith.cmpi ult, %40, %c1_i64_16 : i64
+    %c91_i8_17 = arith.constant 91 : i8
+    cf.cond_br %42, ^bb1(%c91_i8_17 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %47 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_22 = arith.constant 2 : i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_18 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %48 = arith.cmpi uge, %47, %c2_i64_22 : i64
-    %c80_i8_23 = arith.constant 80 : i8
-    cf.cond_br %48, ^bb22, ^bb1(%c80_i8_23 : i8)
+    %44 = arith.cmpi uge, %43, %c2_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb22, ^bb1(%c80_i8_19 : i8)
   ^bb22:  // pred: ^bb21
-    %49 = arith.subi %47, %c2_i64_22 : i64
-    llvm.store %49, %arg1 : i64, !llvm.ptr
+    %45 = arith.subi %43, %c2_i64_18 : i64
+    llvm.store %45, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_24 = arith.constant 1 : i64
-    %51 = arith.subi %50, %c1_i64_24 : i64
-    %52 = llvm.getelementptr %arg2[%51] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    %53 = llvm.load %52 : !llvm.ptr -> i256
+    %46 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %47 = llvm.getelementptr %46[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %48 = llvm.load %47 : !llvm.ptr -> i256
+    llvm.store %47, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb24:  // pred: ^bb26
-    %c1024_i64_25 = arith.constant 1024 : i64
-    %54 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_26 = arith.constant -1 : i64
-    %55 = arith.addi %54, %c-1_i64_26 : i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %56 = arith.cmpi ult, %54, %c1_i64_27 : i64
-    %c91_i8_28 = arith.constant 91 : i8
-    cf.cond_br %56, ^bb1(%c91_i8_28 : i8), ^bb23
+    %c1024_i64_20 = arith.constant 1024 : i64
+    %49 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_21 = arith.constant -1 : i64
+    %50 = arith.addi %49, %c-1_i64_21 : i64
+    llvm.store %50, %arg3 : i64, !llvm.ptr
+    %c1_i64_22 = arith.constant 1 : i64
+    %51 = arith.cmpi ult, %49, %c1_i64_22 : i64
+    %c91_i8_23 = arith.constant 91 : i8
+    cf.cond_br %51, ^bb1(%c91_i8_23 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %57 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_29 = arith.constant 2 : i64
+    %52 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_24 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %58 = arith.cmpi uge, %57, %c2_i64_29 : i64
-    %c80_i8_30 = arith.constant 80 : i8
-    cf.cond_br %58, ^bb26, ^bb1(%c80_i8_30 : i8)
+    %53 = arith.cmpi uge, %52, %c2_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %53, ^bb26, ^bb1(%c80_i8_25 : i8)
   ^bb26:  // pred: ^bb25
-    %59 = arith.subi %57, %c2_i64_29 : i64
-    llvm.store %59, %arg1 : i64, !llvm.ptr
+    %54 = arith.subi %52, %c2_i64_24 : i64
+    llvm.store %54, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb23
-    %c0_i64_31 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %60 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_31, %c0_i64_31, %60, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %55, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_not.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_not.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,46 +95,43 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c-1_i256 = arith.constant -1 : i256
-    %16 = arith.xori %15, %c-1_i256 : i256
-    %17 = llvm.load %arg3 : !llvm.ptr -> i64
-    %18 = llvm.getelementptr %arg2[%17] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %19 = arith.addi %17, %c1_i64_2 : i64
-    llvm.store %19, %arg3 : i64, !llvm.ptr
-    llvm.store %16, %18 : i256, !llvm.ptr
+    %15 = arith.xori %14, %c-1_i256 : i256
+    %16 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %15, %16 : i256, !llvm.ptr
+    %17 = llvm.getelementptr %16[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %17, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %20 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_4 = arith.constant 0 : i64
-    %21 = arith.addi %20, %c0_i64_4 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %22 = arith.cmpi ult, %20, %c1_i64_5 : i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %18 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %19 = arith.addi %18, %c0_i64_2 : i64
+    llvm.store %19, %arg3 : i64, !llvm.ptr
+    %c1_i64_3 = arith.constant 1 : i64
+    %20 = arith.cmpi ult, %18, %c1_i64_3 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %22, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %20, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %23 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %24 = arith.cmpi uge, %23, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %24, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %22 = arith.cmpi uge, %21, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %22, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %25 = arith.subi %23, %c3_i64_6 : i64
-    llvm.store %25, %arg1 : i64, !llvm.ptr
+    %23 = arith.subi %21, %c3_i64_4 : i64
+    llvm.store %23, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %26 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %26, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %24 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %24, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_overflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_overflow.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c-1_i256 = arith.constant -1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c-1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,38 +95,37 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c2_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c2_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_3 : i8)
   ^bb10:  // pred: ^bb9
-    %21 = arith.subi %19, %c2_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c2_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_5 = arith.constant 0 : i64
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %22, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %21, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c125985_i256 = arith.constant 125985 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c125985_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,38 +95,37 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c2_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c2_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_3 : i8)
   ^bb10:  // pred: ^bb9
-    %21 = arith.subi %19, %c2_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c2_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_5 = arith.constant 0 : i64
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %22, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %21, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c42_i256 = arith.constant 42 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c42_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,38 +95,37 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c2_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c2_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_3 : i8)
   ^bb10:  // pred: ^bb9
-    %21 = arith.subi %19, %c2_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c2_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_5 = arith.constant 0 : i64
+    %c0_i64_4 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %22, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %21, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_codesize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_codesize.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,66 +95,64 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c2_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c2_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_3 : i8)
   ^bb10:  // pred: ^bb9
-    %21 = arith.subi %19, %c2_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c2_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %c0_i256_5 = arith.constant 0 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_6 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_6 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_5, %23 : i256, !llvm.ptr
+    %c0_i256_4 = arith.constant 0 : i256
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_4, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_7 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_8 : i64
-    %27 = arith.cmpi ult, %c1024_i64_7, %26 : i64
-    %c92_i8_9 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_9 : i8), ^bb11
+    %c1024_i64_5 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_6 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_6 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_5, %24 : i64
+    %c92_i8_7 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_7 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_10 = arith.constant 2 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_8 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c2_i64_10 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %27 = arith.cmpi uge, %26, %c2_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %30 = arith.subi %28, %c2_i64_10 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c2_i64_8 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %29 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %29, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_with_jump.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_pop_with_jump.snap
@@ -53,32 +53,34 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // pred: ^bb7
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb9, ^bb10, ^bb13, ^bb14, ^bb18, ^bb21, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // pred: ^bb7
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8),
       6: ^bb18
     ]
   ^bb3:  // pred: ^bb4
     %c6_i256 = arith.constant 6 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c6_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,143 +96,140 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    cf.br ^bb2(%15 : i256)
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb2(%14 : i256)
   ^bb8:  // no predecessors
     cf.br ^bb14
   ^bb9:  // pred: ^bb11
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c8_i64 : i64
-    %c80_i8_4 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb11, ^bb1(%c80_i8_4 : i8)
+    %19 = arith.cmpi uge, %18, %c8_i64 : i64
+    %c80_i8_3 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb11, ^bb1(%c80_i8_3 : i8)
   ^bb11:  // pred: ^bb10
-    %21 = arith.subi %19, %c8_i64 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c8_i64 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb13
     %c10_i256 = arith.constant 10 : i256
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_5 = arith.constant 1 : i64
-    %24 = arith.addi %22, %c1_i64_5 : i64
-    llvm.store %24, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %23 : i256, !llvm.ptr
+    %21 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %21 : i256, !llvm.ptr
+    %22 = llvm.getelementptr %21[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %22, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_6 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %26 = arith.addi %25, %c1_i64_7 : i64
-    %27 = arith.cmpi ult, %c1024_i64_6, %26 : i64
-    %c92_i8_8 = arith.constant 92 : i8
-    cf.cond_br %27, ^bb1(%c92_i8_8 : i8), ^bb12
+    %c1024_i64_4 = arith.constant 1024 : i64
+    %23 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_5 = arith.constant 1 : i64
+    %24 = arith.addi %23, %c1_i64_5 : i64
+    llvm.store %24, %arg3 : i64, !llvm.ptr
+    %25 = arith.cmpi ult, %c1024_i64_4, %24 : i64
+    %c92_i8_6 = arith.constant 92 : i8
+    cf.cond_br %25, ^bb1(%c92_i8_6 : i8), ^bb12
   ^bb14:  // pred: ^bb8
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %26 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb15, ^bb1(%c80_i8_10 : i8)
+    %27 = arith.cmpi uge, %26, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %27, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %30 = arith.subi %28, %c3_i64_9 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %28 = arith.subi %26, %c3_i64_7 : i64
+    llvm.store %28, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
-    %32 = arith.addi %31, %c0_i64_12 : i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
+    %30 = arith.addi %29, %c0_i64_10 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb18:  // 2 preds: ^bb2, ^bb12
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c1_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb19, ^bb1(%c80_i8_14 : i8)
+    %32 = arith.cmpi uge, %31, %c1_i64_11 : i64
+    %c80_i8_12 = arith.constant 80 : i8
+    cf.cond_br %32, ^bb19, ^bb1(%c80_i8_12 : i8)
   ^bb19:  // pred: ^bb18
-    %35 = arith.subi %33, %c1_i64_13 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %33 = arith.subi %31, %c1_i64_11 : i64
+    llvm.store %33, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
     %c20_i256 = arith.constant 20 : i256
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %37 = llvm.getelementptr %arg2[%36] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %38 = arith.addi %36, %c1_i64_15 : i64
-    llvm.store %38, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %37 : i256, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %34 : i256, !llvm.ptr
+    %35 = llvm.getelementptr %34[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb21:  // pred: ^bb23
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %40 = arith.addi %39, %c1_i64_17 : i64
-    %41 = arith.cmpi ult, %c1024_i64_16, %40 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %41, ^bb1(%c92_i8_18 : i8), ^bb20
+    %c1024_i64_13 = arith.constant 1024 : i64
+    %36 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_14 = arith.constant 1 : i64
+    %37 = arith.addi %36, %c1_i64_14 : i64
+    llvm.store %37, %arg3 : i64, !llvm.ptr
+    %38 = arith.cmpi ult, %c1024_i64_13, %37 : i64
+    %c92_i8_15 = arith.constant 92 : i8
+    cf.cond_br %38, ^bb1(%c92_i8_15 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_16 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb23, ^bb1(%c80_i8_20 : i8)
+    %40 = arith.cmpi uge, %39, %c3_i64_16 : i64
+    %c80_i8_17 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb23, ^bb1(%c80_i8_17 : i8)
   ^bb23:  // pred: ^bb22
-    %44 = arith.subi %42, %c3_i64_19 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c3_i64_16 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb25
-    %45 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %46 = arith.subi %45, %c1_i64_21 : i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %46, %arg3 : i64, !llvm.ptr
-    %48 = llvm.load %47 : !llvm.ptr -> i256
+    %42 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb28
   ^bb25:  // pred: ^bb27
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_23 = arith.constant -1 : i64
-    %50 = arith.addi %49, %c-1_i64_23 : i64
-    %c1_i64_24 = arith.constant 1 : i64
-    %51 = arith.cmpi ult, %49, %c1_i64_24 : i64
-    %c91_i8_25 = arith.constant 91 : i8
-    cf.cond_br %51, ^bb1(%c91_i8_25 : i8), ^bb24
+    %c1024_i64_18 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_19 = arith.constant -1 : i64
+    %46 = arith.addi %45, %c-1_i64_19 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %c1_i64_20 = arith.constant 1 : i64
+    %47 = arith.cmpi ult, %45, %c1_i64_20 : i64
+    %c91_i8_21 = arith.constant 91 : i8
+    cf.cond_br %47, ^bb1(%c91_i8_21 : i8), ^bb24
   ^bb26:  // pred: ^bb20
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c2_i64 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb27, ^bb1(%c80_i8_26 : i8)
+    %49 = arith.cmpi uge, %48, %c2_i64 : i64
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb27, ^bb1(%c80_i8_22 : i8)
   ^bb27:  // pred: ^bb26
-    %54 = arith.subi %52, %c2_i64 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c2_i64 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb25
   ^bb28:  // pred: ^bb24
-    %c0_i64_27 = arith.constant 0 : i64
+    %c0_i64_23 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_27, %c0_i64_27, %55, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %51 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %51, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256_1 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.addi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_10 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.addi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_12 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_8 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c340282366920938463463374607431768211455_i256 = arith.constant 340282366920938463463374607431768211455 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c340282366920938463463374607431768211455_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.addi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.addi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_add_overflow_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c18446744073709551615_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.addi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.addi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c255_i256 = arith.constant 255 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c255_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c255_i256_1 = arith.constant 255 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c255_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c255_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.andi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_10 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.andi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_12 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_8 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c255_i256 = arith.constant 255 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c255_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c255_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.andi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.andi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_and_edge_case.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c340282366920938463463374607431768211455_i256 = arith.constant 340282366920938463463374607431768211455 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c340282366920938463463374607431768211455_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.andi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.andi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_byte.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_byte.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c255_i256 = arith.constant 255 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c255_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,91 +96,85 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c31_i256 = arith.constant 31 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c31_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c31_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c8_i256 = arith.constant 8 : i256
     %c248_i256 = arith.constant 248 : i256
-    %29 = arith.muli %24, %c8_i256 : i256
-    %30 = arith.cmpi ugt, %29, %c248_i256 : i256
-    %31 = scf.if %30 -> (i256) {
+    %26 = arith.muli %22, %c8_i256 : i256
+    %27 = arith.cmpi ugt, %26, %c248_i256 : i256
+    %28 = scf.if %27 -> (i256) {
       %c0_i256 = arith.constant 0 : i256
       scf.yield %c0_i256 : i256
     } else {
-      %42 = arith.subi %c248_i256, %29 : i256
-      %43 = arith.shrui %28, %42 : i256
-      %c255_i256_14 = arith.constant 255 : i256
-      %44 = arith.andi %43, %c255_i256_14 : i256
-      scf.yield %44 : i256
+      %38 = arith.subi %c248_i256, %26 : i256
+      %39 = arith.shrui %25, %38 : i256
+      %c255_i256_10 = arith.constant 255 : i256
+      %40 = arith.andi %39, %c255_i256_10 : i256
+      scf.yield %40 : i256
     }
-    %32 = llvm.load %arg3 : !llvm.ptr -> i64
-    %33 = llvm.getelementptr %arg2[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %34 = arith.addi %32, %c1_i64_9 : i64
-    llvm.store %34, %arg3 : i64, !llvm.ptr
-    llvm.store %31, %33 : i256, !llvm.ptr
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %28, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %36 = arith.addi %35, %c-1_i64 : i64
+    %32 = arith.addi %31, %c-1_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %40 = arith.subi %38, %c3_i64_11 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_7 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,81 +96,75 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256_1 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.divui %24, %28 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.divui %22, %25 : i256
     %c0_i256 = arith.constant 0 : i256
-    %30 = arith.cmpi eq, %28, %c0_i256 : i256
-    %31 = arith.select %30, %c0_i256, %29 : i256
-    %32 = llvm.load %arg3 : !llvm.ptr -> i64
-    %33 = llvm.getelementptr %arg2[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %34 = arith.addi %32, %c1_i64_10 : i64
-    llvm.store %34, %arg3 : i64, !llvm.ptr
-    llvm.store %31, %33 : i256, !llvm.ptr
+    %27 = arith.cmpi eq, %25, %c0_i256 : i256
+    %28 = arith.select %27, %c0_i256, %26 : i256
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %28, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %36 = arith.addi %35, %c-1_i64 : i64
+    %32 = arith.addi %31, %c-1_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %40 = arith.subi %38, %c5_i64 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c5_i64 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,81 +96,75 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.divui %24, %28 : i256
-    %c0_i256_9 = arith.constant 0 : i256
-    %30 = arith.cmpi eq, %28, %c0_i256_9 : i256
-    %31 = arith.select %30, %c0_i256_9, %29 : i256
-    %32 = llvm.load %arg3 : !llvm.ptr -> i64
-    %33 = llvm.getelementptr %arg2[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %34 = arith.addi %32, %c1_i64_10 : i64
-    llvm.store %34, %arg3 : i64, !llvm.ptr
-    llvm.store %31, %33 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.divui %22, %25 : i256
+    %c0_i256_6 = arith.constant 0 : i256
+    %27 = arith.cmpi eq, %25, %c0_i256_6 : i256
+    %28 = arith.select %27, %c0_i256_6, %26 : i256
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %28, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %36 = arith.addi %35, %c-1_i64 : i64
+    %32 = arith.addi %31, %c-1_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %40 = arith.subi %38, %c5_i64 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c5_i64 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_div_zero_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,81 +96,75 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.divui %24, %28 : i256
-    %c0_i256_9 = arith.constant 0 : i256
-    %30 = arith.cmpi eq, %28, %c0_i256_9 : i256
-    %31 = arith.select %30, %c0_i256_9, %29 : i256
-    %32 = llvm.load %arg3 : !llvm.ptr -> i64
-    %33 = llvm.getelementptr %arg2[%32] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %34 = arith.addi %32, %c1_i64_10 : i64
-    llvm.store %34, %arg3 : i64, !llvm.ptr
-    llvm.store %31, %33 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.divui %22, %25 : i256
+    %c0_i256_6 = arith.constant 0 : i256
+    %27 = arith.cmpi eq, %25, %c0_i256_6 : i256
+    %28 = arith.select %27, %c0_i256_6, %26 : i256
+    %29 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %28, %29 : i256, !llvm.ptr
+    %30 = llvm.getelementptr %29[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %30, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %36 = arith.addi %35, %c-1_i64 : i64
+    %32 = arith.addi %31, %c-1_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %40 = arith.subi %38, %c5_i64 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c5_i64 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %37, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,79 +96,73 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256_1 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.cmpi eq, %24, %28 : i256
-    %30 = arith.extui %29 : i1 to i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_10 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.cmpi eq, %22, %25 : i256
+    %27 = arith.extui %26 : i1 to i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_12 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_8 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_eq_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c5_i256 = arith.constant 5 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c5_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,79 +96,73 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.cmpi eq, %24, %28 : i256
-    %30 = arith.extui %29 : i1 to i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.cmpi eq, %22, %25 : i256
+    %27 = arith.extui %26 : i1 to i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_7 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c3_i256 = arith.constant 3 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c3_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,113 +96,107 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c3_i256_1 = arith.constant 3 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c3_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i64) {
-      %c0_i64_16 = arith.constant 0 : i64
-      scf.yield %c0_i64_16 : i64
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i64) {
+      %c0_i64_12 = arith.constant 0 : i64
+      scf.yield %c0_i64_12 : i64
     } else {
-      %46 = "llvm.intr.ctlz"(%28) <{is_zero_poison = false}> : (i256) -> i256
+      %42 = "llvm.intr.ctlz"(%25) <{is_zero_poison = false}> : (i256) -> i256
       %c256_i256 = arith.constant 256 : i256
-      %47 = arith.subi %c256_i256, %46 : i256
+      %43 = arith.subi %c256_i256, %42 : i256
       %c7_i256 = arith.constant 7 : i256
-      %48 = arith.addi %47, %c7_i256 : i256
+      %44 = arith.addi %43, %c7_i256 : i256
       %c8_i256 = arith.constant 8 : i256
-      %49 = arith.divui %48, %c8_i256 : i256
+      %45 = arith.divui %44, %c8_i256 : i256
       %c50_i256 = arith.constant 50 : i256
-      %50 = arith.muli %49, %c50_i256 : i256
-      %51 = arith.trunci %50 : i256 to i64
-      scf.yield %51 : i64
+      %46 = arith.muli %45, %c50_i256 : i256
+      %47 = arith.trunci %46 : i256 to i64
+      scf.yield %47 : i64
     }
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = arith.cmpi ult, %31, %30 : i64
-    scf.if %32 {
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = arith.cmpi ult, %28, %27 : i64
+    scf.if %29 {
     } else {
-      %46 = arith.subi %31, %30 : i64
-      llvm.store %46, %arg1 : i64, !llvm.ptr
+      %42 = arith.subi %28, %27 : i64
+      llvm.store %42, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb1(%c80_i8_10 : i8), ^bb12
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %29, ^bb1(%c80_i8_7 : i8), ^bb12
   ^bb12:  // pred: ^bb11
     %c1_i256 = arith.constant 1 : i256
-    %33 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %33 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_11 = arith.constant 1 : i256
-    %34 = llvm.alloca %c1_i256_11 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %34 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_exp(%arg0, %33, %34) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-    %35 = llvm.load %34 : !llvm.ptr -> i256
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %37 = llvm.getelementptr %arg2[%36] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_12 = arith.constant 1 : i64
-    %38 = arith.addi %36, %c1_i64_12 : i64
-    llvm.store %38, %arg3 : i64, !llvm.ptr
-    llvm.store %35, %37 : i256, !llvm.ptr
+    %30 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %30 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_8 = arith.constant 1 : i256
+    %31 = llvm.alloca %c1_i256_8 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %31 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_exp(%arg0, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %32 = llvm.load %31 : !llvm.ptr -> i256
+    %33 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %32, %33 : i256, !llvm.ptr
+    %34 = llvm.getelementptr %33[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %34, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_13 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %35 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %40 = arith.addi %39, %c-1_i64 : i64
+    %36 = arith.addi %35, %c-1_i64 : i64
+    llvm.store %36, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %41 = arith.cmpi ult, %39, %c2_i64 : i64
+    %37 = arith.cmpi ult, %35, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %41, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
     %c10_i64 = arith.constant 10 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c10_i64 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb15, ^bb1(%c80_i8_14 : i8)
+    %39 = arith.cmpi uge, %38, %c10_i64 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %39, ^bb15, ^bb1(%c80_i8_10 : i8)
   ^bb15:  // pred: ^bb14
-    %44 = arith.subi %42, %c10_i64 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %40 = arith.subi %38, %c10_i64 : i64
+    llvm.store %40, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %45, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_edge_case.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,113 +96,107 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c340282366920938463463374607431768211455_i256 = arith.constant 340282366920938463463374607431768211455 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c340282366920938463463374607431768211455_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c340282366920938463463374607431768211455_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i64) {
-      %c0_i64_16 = arith.constant 0 : i64
-      scf.yield %c0_i64_16 : i64
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i64) {
+      %c0_i64_12 = arith.constant 0 : i64
+      scf.yield %c0_i64_12 : i64
     } else {
-      %46 = "llvm.intr.ctlz"(%28) <{is_zero_poison = false}> : (i256) -> i256
+      %42 = "llvm.intr.ctlz"(%25) <{is_zero_poison = false}> : (i256) -> i256
       %c256_i256 = arith.constant 256 : i256
-      %47 = arith.subi %c256_i256, %46 : i256
+      %43 = arith.subi %c256_i256, %42 : i256
       %c7_i256 = arith.constant 7 : i256
-      %48 = arith.addi %47, %c7_i256 : i256
+      %44 = arith.addi %43, %c7_i256 : i256
       %c8_i256 = arith.constant 8 : i256
-      %49 = arith.divui %48, %c8_i256 : i256
+      %45 = arith.divui %44, %c8_i256 : i256
       %c50_i256 = arith.constant 50 : i256
-      %50 = arith.muli %49, %c50_i256 : i256
-      %51 = arith.trunci %50 : i256 to i64
-      scf.yield %51 : i64
+      %46 = arith.muli %45, %c50_i256 : i256
+      %47 = arith.trunci %46 : i256 to i64
+      scf.yield %47 : i64
     }
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = arith.cmpi ult, %31, %30 : i64
-    scf.if %32 {
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = arith.cmpi ult, %28, %27 : i64
+    scf.if %29 {
     } else {
-      %46 = arith.subi %31, %30 : i64
-      llvm.store %46, %arg1 : i64, !llvm.ptr
+      %42 = arith.subi %28, %27 : i64
+      llvm.store %42, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_9 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb1(%c80_i8_9 : i8), ^bb12
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %29, ^bb1(%c80_i8_6 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %c1_i256_10 = arith.constant 1 : i256
-    %33 = llvm.alloca %c1_i256_10 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %33 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_11 = arith.constant 1 : i256
-    %34 = llvm.alloca %c1_i256_11 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %34 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_exp(%arg0, %33, %34) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-    %35 = llvm.load %34 : !llvm.ptr -> i256
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %37 = llvm.getelementptr %arg2[%36] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_12 = arith.constant 1 : i64
-    %38 = arith.addi %36, %c1_i64_12 : i64
-    llvm.store %38, %arg3 : i64, !llvm.ptr
-    llvm.store %35, %37 : i256, !llvm.ptr
+    %c1_i256_7 = arith.constant 1 : i256
+    %30 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %30 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_8 = arith.constant 1 : i256
+    %31 = llvm.alloca %c1_i256_8 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %31 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_exp(%arg0, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %32 = llvm.load %31 : !llvm.ptr -> i256
+    %33 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %32, %33 : i256, !llvm.ptr
+    %34 = llvm.getelementptr %33[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %34, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_13 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %35 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %40 = arith.addi %39, %c-1_i64 : i64
+    %36 = arith.addi %35, %c-1_i64 : i64
+    llvm.store %36, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %41 = arith.cmpi ult, %39, %c2_i64 : i64
+    %37 = arith.cmpi ult, %35, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %41, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
     %c10_i64 = arith.constant 10 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c10_i64 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb15, ^bb1(%c80_i8_14 : i8)
+    %39 = arith.cmpi uge, %38, %c10_i64 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %39, ^bb15, ^bb1(%c80_i8_10 : i8)
   ^bb15:  // pred: ^bb14
-    %44 = arith.subi %42, %c10_i64 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %40 = arith.subi %38, %c10_i64 : i64
+    llvm.store %40, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %45, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_large_base.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_exp_large_base.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c5_i256 = arith.constant 5 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c5_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,113 +96,107 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c123456789_i256 = arith.constant 123456789 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c123456789_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c123456789_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i64) {
-      %c0_i64_15 = arith.constant 0 : i64
-      scf.yield %c0_i64_15 : i64
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i64) {
+      %c0_i64_11 = arith.constant 0 : i64
+      scf.yield %c0_i64_11 : i64
     } else {
-      %46 = "llvm.intr.ctlz"(%28) <{is_zero_poison = false}> : (i256) -> i256
+      %42 = "llvm.intr.ctlz"(%25) <{is_zero_poison = false}> : (i256) -> i256
       %c256_i256 = arith.constant 256 : i256
-      %47 = arith.subi %c256_i256, %46 : i256
+      %43 = arith.subi %c256_i256, %42 : i256
       %c7_i256 = arith.constant 7 : i256
-      %48 = arith.addi %47, %c7_i256 : i256
+      %44 = arith.addi %43, %c7_i256 : i256
       %c8_i256 = arith.constant 8 : i256
-      %49 = arith.divui %48, %c8_i256 : i256
+      %45 = arith.divui %44, %c8_i256 : i256
       %c50_i256 = arith.constant 50 : i256
-      %50 = arith.muli %49, %c50_i256 : i256
-      %51 = arith.trunci %50 : i256 to i64
-      scf.yield %51 : i64
+      %46 = arith.muli %45, %c50_i256 : i256
+      %47 = arith.trunci %46 : i256 to i64
+      scf.yield %47 : i64
     }
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = arith.cmpi ult, %31, %30 : i64
-    scf.if %32 {
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = arith.cmpi ult, %28, %27 : i64
+    scf.if %29 {
     } else {
-      %46 = arith.subi %31, %30 : i64
-      llvm.store %46, %arg1 : i64, !llvm.ptr
+      %42 = arith.subi %28, %27 : i64
+      llvm.store %42, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_9 = arith.constant 80 : i8
-    cf.cond_br %32, ^bb1(%c80_i8_9 : i8), ^bb12
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %29, ^bb1(%c80_i8_6 : i8), ^bb12
   ^bb12:  // pred: ^bb11
     %c1_i256 = arith.constant 1 : i256
-    %33 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %33 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_10 = arith.constant 1 : i256
-    %34 = llvm.alloca %c1_i256_10 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %34 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_exp(%arg0, %33, %34) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-    %35 = llvm.load %34 : !llvm.ptr -> i256
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %37 = llvm.getelementptr %arg2[%36] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_11 = arith.constant 1 : i64
-    %38 = arith.addi %36, %c1_i64_11 : i64
-    llvm.store %38, %arg3 : i64, !llvm.ptr
-    llvm.store %35, %37 : i256, !llvm.ptr
+    %30 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %30 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_7 = arith.constant 1 : i256
+    %31 = llvm.alloca %c1_i256_7 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %31 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_exp(%arg0, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %32 = llvm.load %31 : !llvm.ptr -> i256
+    %33 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %32, %33 : i256, !llvm.ptr
+    %34 = llvm.getelementptr %33[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %34, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %35 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %40 = arith.addi %39, %c-1_i64 : i64
+    %36 = arith.addi %35, %c-1_i64 : i64
+    llvm.store %36, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %41 = arith.cmpi ult, %39, %c2_i64 : i64
+    %37 = arith.cmpi ult, %35, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %41, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
     %c10_i64 = arith.constant 10 : i64
     call @dora_fn_nop() : () -> ()
-    %43 = arith.cmpi uge, %42, %c10_i64 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %43, ^bb15, ^bb1(%c80_i8_13 : i8)
+    %39 = arith.cmpi uge, %38, %c10_i64 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %39, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %44 = arith.subi %42, %c10_i64 : i64
-    llvm.store %44, %arg1 : i64, !llvm.ptr
+    %40 = arith.subi %38, %c10_i64 : i64
+    llvm.store %40, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %45, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_gt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_gt.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,79 +96,73 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c9_i256 = arith.constant 9 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c9_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c9_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.cmpi ugt, %24, %28 : i256
-    %30 = arith.extui %29 : i1 to i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.cmpi ugt, %22, %25 : i256
+    %27 = arith.extui %26 : i1 to i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_7 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,47 +95,44 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %16 = arith.cmpi eq, %15, %c0_i256 : i256
-    %17 = arith.extui %16 : i1 to i256
-    %18 = llvm.load %arg3 : !llvm.ptr -> i64
-    %19 = llvm.getelementptr %arg2[%18] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %20 = arith.addi %18, %c1_i64_2 : i64
-    llvm.store %20, %arg3 : i64, !llvm.ptr
-    llvm.store %17, %19 : i256, !llvm.ptr
+    %15 = arith.cmpi eq, %14, %c0_i256 : i256
+    %16 = arith.extui %15 : i1 to i256
+    %17 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %16, %17 : i256, !llvm.ptr
+    %18 = llvm.getelementptr %17[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %18, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_4 = arith.constant 0 : i64
-    %22 = arith.addi %21, %c0_i64_4 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %23 = arith.cmpi ult, %21, %c1_i64_5 : i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %19 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %20 = arith.addi %19, %c0_i64_2 : i64
+    llvm.store %20, %arg3 : i64, !llvm.ptr
+    %c1_i64_3 = arith.constant 1 : i64
+    %21 = arith.cmpi ult, %19, %c1_i64_3 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %23, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %21, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %22 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %25 = arith.cmpi uge, %24, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %25, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %23 = arith.cmpi uge, %22, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %23, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %26 = arith.subi %24, %c3_i64_6 : i64
-    llvm.store %26, %arg1 : i64, !llvm.ptr
+    %24 = arith.subi %22, %c3_i64_4 : i64
+    llvm.store %24, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_6 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %27, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %25, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_iszero_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,47 +95,44 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %c0_i256_2 = arith.constant 0 : i256
-    %16 = arith.cmpi eq, %15, %c0_i256_2 : i256
-    %17 = arith.extui %16 : i1 to i256
-    %18 = llvm.load %arg3 : !llvm.ptr -> i64
-    %19 = llvm.getelementptr %arg2[%18] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_3 = arith.constant 1 : i64
-    %20 = arith.addi %18, %c1_i64_3 : i64
-    llvm.store %20, %arg3 : i64, !llvm.ptr
-    llvm.store %17, %19 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    %c0_i256_1 = arith.constant 0 : i256
+    %15 = arith.cmpi eq, %14, %c0_i256_1 : i256
+    %16 = arith.extui %15 : i1 to i256
+    %17 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %16, %17 : i256, !llvm.ptr
+    %18 = llvm.getelementptr %17[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %18, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_5 = arith.constant 0 : i64
-    %22 = arith.addi %21, %c0_i64_5 : i64
-    %c1_i64_6 = arith.constant 1 : i64
-    %23 = arith.cmpi ult, %21, %c1_i64_6 : i64
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %19 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
+    %20 = arith.addi %19, %c0_i64_3 : i64
+    llvm.store %20, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %21 = arith.cmpi ult, %19, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %23, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %21, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_7 = arith.constant 3 : i64
+    %22 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %25 = arith.cmpi uge, %24, %c3_i64_7 : i64
-    %c80_i8_8 = arith.constant 80 : i8
-    cf.cond_br %25, ^bb10, ^bb1(%c80_i8_8 : i8)
+    %23 = arith.cmpi uge, %22, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %23, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %26 = arith.subi %24, %c3_i64_7 : i64
-    llvm.store %26, %arg1 : i64, !llvm.ptr
+    %24 = arith.subi %22, %c3_i64_5 : i64
+    llvm.store %24, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_9 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %27, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %25, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_lt.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_lt.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,79 +96,73 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c9_i256 = arith.constant 9 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c9_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c9_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.cmpi ult, %24, %28 : i256
-    %30 = arith.extui %29 : i1 to i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.cmpi ult, %22, %25 : i256
+    %27 = arith.extui %26 : i1 to i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_7 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c3_i256 = arith.constant 3 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c3_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,85 +96,79 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i256) {
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i256) {
       scf.yield %c0_i256 : i256
     } else {
-      %41 = arith.remui %24, %28 : i256
-      scf.yield %41 : i256
+      %37 = arith.remui %22, %25 : i256
+      scf.yield %37 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c5_i256 = arith.constant 5 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c5_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,85 +96,79 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c17_i256 = arith.constant 17 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c17_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c17_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i256) {
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i256) {
       scf.yield %c0_i256 : i256
     } else {
-      %41 = arith.remui %24, %28 : i256
-      scf.yield %41 : i256
+      %37 = arith.remui %22, %25 : i256
+      scf.yield %37 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_zero_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mod_zero_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,85 +96,79 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %c0_i256_9 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256_9 : i256
-    %30 = scf.if %29 -> (i256) {
-      scf.yield %c0_i256_9 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %c0_i256_6 = arith.constant 0 : i256
+    %26 = arith.cmpi eq, %25, %c0_i256_6 : i256
+    %27 = scf.if %26 -> (i256) {
+      scf.yield %c0_i256_6 : i256
     } else {
-      %41 = arith.remui %24, %28 : i256
-      scf.yield %41 : i256
+      %37 = arith.remui %22, %25 : i256
+      scf.yield %37 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_10 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256_1 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.muli %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_10 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.muli %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c5_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c5_i64 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_large.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_large.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c123456789_i256 = arith.constant 123456789 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c123456789_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c987654321_i256 = arith.constant 987654321 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c987654321_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c987654321_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.muli %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.muli %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %33 = arith.cmpi uge, %32, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c5_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c5_i64 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_overflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_mul_overflow.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c18446744073709551615_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c2_i256 = arith.constant 2 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.muli %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.muli %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %33 = arith.cmpi uge, %32, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c5_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c5_i64 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c15_i256 = arith.constant 15 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c15_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c240_i256 = arith.constant 240 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c240_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c240_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.ori %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.ori %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c255_i256 = arith.constant 255 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c255_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c255_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.ori %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.ori %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_or_edge_case.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c340282366920938463463374607431768211455_i256 = arith.constant 340282366920938463463374607431768211455 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c340282366920938463463374607431768211455_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.ori %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.ori %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c2_i256 = arith.constant 2 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c2_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,120 +96,111 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %c1_i256_7 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_7, %22 : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_6, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = arith.extui %33 : i256 to i257
-    %43 = arith.extui %37 : i256 to i257
-    %44 = arith.extui %41 : i256 to i257
-    %45 = arith.addi %42, %43 : i257
-    %46 = arith.remui %45, %44 : i257
-    %47 = arith.trunci %46 : i257 to i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = arith.extui %30 : i256 to i257
+    %38 = arith.extui %33 : i256 to i257
+    %39 = arith.extui %36 : i256 to i257
+    %40 = arith.addi %37, %38 : i257
+    %41 = arith.remui %40, %39 : i257
+    %42 = arith.trunci %41 : i257 to i256
     %c0_i256 = arith.constant 0 : i256
-    %48 = arith.cmpi eq, %41, %c0_i256 : i256
-    %49 = arith.select %48, %c0_i256, %47 : i256
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_17 = arith.constant 1 : i64
-    %52 = arith.addi %50, %c1_i64_17 : i64
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    llvm.store %49, %51 : i256, !llvm.ptr
+    %43 = arith.cmpi eq, %36, %c0_i256 : i256
+    %44 = arith.select %43, %c0_i256, %42 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %44, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_18 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %54 = arith.addi %53, %c-2_i64 : i64
-    %c3_i64_19 = arith.constant 3 : i64
-    %55 = arith.cmpi ult, %53, %c3_i64_19 : i64
+    %48 = arith.addi %47, %c-2_i64 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %c3_i64_13 = arith.constant 3 : i64
+    %49 = arith.cmpi ult, %47, %c3_i64_13 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %55, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %49, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c8_i64 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb18, ^bb1(%c80_i8_20 : i8)
+    %51 = arith.cmpi uge, %50, %c8_i64 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb18, ^bb1(%c80_i8_14 : i8)
   ^bb18:  // pred: ^bb17
-    %58 = arith.subi %56, %c8_i64 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c8_i64 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_21 = arith.constant 0 : i64
+    %c0_i64_15 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %59, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %53, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod_large_mod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_addmod_large_mod.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c340282366920938463463374607431768211455_i256 = arith.constant 340282366920938463463374607431768211455 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c340282366920938463463374607431768211455_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,120 +96,111 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c340282366920938463463374607431768211455_i256_1 = arith.constant 340282366920938463463374607431768211455 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c340282366920938463463374607431768211455_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c340282366920938463463374607431768211455_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c100_i256 = arith.constant 100 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c100_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c100_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = arith.extui %33 : i256 to i257
-    %43 = arith.extui %37 : i256 to i257
-    %44 = arith.extui %41 : i256 to i257
-    %45 = arith.addi %42, %43 : i257
-    %46 = arith.remui %45, %44 : i257
-    %47 = arith.trunci %46 : i257 to i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = arith.extui %30 : i256 to i257
+    %38 = arith.extui %33 : i256 to i257
+    %39 = arith.extui %36 : i256 to i257
+    %40 = arith.addi %37, %38 : i257
+    %41 = arith.remui %40, %39 : i257
+    %42 = arith.trunci %41 : i257 to i256
     %c0_i256 = arith.constant 0 : i256
-    %48 = arith.cmpi eq, %41, %c0_i256 : i256
-    %49 = arith.select %48, %c0_i256, %47 : i256
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_17 = arith.constant 1 : i64
-    %52 = arith.addi %50, %c1_i64_17 : i64
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    llvm.store %49, %51 : i256, !llvm.ptr
+    %43 = arith.cmpi eq, %36, %c0_i256 : i256
+    %44 = arith.select %43, %c0_i256, %42 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %44, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_18 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %54 = arith.addi %53, %c-2_i64 : i64
-    %c3_i64_19 = arith.constant 3 : i64
-    %55 = arith.cmpi ult, %53, %c3_i64_19 : i64
+    %48 = arith.addi %47, %c-2_i64 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %c3_i64_13 = arith.constant 3 : i64
+    %49 = arith.cmpi ult, %47, %c3_i64_13 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %55, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %49, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c8_i64 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb18, ^bb1(%c80_i8_20 : i8)
+    %51 = arith.cmpi uge, %50, %c8_i64 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb18, ^bb1(%c80_i8_14 : i8)
   ^bb18:  // pred: ^bb17
-    %58 = arith.subi %56, %c8_i64 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c8_i64 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_21 = arith.constant 0 : i64
+    %c0_i64_15 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %59, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %53, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c8_i256 = arith.constant 8 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c8_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,120 +96,111 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %c10_i256_7 = arith.constant 10 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_7, %22 : i256, !llvm.ptr
+    %c10_i256_6 = arith.constant 10 : i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_6, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = arith.extui %33 : i256 to i512
-    %43 = arith.extui %37 : i256 to i512
-    %44 = arith.extui %41 : i256 to i512
-    %45 = arith.muli %42, %43 : i512
-    %46 = arith.remui %45, %44 : i512
-    %47 = arith.trunci %46 : i512 to i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = arith.extui %30 : i256 to i512
+    %38 = arith.extui %33 : i256 to i512
+    %39 = arith.extui %36 : i256 to i512
+    %40 = arith.muli %37, %38 : i512
+    %41 = arith.remui %40, %39 : i512
+    %42 = arith.trunci %41 : i512 to i256
     %c0_i256 = arith.constant 0 : i256
-    %48 = arith.cmpi eq, %41, %c0_i256 : i256
-    %49 = arith.select %48, %c0_i256, %47 : i256
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_17 = arith.constant 1 : i64
-    %52 = arith.addi %50, %c1_i64_17 : i64
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    llvm.store %49, %51 : i256, !llvm.ptr
+    %43 = arith.cmpi eq, %36, %c0_i256 : i256
+    %44 = arith.select %43, %c0_i256, %42 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %44, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_18 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %54 = arith.addi %53, %c-2_i64 : i64
-    %c3_i64_19 = arith.constant 3 : i64
-    %55 = arith.cmpi ult, %53, %c3_i64_19 : i64
+    %48 = arith.addi %47, %c-2_i64 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %c3_i64_13 = arith.constant 3 : i64
+    %49 = arith.cmpi ult, %47, %c3_i64_13 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %55, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %49, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c8_i64 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb18, ^bb1(%c80_i8_20 : i8)
+    %51 = arith.cmpi uge, %50, %c8_i64 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb18, ^bb1(%c80_i8_14 : i8)
   ^bb18:  // pred: ^bb17
-    %58 = arith.subi %56, %c8_i64 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c8_i64 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_21 = arith.constant 0 : i64
+    %c0_i64_15 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %59, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %53, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod_zero_mod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_push_mulmod_zero_mod.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c2_i256 = arith.constant 2 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c2_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,120 +96,111 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c2_i256_1 = arith.constant 2 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c0_i256 = arith.constant 0 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
-    %42 = arith.extui %33 : i256 to i512
-    %43 = arith.extui %37 : i256 to i512
-    %44 = arith.extui %41 : i256 to i512
-    %45 = arith.muli %42, %43 : i512
-    %46 = arith.remui %45, %44 : i512
-    %47 = arith.trunci %46 : i512 to i256
-    %c0_i256_17 = arith.constant 0 : i256
-    %48 = arith.cmpi eq, %41, %c0_i256_17 : i256
-    %49 = arith.select %48, %c0_i256_17, %47 : i256
-    %50 = llvm.load %arg3 : !llvm.ptr -> i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_18 = arith.constant 1 : i64
-    %52 = arith.addi %50, %c1_i64_18 : i64
-    llvm.store %52, %arg3 : i64, !llvm.ptr
-    llvm.store %49, %51 : i256, !llvm.ptr
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
+    %37 = arith.extui %30 : i256 to i512
+    %38 = arith.extui %33 : i256 to i512
+    %39 = arith.extui %36 : i256 to i512
+    %40 = arith.muli %37, %38 : i512
+    %41 = arith.remui %40, %39 : i512
+    %42 = arith.trunci %41 : i512 to i256
+    %c0_i256_12 = arith.constant 0 : i256
+    %43 = arith.cmpi eq, %36, %c0_i256_12 : i256
+    %44 = arith.select %43, %c0_i256_12, %42 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %44, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_19 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_13 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %54 = arith.addi %53, %c-2_i64 : i64
-    %c3_i64_20 = arith.constant 3 : i64
-    %55 = arith.cmpi ult, %53, %c3_i64_20 : i64
+    %48 = arith.addi %47, %c-2_i64 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %c3_i64_14 = arith.constant 3 : i64
+    %49 = arith.cmpi ult, %47, %c3_i64_14 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %55, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %49, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
     %c8_i64 = arith.constant 8 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c8_i64 : i64
-    %c80_i8_21 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb18, ^bb1(%c80_i8_21 : i8)
+    %51 = arith.cmpi uge, %50, %c8_i64 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %58 = arith.subi %56, %c8_i64 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c8_i64 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_22 = arith.constant 0 : i64
+    %c0_i64_16 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_22, %c0_i64_22, %59, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %53 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_16, %c0_i64_16, %53, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sar.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sar.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c2_i256 = arith.constant 2 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c2_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,80 +96,74 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c255_i256 = arith.constant 255 : i256
-    %29 = arith.minui %24, %c255_i256 : i256
-    %30 = arith.shrsi %28, %29 : i256
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %26 = arith.minui %22, %c255_i256 : i256
+    %27 = arith.shrsi %25, %26 : i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_7 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,91 +96,85 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256_1 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i256) {
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i256) {
       scf.yield %c0_i256 : i256
     } else {
       %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256 = arith.constant -57896044618658097711785492504343953926634992332820282019728792003956564819968 : i256
-      %41 = arith.cmpi eq, %24, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256 : i256
+      %37 = arith.cmpi eq, %22, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256 : i256
       %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-      %42 = arith.cmpi eq, %28, %c18446744073709551615_i256 : i256
-      %43 = arith.andi %41, %42 : i1
-      %44 = arith.divsi %24, %28 : i256
-      %45 = arith.select %43, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256, %44 : i256
-      scf.yield %45 : i256
+      %38 = arith.cmpi eq, %25, %c18446744073709551615_i256 : i256
+      %39 = arith.andi %37, %38 : i1
+      %40 = arith.divsi %22, %25 : i256
+      %41 = arith.select %39, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256, %40 : i256
+      scf.yield %41 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_10 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sdiv_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1329227995784915872903807060280344575_i256 = arith.constant 1329227995784915872903807060280344575 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1329227995784915872903807060280344575_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,91 +96,85 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1329227995784915872903807060280344575_i256_1 = arith.constant 1329227995784915872903807060280344575 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1329227995784915872903807060280344575_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1329227995784915872903807060280344575_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i256) {
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i256) {
       scf.yield %c0_i256 : i256
     } else {
       %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256 = arith.constant -57896044618658097711785492504343953926634992332820282019728792003956564819968 : i256
-      %41 = arith.cmpi eq, %24, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256 : i256
+      %37 = arith.cmpi eq, %22, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256 : i256
       %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-      %42 = arith.cmpi eq, %28, %c18446744073709551615_i256 : i256
-      %43 = arith.andi %41, %42 : i1
-      %44 = arith.divsi %24, %28 : i256
-      %45 = arith.select %43, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256, %44 : i256
-      scf.yield %45 : i256
+      %38 = arith.cmpi eq, %25, %c18446744073709551615_i256 : i256
+      %39 = arith.andi %37, %38 : i1
+      %40 = arith.divsi %22, %25 : i256
+      %41 = arith.select %39, %c-57896044618658097711785492504343953926634992332820282019728792003956564819968_i256, %40 : i256
+      scf.yield %41 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_10 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shl.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shl.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,86 +96,80 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256_1 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c255_i256 = arith.constant 255 : i256
-    %29 = arith.cmpi ule, %24, %c255_i256 : i256
-    %30 = scf.if %29 -> (i256) {
-      %41 = arith.shli %28, %24 : i256
-      scf.yield %41 : i256
+    %26 = arith.cmpi ule, %22, %c255_i256 : i256
+    %27 = scf.if %26 -> (i256) {
+      %37 = arith.shli %25, %22 : i256
+      scf.yield %37 : i256
     } else {
       %c0_i256 = arith.constant 0 : i256
       scf.yield %c0_i256 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_10 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_12 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_8 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shr.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_shr.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c3_i256 = arith.constant 3 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c3_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,86 +96,80 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c3_i256_1 = arith.constant 3 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c3_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c3_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c255_i256 = arith.constant 255 : i256
-    %29 = arith.cmpi ule, %24, %c255_i256 : i256
-    %30 = scf.if %29 -> (i256) {
-      %41 = arith.shrui %28, %24 : i256
-      scf.yield %41 : i256
+    %26 = arith.cmpi ule, %22, %c255_i256 : i256
+    %27 = scf.if %26 -> (i256) {
+      %37 = arith.shrui %25, %22 : i256
+      scf.yield %37 : i256
     } else {
       %c0_i256 = arith.constant 0 : i256
       scf.yield %c0_i256 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_10 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c3_i64_12 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_8 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_signextend.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_signextend.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c255_i256 = arith.constant 255 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c255_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,87 +96,81 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c31_i256 = arith.constant 31 : i256
     %c8_i256 = arith.constant 8 : i256
     %c7_i256 = arith.constant 7 : i256
-    %c255_i256_9 = arith.constant 255 : i256
-    %29 = arith.minui %24, %c31_i256 : i256
-    %30 = arith.muli %29, %c8_i256 : i256
-    %31 = arith.addi %30, %c7_i256 : i256
-    %32 = arith.subi %c255_i256_9, %31 : i256
-    %33 = llvm.shl %28, %32 : i256
-    %34 = llvm.ashr %33, %32  : i256
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %37 = arith.addi %35, %c1_i64_10 : i64
-    llvm.store %37, %arg3 : i64, !llvm.ptr
-    llvm.store %34, %36 : i256, !llvm.ptr
+    %c255_i256_6 = arith.constant 255 : i256
+    %26 = arith.minui %22, %c31_i256 : i256
+    %27 = arith.muli %26, %c8_i256 : i256
+    %28 = arith.addi %27, %c7_i256 : i256
+    %29 = arith.subi %c255_i256_6, %28 : i256
+    %30 = llvm.shl %25, %29 : i256
+    %31 = llvm.ashr %30, %29  : i256
+    %32 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %31, %32 : i256, !llvm.ptr
+    %33 = llvm.getelementptr %32[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %33, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %34 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %39 = arith.addi %38, %c-1_i64 : i64
+    %35 = arith.addi %34, %c-1_i64 : i64
+    llvm.store %35, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %40 = arith.cmpi ult, %38, %c2_i64 : i64
+    %36 = arith.cmpi ult, %34, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %40, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %37 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %42 = arith.cmpi uge, %41, %c5_i64 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %42, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %38 = arith.cmpi uge, %37, %c5_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %43 = arith.subi %41, %c5_i64 : i64
-    llvm.store %43, %arg1 : i64, !llvm.ptr
+    %39 = arith.subi %37, %c5_i64 : i64
+    llvm.store %39, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %44 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %44, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c3_i256 = arith.constant 3 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c3_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,85 +96,79 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i256) {
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i256) {
       scf.yield %c0_i256 : i256
     } else {
-      %41 = arith.remsi %24, %28 : i256
-      scf.yield %41 : i256
+      %37 = arith.remsi %22, %25 : i256
+      scf.yield %37 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod_with_negative.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_smod_with_negative.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c-3_i256 = arith.constant -3 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c-3_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,85 +96,79 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c-8_i256 = arith.constant -8 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c-8_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c-8_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
-    %29 = arith.cmpi eq, %28, %c0_i256 : i256
-    %30 = scf.if %29 -> (i256) {
+    %26 = arith.cmpi eq, %25, %c0_i256 : i256
+    %27 = scf.if %26 -> (i256) {
       scf.yield %c0_i256 : i256
     } else {
-      %41 = arith.remsi %24, %28 : i256
-      scf.yield %41 : i256
+      %37 = arith.remsi %22, %25 : i256
+      scf.yield %37 : i256
     }
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %33 = arith.addi %31, %c1_i64_9 : i64
-    llvm.store %33, %arg3 : i64, !llvm.ptr
-    llvm.store %30, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %27, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %35 = arith.addi %34, %c-1_i64 : i64
+    %31 = arith.addi %30, %c-1_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %39 = arith.subi %37, %c5_i64 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c5_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %40 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %40, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c65535_i256 = arith.constant 65535 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c65535_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,97 +96,93 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %47 = arith.subi %38, %37 : i64
-      llvm.store %47, %arg1 : i64, !llvm.ptr
+      %44 = arith.subi %35, %34 : i64
+      llvm.store %44, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb17
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb13
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %46, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %43, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore_sload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sstore_sload.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb21, ^bb23, ^bb24
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb21, ^bb23, ^bb24
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c46_i256 = arith.constant 46 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c46_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,178 +96,170 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %77 = arith.subi %38, %37 : i64
-      llvm.store %77, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %35, %34 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
-    %c0_i256_14 = arith.constant 0 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_15 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_14, %47 : i256, !llvm.ptr
+    %c0_i256_11 = arith.constant 0 : i256
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb18:  // pred: ^bb20
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_17 : i64
-    %51 = arith.cmpi ult, %c1024_i64_16, %50 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_18 : i8), ^bb17
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_13 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_12, %46 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_14 : i8), ^bb17
   ^bb19:  // pred: ^bb13
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb20, ^bb1(%c80_i8_20 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb20, ^bb1(%c80_i8_16 : i8)
   ^bb20:  // pred: ^bb19
-    %54 = arith.subi %52, %c3_i64_19 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_15 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb23
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %56 = arith.subi %55, %c1_i64_21 : i64
-    %57 = llvm.getelementptr %arg2[%56] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %56, %arg3 : i64, !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i256
-    %c1_i256_22 = arith.constant 1 : i256
-    %59 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
-    llvm.store %58, %59 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_23 = arith.constant 1 : i256
-    %60 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
-    %61 = call @dora_fn_sload(%arg0, %59, %60) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %62 = llvm.getelementptr %61[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %63 = llvm.load %62 : !llvm.ptr -> i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %53 = llvm.load %52 : !llvm.ptr -> i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_17 = arith.constant 1 : i256
+    %54 = llvm.alloca %c1_i256_17 x i256 : (i256) -> !llvm.ptr
+    llvm.store %53, %54 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_18 = arith.constant 1 : i256
+    %55 = llvm.alloca %c1_i256_18 x i256 : (i256) -> !llvm.ptr
+    %56 = call @dora_fn_sload(%arg0, %54, %55) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %57 = llvm.getelementptr %56[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %60 = arith.cmpi ult, %59, %58 : i64
+    scf.if %60 {
     } else {
-      %77 = arith.subi %64, %63 : i64
-      llvm.store %77, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %59, %58 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_24 : i8), ^bb22
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb1(%c80_i8_19 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %66 = llvm.load %60 : !llvm.ptr -> i256
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %68 = llvm.getelementptr %arg2[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_25 = arith.constant 1 : i64
-    %69 = arith.addi %67, %c1_i64_25 : i64
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    llvm.store %66, %68 : i256, !llvm.ptr
+    %61 = llvm.load %55 : !llvm.ptr -> i256
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %61, %62 : i256, !llvm.ptr
+    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_26 = arith.constant 1024 : i64
-    %70 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_27 = arith.constant 0 : i64
-    %71 = arith.addi %70, %c0_i64_27 : i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %72 = arith.cmpi ult, %70, %c1_i64_28 : i64
-    %c91_i8_29 = arith.constant 91 : i8
-    cf.cond_br %72, ^bb1(%c91_i8_29 : i8), ^bb21
+    %c1024_i64_20 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %65 = arith.addi %64, %c0_i64_21 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c1_i64_22 = arith.constant 1 : i64
+    %66 = arith.cmpi ult, %64, %c1_i64_22 : i64
+    %c91_i8_23 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_23 : i8), ^bb21
   ^bb24:  // pred: ^bb17
-    %73 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_30 = arith.constant 0 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_24 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %74 = arith.cmpi uge, %73, %c0_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %74, ^bb25, ^bb1(%c80_i8_31 : i8)
+    %68 = arith.cmpi uge, %67, %c0_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb25, ^bb1(%c80_i8_25 : i8)
   ^bb25:  // pred: ^bb24
-    %75 = arith.subi %73, %c0_i64_30 : i64
-    llvm.store %75, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c0_i64_24 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_32 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_32, %c0_i64_32, %76, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %70, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256_1 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_8 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_9 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.subi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_10 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_10 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.subi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_12 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_8 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.subi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.subi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_sub_underflow_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.subi %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.subi %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c15_i256 = arith.constant 15 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c15_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c240_i256 = arith.constant 240 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c240_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c240_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.xori %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.xori %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c255_i256 = arith.constant 255 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c255_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c255_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.xori %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.xori %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_edge_case.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_push_xor_edge_case.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c340282366920938463463374607431768211455_i256 = arith.constant 340282366920938463463374607431768211455 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c340282366920938463463374607431768211455_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = arith.xori %24, %28 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = arith.xori %22, %25 : i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,157 +96,153 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb16
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %29 = arith.cmpi sgt, %28, %c18446744073709551615_i256 : i256
+    %26 = arith.cmpi sgt, %25, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb12
+    cf.cond_br %26, ^bb1(%c84_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %30 = arith.trunci %28 : i256 to i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %31 = arith.cmpi slt, %30, %c0_i64_9 : i64
-    %c84_i8_10 = arith.constant 84 : i8
-    cf.cond_br %31, ^bb1(%c84_i8_10 : i8), ^bb13
+    %27 = arith.trunci %25 : i256 to i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %28 = arith.cmpi slt, %27, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %28, ^bb1(%c84_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_11 = arith.constant 0 : i64
-    %32 = arith.cmpi ne, %30, %c0_i64_11 : i64
-    cf.cond_br %32, ^bb20, ^bb14
+    %c0_i64_8 = arith.constant 0 : i64
+    %29 = arith.cmpi ne, %27, %c0_i64_8 : i64
+    cf.cond_br %29, ^bb20, ^bb14
   ^bb14:  // 2 preds: ^bb13, ^bb24
     %c0_i8 = arith.constant 0 : i8
-    %33 = arith.trunci %24 : i256 to i64
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %33, %30, %34, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %30 = arith.trunci %22 : i256 to i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %30, %27, %31, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8 : i8
   ^bb15:  // no predecessors
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %32 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %36 = arith.addi %35, %c-2_i64 : i64
+    %33 = arith.addi %32, %c-2_i64 : i64
+    llvm.store %33, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %34 = arith.cmpi ult, %32, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %34, ^bb1(%c91_i8 : i8), ^bb11
   ^bb17:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_13 = arith.constant 0 : i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c0_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb18, ^bb1(%c80_i8_14 : i8)
+    %36 = arith.cmpi uge, %35, %c0_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb18, ^bb1(%c80_i8_11 : i8)
   ^bb18:  // pred: ^bb17
-    %40 = arith.subi %38, %c0_i64_13 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %37 = arith.subi %35, %c0_i64_10 : i64
+    llvm.store %37, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %38, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb20:  // pred: ^bb13
-    %c18446744073709551615_i256_16 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %24, %c18446744073709551615_i256_16 : i256
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8_17 : i8), ^bb21
+    %c18446744073709551615_i256_13 = arith.constant 18446744073709551615 : i256
+    %39 = arith.cmpi sgt, %22, %c18446744073709551615_i256_13 : i256
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_14 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %43 = arith.trunci %24 : i256 to i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_18 : i64
-    %c84_i8_19 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_19 : i8), ^bb22
+    %40 = arith.trunci %22 : i256 to i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_15 : i64
+    %c84_i8_16 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_16 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %45 = arith.addi %43, %30 : i64
-    %c0_i64_20 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_20 : i64
-    %c84_i8_21 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_21 : i8), ^bb23
+    %42 = arith.addi %40, %27 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %43 = arith.cmpi slt, %42, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %43, ^bb1(%c84_i8_18 : i8), ^bb23
   ^bb23:  // pred: ^bb22
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %47 = arith.addi %45, %c31_i64 : i64
-    %48 = arith.divui %47, %c32_i64 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %49 = arith.muli %48, %c32_i64_22 : i64
-    %50 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_23 = arith.constant 31 : i64
-    %c32_i64_24 = arith.constant 32 : i64
-    %51 = arith.addi %50, %c31_i64_23 : i64
-    %52 = arith.divui %51, %c32_i64_24 : i64
-    %53 = arith.muli %52, %c32_i64_22 : i64
-    %54 = arith.cmpi ult, %53, %49 : i64
-    cf.cond_br %54, ^bb25, ^bb24
+    %44 = arith.addi %42, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %46 = arith.muli %45, %c32_i64_19 : i64
+    %47 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %48 = arith.addi %47, %c31_i64_20 : i64
+    %49 = arith.divui %48, %c32_i64_21 : i64
+    %50 = arith.muli %49, %c32_i64_19 : i64
+    %51 = arith.cmpi ult, %50, %46 : i64
+    cf.cond_br %51, ^bb25, ^bb24
   ^bb24:  // 2 preds: ^bb23, ^bb27
     cf.br ^bb14
   ^bb25:  // pred: ^bb23
-    %c3_i64_25 = arith.constant 3 : i64
+    %c3_i64_22 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %55 = arith.muli %52, %52 : i64
-    %56 = arith.divui %55, %c512_i64 : i64
-    %57 = arith.muli %52, %c3_i64_25 : i64
-    %58 = arith.addi %56, %57 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %c512_i64_27 = arith.constant 512 : i64
-    %59 = arith.muli %48, %48 : i64
-    %60 = arith.divui %59, %c512_i64_27 : i64
-    %61 = arith.muli %48, %c3_i64_26 : i64
-    %62 = arith.addi %60, %61 : i64
-    %63 = arith.subi %62, %58 : i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %52 = arith.muli %49, %49 : i64
+    %53 = arith.divui %52, %c512_i64 : i64
+    %54 = arith.muli %49, %c3_i64_22 : i64
+    %55 = arith.addi %53, %54 : i64
+    %c3_i64_23 = arith.constant 3 : i64
+    %c512_i64_24 = arith.constant 512 : i64
+    %56 = arith.muli %45, %45 : i64
+    %57 = arith.divui %56, %c512_i64_24 : i64
+    %58 = arith.muli %45, %c3_i64_23 : i64
+    %59 = arith.addi %57, %58 : i64
+    %60 = arith.subi %59, %55 : i64
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %62 = arith.cmpi ult, %61, %60 : i64
+    scf.if %62 {
     } else {
-      %70 = arith.subi %64, %63 : i64
-      llvm.store %70, %arg1 : i64, !llvm.ptr
+      %67 = arith.subi %61, %60 : i64
+      llvm.store %67, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_28 : i8), ^bb26
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %62, ^bb1(%c80_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %66 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
-    %67 = llvm.getelementptr %66[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %68 = llvm.load %67 : !llvm.ptr -> i8
-    %c0_i8_29 = arith.constant 0 : i8
-    %69 = arith.cmpi ne, %68, %c0_i8_29 : i8
-    cf.cond_br %69, ^bb1(%68 : i8), ^bb27
+    %63 = call @dora_fn_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+    %64 = llvm.getelementptr %63[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %65 = llvm.load %64 : !llvm.ptr -> i8
+    %c0_i8_26 = arith.constant 0 : i8
+    %66 = arith.cmpi ne, %65, %c0_i8_26 : i8
+    cf.cond_br %66, ^bb1(%65 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb24
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return_large_data.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_return_large_data.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c64_i256 = arith.constant 64 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c64_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,157 +96,153 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb16
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %29 = arith.cmpi sgt, %28, %c18446744073709551615_i256 : i256
+    %26 = arith.cmpi sgt, %25, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb12
+    cf.cond_br %26, ^bb1(%c84_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %30 = arith.trunci %28 : i256 to i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %31 = arith.cmpi slt, %30, %c0_i64_9 : i64
-    %c84_i8_10 = arith.constant 84 : i8
-    cf.cond_br %31, ^bb1(%c84_i8_10 : i8), ^bb13
+    %27 = arith.trunci %25 : i256 to i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %28 = arith.cmpi slt, %27, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %28, ^bb1(%c84_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_11 = arith.constant 0 : i64
-    %32 = arith.cmpi ne, %30, %c0_i64_11 : i64
-    cf.cond_br %32, ^bb20, ^bb14
+    %c0_i64_8 = arith.constant 0 : i64
+    %29 = arith.cmpi ne, %27, %c0_i64_8 : i64
+    cf.cond_br %29, ^bb20, ^bb14
   ^bb14:  // 2 preds: ^bb13, ^bb24
     %c0_i8 = arith.constant 0 : i8
-    %33 = arith.trunci %24 : i256 to i64
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %33, %30, %34, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %30 = arith.trunci %22 : i256 to i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %30, %27, %31, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8 : i8
   ^bb15:  // no predecessors
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %32 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %36 = arith.addi %35, %c-2_i64 : i64
+    %33 = arith.addi %32, %c-2_i64 : i64
+    llvm.store %33, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %34 = arith.cmpi ult, %32, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %34, ^bb1(%c91_i8 : i8), ^bb11
   ^bb17:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_13 = arith.constant 0 : i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c0_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb18, ^bb1(%c80_i8_14 : i8)
+    %36 = arith.cmpi uge, %35, %c0_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb18, ^bb1(%c80_i8_11 : i8)
   ^bb18:  // pred: ^bb17
-    %40 = arith.subi %38, %c0_i64_13 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %37 = arith.subi %35, %c0_i64_10 : i64
+    llvm.store %37, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %38, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb20:  // pred: ^bb13
-    %c18446744073709551615_i256_16 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %24, %c18446744073709551615_i256_16 : i256
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8_17 : i8), ^bb21
+    %c18446744073709551615_i256_13 = arith.constant 18446744073709551615 : i256
+    %39 = arith.cmpi sgt, %22, %c18446744073709551615_i256_13 : i256
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_14 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %43 = arith.trunci %24 : i256 to i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_18 : i64
-    %c84_i8_19 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_19 : i8), ^bb22
+    %40 = arith.trunci %22 : i256 to i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_15 : i64
+    %c84_i8_16 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_16 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %45 = arith.addi %43, %30 : i64
-    %c0_i64_20 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_20 : i64
-    %c84_i8_21 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_21 : i8), ^bb23
+    %42 = arith.addi %40, %27 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %43 = arith.cmpi slt, %42, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %43, ^bb1(%c84_i8_18 : i8), ^bb23
   ^bb23:  // pred: ^bb22
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %47 = arith.addi %45, %c31_i64 : i64
-    %48 = arith.divui %47, %c32_i64 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %49 = arith.muli %48, %c32_i64_22 : i64
-    %50 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_23 = arith.constant 31 : i64
-    %c32_i64_24 = arith.constant 32 : i64
-    %51 = arith.addi %50, %c31_i64_23 : i64
-    %52 = arith.divui %51, %c32_i64_24 : i64
-    %53 = arith.muli %52, %c32_i64_22 : i64
-    %54 = arith.cmpi ult, %53, %49 : i64
-    cf.cond_br %54, ^bb25, ^bb24
+    %44 = arith.addi %42, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %46 = arith.muli %45, %c32_i64_19 : i64
+    %47 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %48 = arith.addi %47, %c31_i64_20 : i64
+    %49 = arith.divui %48, %c32_i64_21 : i64
+    %50 = arith.muli %49, %c32_i64_19 : i64
+    %51 = arith.cmpi ult, %50, %46 : i64
+    cf.cond_br %51, ^bb25, ^bb24
   ^bb24:  // 2 preds: ^bb23, ^bb27
     cf.br ^bb14
   ^bb25:  // pred: ^bb23
-    %c3_i64_25 = arith.constant 3 : i64
+    %c3_i64_22 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %55 = arith.muli %52, %52 : i64
-    %56 = arith.divui %55, %c512_i64 : i64
-    %57 = arith.muli %52, %c3_i64_25 : i64
-    %58 = arith.addi %56, %57 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %c512_i64_27 = arith.constant 512 : i64
-    %59 = arith.muli %48, %48 : i64
-    %60 = arith.divui %59, %c512_i64_27 : i64
-    %61 = arith.muli %48, %c3_i64_26 : i64
-    %62 = arith.addi %60, %61 : i64
-    %63 = arith.subi %62, %58 : i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %52 = arith.muli %49, %49 : i64
+    %53 = arith.divui %52, %c512_i64 : i64
+    %54 = arith.muli %49, %c3_i64_22 : i64
+    %55 = arith.addi %53, %54 : i64
+    %c3_i64_23 = arith.constant 3 : i64
+    %c512_i64_24 = arith.constant 512 : i64
+    %56 = arith.muli %45, %45 : i64
+    %57 = arith.divui %56, %c512_i64_24 : i64
+    %58 = arith.muli %45, %c3_i64_23 : i64
+    %59 = arith.addi %57, %58 : i64
+    %60 = arith.subi %59, %55 : i64
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %62 = arith.cmpi ult, %61, %60 : i64
+    scf.if %62 {
     } else {
-      %70 = arith.subi %64, %63 : i64
-      llvm.store %70, %arg1 : i64, !llvm.ptr
+      %67 = arith.subi %61, %60 : i64
+      llvm.store %67, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_28 : i8), ^bb26
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %62, ^bb1(%c80_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %66 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
-    %67 = llvm.getelementptr %66[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %68 = llvm.load %67 : !llvm.ptr -> i8
-    %c0_i8_29 = arith.constant 0 : i8
-    %69 = arith.cmpi ne, %68, %c0_i8_29 : i8
-    cf.cond_br %69, ^bb1(%68 : i8), ^bb27
+    %63 = call @dora_fn_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+    %64 = llvm.getelementptr %63[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %65 = llvm.load %64 : !llvm.ptr -> i8
+    %c0_i8_26 = arith.constant 0 : i8
+    %66 = arith.cmpi ne, %65, %c0_i8_26 : i8
+    cf.cond_br %66, ^bb1(%65 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb24
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c32_i256 = arith.constant 32 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c32_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,157 +96,153 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb16
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %29 = arith.cmpi sgt, %28, %c18446744073709551615_i256 : i256
+    %26 = arith.cmpi sgt, %25, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb12
+    cf.cond_br %26, ^bb1(%c84_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %30 = arith.trunci %28 : i256 to i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %31 = arith.cmpi slt, %30, %c0_i64_9 : i64
-    %c84_i8_10 = arith.constant 84 : i8
-    cf.cond_br %31, ^bb1(%c84_i8_10 : i8), ^bb13
+    %27 = arith.trunci %25 : i256 to i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %28 = arith.cmpi slt, %27, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %28, ^bb1(%c84_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_11 = arith.constant 0 : i64
-    %32 = arith.cmpi ne, %30, %c0_i64_11 : i64
-    cf.cond_br %32, ^bb20, ^bb14
+    %c0_i64_8 = arith.constant 0 : i64
+    %29 = arith.cmpi ne, %27, %c0_i64_8 : i64
+    cf.cond_br %29, ^bb20, ^bb14
   ^bb14:  // 2 preds: ^bb13, ^bb24
-    %33 = arith.trunci %24 : i256 to i64
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %30 = arith.trunci %22 : i256 to i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
     %c16_i8 = arith.constant 16 : i8
-    call @dora_fn_write_result(%arg0, %33, %30, %34, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    call @dora_fn_write_result(%arg0, %30, %27, %31, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c16_i8 : i8
   ^bb15:  // no predecessors
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %32 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %36 = arith.addi %35, %c-2_i64 : i64
+    %33 = arith.addi %32, %c-2_i64 : i64
+    llvm.store %33, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %34 = arith.cmpi ult, %32, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %34, ^bb1(%c91_i8 : i8), ^bb11
   ^bb17:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_13 = arith.constant 0 : i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c0_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb18, ^bb1(%c80_i8_14 : i8)
+    %36 = arith.cmpi uge, %35, %c0_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb18, ^bb1(%c80_i8_11 : i8)
   ^bb18:  // pred: ^bb17
-    %40 = arith.subi %38, %c0_i64_13 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %37 = arith.subi %35, %c0_i64_10 : i64
+    llvm.store %37, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %38, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb20:  // pred: ^bb13
-    %c18446744073709551615_i256_16 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %24, %c18446744073709551615_i256_16 : i256
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8_17 : i8), ^bb21
+    %c18446744073709551615_i256_13 = arith.constant 18446744073709551615 : i256
+    %39 = arith.cmpi sgt, %22, %c18446744073709551615_i256_13 : i256
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_14 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %43 = arith.trunci %24 : i256 to i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_18 : i64
-    %c84_i8_19 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_19 : i8), ^bb22
+    %40 = arith.trunci %22 : i256 to i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_15 : i64
+    %c84_i8_16 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_16 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %45 = arith.addi %43, %30 : i64
-    %c0_i64_20 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_20 : i64
-    %c84_i8_21 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_21 : i8), ^bb23
+    %42 = arith.addi %40, %27 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %43 = arith.cmpi slt, %42, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %43, ^bb1(%c84_i8_18 : i8), ^bb23
   ^bb23:  // pred: ^bb22
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %47 = arith.addi %45, %c31_i64 : i64
-    %48 = arith.divui %47, %c32_i64 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %49 = arith.muli %48, %c32_i64_22 : i64
-    %50 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_23 = arith.constant 31 : i64
-    %c32_i64_24 = arith.constant 32 : i64
-    %51 = arith.addi %50, %c31_i64_23 : i64
-    %52 = arith.divui %51, %c32_i64_24 : i64
-    %53 = arith.muli %52, %c32_i64_22 : i64
-    %54 = arith.cmpi ult, %53, %49 : i64
-    cf.cond_br %54, ^bb25, ^bb24
+    %44 = arith.addi %42, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %46 = arith.muli %45, %c32_i64_19 : i64
+    %47 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %48 = arith.addi %47, %c31_i64_20 : i64
+    %49 = arith.divui %48, %c32_i64_21 : i64
+    %50 = arith.muli %49, %c32_i64_19 : i64
+    %51 = arith.cmpi ult, %50, %46 : i64
+    cf.cond_br %51, ^bb25, ^bb24
   ^bb24:  // 2 preds: ^bb23, ^bb27
     cf.br ^bb14
   ^bb25:  // pred: ^bb23
-    %c3_i64_25 = arith.constant 3 : i64
+    %c3_i64_22 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %55 = arith.muli %52, %52 : i64
-    %56 = arith.divui %55, %c512_i64 : i64
-    %57 = arith.muli %52, %c3_i64_25 : i64
-    %58 = arith.addi %56, %57 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %c512_i64_27 = arith.constant 512 : i64
-    %59 = arith.muli %48, %48 : i64
-    %60 = arith.divui %59, %c512_i64_27 : i64
-    %61 = arith.muli %48, %c3_i64_26 : i64
-    %62 = arith.addi %60, %61 : i64
-    %63 = arith.subi %62, %58 : i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %52 = arith.muli %49, %49 : i64
+    %53 = arith.divui %52, %c512_i64 : i64
+    %54 = arith.muli %49, %c3_i64_22 : i64
+    %55 = arith.addi %53, %54 : i64
+    %c3_i64_23 = arith.constant 3 : i64
+    %c512_i64_24 = arith.constant 512 : i64
+    %56 = arith.muli %45, %45 : i64
+    %57 = arith.divui %56, %c512_i64_24 : i64
+    %58 = arith.muli %45, %c3_i64_23 : i64
+    %59 = arith.addi %57, %58 : i64
+    %60 = arith.subi %59, %55 : i64
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %62 = arith.cmpi ult, %61, %60 : i64
+    scf.if %62 {
     } else {
-      %70 = arith.subi %64, %63 : i64
-      llvm.store %70, %arg1 : i64, !llvm.ptr
+      %67 = arith.subi %61, %60 : i64
+      llvm.store %67, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_28 : i8), ^bb26
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %62, ^bb1(%c80_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %66 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
-    %67 = llvm.getelementptr %66[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %68 = llvm.load %67 : !llvm.ptr -> i8
+    %63 = call @dora_fn_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+    %64 = llvm.getelementptr %63[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %65 = llvm.load %64 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %69 = arith.cmpi ne, %68, %c0_i8 : i8
-    cf.cond_br %69, ^bb1(%68 : i8), ^bb27
+    %66 = arith.cmpi ne, %65, %c0_i8 : i8
+    cf.cond_br %66, ^bb1(%65 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb24
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert_large_data.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_revert_large_data.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb16, ^bb17, ^bb20, ^bb21, ^bb22, ^bb25, ^bb26
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c64_i256 = arith.constant 64 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c64_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,157 +96,153 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb16
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %29 = arith.cmpi sgt, %28, %c18446744073709551615_i256 : i256
+    %26 = arith.cmpi sgt, %25, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %29, ^bb1(%c84_i8 : i8), ^bb12
+    cf.cond_br %26, ^bb1(%c84_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %30 = arith.trunci %28 : i256 to i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %31 = arith.cmpi slt, %30, %c0_i64_9 : i64
-    %c84_i8_10 = arith.constant 84 : i8
-    cf.cond_br %31, ^bb1(%c84_i8_10 : i8), ^bb13
+    %27 = arith.trunci %25 : i256 to i64
+    %c0_i64_6 = arith.constant 0 : i64
+    %28 = arith.cmpi slt, %27, %c0_i64_6 : i64
+    %c84_i8_7 = arith.constant 84 : i8
+    cf.cond_br %28, ^bb1(%c84_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
-    %c0_i64_11 = arith.constant 0 : i64
-    %32 = arith.cmpi ne, %30, %c0_i64_11 : i64
-    cf.cond_br %32, ^bb20, ^bb14
+    %c0_i64_8 = arith.constant 0 : i64
+    %29 = arith.cmpi ne, %27, %c0_i64_8 : i64
+    cf.cond_br %29, ^bb20, ^bb14
   ^bb14:  // 2 preds: ^bb13, ^bb24
-    %33 = arith.trunci %24 : i256 to i64
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %30 = arith.trunci %22 : i256 to i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
     %c16_i8 = arith.constant 16 : i8
-    call @dora_fn_write_result(%arg0, %33, %30, %34, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    call @dora_fn_write_result(%arg0, %30, %27, %31, %c16_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c16_i8 : i8
   ^bb15:  // no predecessors
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_12 = arith.constant 1024 : i64
-    %35 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %32 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %36 = arith.addi %35, %c-2_i64 : i64
+    %33 = arith.addi %32, %c-2_i64 : i64
+    llvm.store %33, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %37 = arith.cmpi ult, %35, %c2_i64 : i64
+    %34 = arith.cmpi ult, %32, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %37, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %34, ^bb1(%c91_i8 : i8), ^bb11
   ^bb17:  // pred: ^bb7
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_13 = arith.constant 0 : i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_10 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %39 = arith.cmpi uge, %38, %c0_i64_13 : i64
-    %c80_i8_14 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb18, ^bb1(%c80_i8_14 : i8)
+    %36 = arith.cmpi uge, %35, %c0_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb18, ^bb1(%c80_i8_11 : i8)
   ^bb18:  // pred: ^bb17
-    %40 = arith.subi %38, %c0_i64_13 : i64
-    llvm.store %40, %arg1 : i64, !llvm.ptr
+    %37 = arith.subi %35, %c0_i64_10 : i64
+    llvm.store %37, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_15 = arith.constant 0 : i64
+    %c0_i64_12 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %41 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_15, %c0_i64_15, %41, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %38 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %38, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb20:  // pred: ^bb13
-    %c18446744073709551615_i256_16 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %24, %c18446744073709551615_i256_16 : i256
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8_17 : i8), ^bb21
+    %c18446744073709551615_i256_13 = arith.constant 18446744073709551615 : i256
+    %39 = arith.cmpi sgt, %22, %c18446744073709551615_i256_13 : i256
+    %c84_i8_14 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_14 : i8), ^bb21
   ^bb21:  // pred: ^bb20
-    %43 = arith.trunci %24 : i256 to i64
-    %c0_i64_18 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_18 : i64
-    %c84_i8_19 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_19 : i8), ^bb22
+    %40 = arith.trunci %22 : i256 to i64
+    %c0_i64_15 = arith.constant 0 : i64
+    %41 = arith.cmpi slt, %40, %c0_i64_15 : i64
+    %c84_i8_16 = arith.constant 84 : i8
+    cf.cond_br %41, ^bb1(%c84_i8_16 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %45 = arith.addi %43, %30 : i64
-    %c0_i64_20 = arith.constant 0 : i64
-    %46 = arith.cmpi slt, %45, %c0_i64_20 : i64
-    %c84_i8_21 = arith.constant 84 : i8
-    cf.cond_br %46, ^bb1(%c84_i8_21 : i8), ^bb23
+    %42 = arith.addi %40, %27 : i64
+    %c0_i64_17 = arith.constant 0 : i64
+    %43 = arith.cmpi slt, %42, %c0_i64_17 : i64
+    %c84_i8_18 = arith.constant 84 : i8
+    cf.cond_br %43, ^bb1(%c84_i8_18 : i8), ^bb23
   ^bb23:  // pred: ^bb22
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %47 = arith.addi %45, %c31_i64 : i64
-    %48 = arith.divui %47, %c32_i64 : i64
-    %c32_i64_22 = arith.constant 32 : i64
-    %49 = arith.muli %48, %c32_i64_22 : i64
-    %50 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_23 = arith.constant 31 : i64
-    %c32_i64_24 = arith.constant 32 : i64
-    %51 = arith.addi %50, %c31_i64_23 : i64
-    %52 = arith.divui %51, %c32_i64_24 : i64
-    %53 = arith.muli %52, %c32_i64_22 : i64
-    %54 = arith.cmpi ult, %53, %49 : i64
-    cf.cond_br %54, ^bb25, ^bb24
+    %44 = arith.addi %42, %c31_i64 : i64
+    %45 = arith.divui %44, %c32_i64 : i64
+    %c32_i64_19 = arith.constant 32 : i64
+    %46 = arith.muli %45, %c32_i64_19 : i64
+    %47 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_20 = arith.constant 31 : i64
+    %c32_i64_21 = arith.constant 32 : i64
+    %48 = arith.addi %47, %c31_i64_20 : i64
+    %49 = arith.divui %48, %c32_i64_21 : i64
+    %50 = arith.muli %49, %c32_i64_19 : i64
+    %51 = arith.cmpi ult, %50, %46 : i64
+    cf.cond_br %51, ^bb25, ^bb24
   ^bb24:  // 2 preds: ^bb23, ^bb27
     cf.br ^bb14
   ^bb25:  // pred: ^bb23
-    %c3_i64_25 = arith.constant 3 : i64
+    %c3_i64_22 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %55 = arith.muli %52, %52 : i64
-    %56 = arith.divui %55, %c512_i64 : i64
-    %57 = arith.muli %52, %c3_i64_25 : i64
-    %58 = arith.addi %56, %57 : i64
-    %c3_i64_26 = arith.constant 3 : i64
-    %c512_i64_27 = arith.constant 512 : i64
-    %59 = arith.muli %48, %48 : i64
-    %60 = arith.divui %59, %c512_i64_27 : i64
-    %61 = arith.muli %48, %c3_i64_26 : i64
-    %62 = arith.addi %60, %61 : i64
-    %63 = arith.subi %62, %58 : i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %52 = arith.muli %49, %49 : i64
+    %53 = arith.divui %52, %c512_i64 : i64
+    %54 = arith.muli %49, %c3_i64_22 : i64
+    %55 = arith.addi %53, %54 : i64
+    %c3_i64_23 = arith.constant 3 : i64
+    %c512_i64_24 = arith.constant 512 : i64
+    %56 = arith.muli %45, %45 : i64
+    %57 = arith.divui %56, %c512_i64_24 : i64
+    %58 = arith.muli %45, %c3_i64_23 : i64
+    %59 = arith.addi %57, %58 : i64
+    %60 = arith.subi %59, %55 : i64
+    %61 = llvm.load %arg1 : !llvm.ptr -> i64
+    %62 = arith.cmpi ult, %61, %60 : i64
+    scf.if %62 {
     } else {
-      %70 = arith.subi %64, %63 : i64
-      llvm.store %70, %arg1 : i64, !llvm.ptr
+      %67 = arith.subi %61, %60 : i64
+      llvm.store %67, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_28 : i8), ^bb26
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %62, ^bb1(%c80_i8_25 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %66 = call @dora_fn_extend_memory(%arg0, %49) : (!llvm.ptr, i64) -> !llvm.ptr
-    %67 = llvm.getelementptr %66[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %68 = llvm.load %67 : !llvm.ptr -> i8
+    %63 = call @dora_fn_extend_memory(%arg0, %46) : (!llvm.ptr, i64) -> !llvm.ptr
+    %64 = llvm.getelementptr %63[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %65 = llvm.load %64 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %69 = arith.cmpi ne, %68, %c0_i8 : i8
-    cf.cond_br %69, ^bb1(%68 : i8), ^bb27
+    %66 = arith.cmpi ne, %65, %c0_i8 : i8
+    cf.cond_br %66, ^bb1(%65 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb24
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb8, ^bb11, ^bb12
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb8, ^bb11, ^bb12
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c103929005321308650608990281194157653061304342136_i256 = arith.constant 103929005321308650608990281194157653061304342136 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c103929005321308650608990281194157653061304342136_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,66 +95,65 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb11
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %16 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    %15 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %17 = arith.cmpi ne, %16, %c0_i8 : i8
+    %16 = arith.cmpi ne, %15, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %17, ^bb1(%c87_i8 : i8), ^bb8
+    cf.cond_br %16, ^bb1(%c87_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
     %c1_i256 = arith.constant 1 : i256
-    %18 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %18 {alignment = 1 : i64} : i256, !llvm.ptr
-    %19 = call @dora_fn_selfdestruct(%arg0, %18) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %20 = llvm.getelementptr %19[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %21 = llvm.load %20 : !llvm.ptr -> i64
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    %23 = arith.cmpi ult, %22, %21 : i64
-    scf.if %23 {
+    %17 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %17 {alignment = 1 : i64} : i256, !llvm.ptr
+    %18 = call @dora_fn_selfdestruct(%arg0, %17) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %19 = llvm.getelementptr %18[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %20 = llvm.load %19 : !llvm.ptr -> i64
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    %22 = arith.cmpi ult, %21, %20 : i64
+    scf.if %22 {
     } else {
-      %32 = arith.subi %22, %21 : i64
-      llvm.store %32, %arg1 : i64, !llvm.ptr
+      %31 = arith.subi %21, %20 : i64
+      llvm.store %31, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %23, ^bb1(%c80_i8_2 : i8), ^bb9
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %22, ^bb1(%c80_i8_1 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i64_3 = arith.constant 0 : i64
+    %c0_i64_2 = arith.constant 0 : i64
     %c2_i8 = arith.constant 2 : i8
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %24, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %23 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_2, %c0_i64_2, %23, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c2_i8 : i8
   ^bb10:  // no predecessors
     cf.br ^bb14
   ^bb11:  // pred: ^bb13
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_3 = arith.constant 1024 : i64
+    %24 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %26 = arith.addi %25, %c-1_i64 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %27 = arith.cmpi ult, %25, %c1_i64_5 : i64
+    %25 = arith.addi %24, %c-1_i64 : i64
+    llvm.store %25, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %26 = arith.cmpi ult, %24, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %26, ^bb1(%c91_i8 : i8), ^bb7
   ^bb12:  // pred: ^bb3
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_6 = arith.constant 0 : i64
+    %27 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c0_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb13, ^bb1(%c80_i8_7 : i8)
+    %28 = arith.cmpi uge, %27, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %28, ^bb13, ^bb1(%c80_i8_6 : i8)
   ^bb13:  // pred: ^bb12
-    %30 = arith.subi %28, %c0_i64_6 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %29 = arith.subi %27, %c0_i64_5 : i64
+    llvm.store %29, %arg1 : i64, !llvm.ptr
     cf.br ^bb11
   ^bb14:  // pred: ^bb10
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %30, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct_zero_address.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_selfdestruct_zero_address.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb8, ^bb11, ^bb12
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb8, ^bb11, ^bb12
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,66 +95,65 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb11
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %16 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    %15 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %17 = arith.cmpi ne, %16, %c0_i8 : i8
+    %16 = arith.cmpi ne, %15, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %17, ^bb1(%c87_i8 : i8), ^bb8
+    cf.cond_br %16, ^bb1(%c87_i8 : i8), ^bb8
   ^bb8:  // pred: ^bb7
     %c1_i256 = arith.constant 1 : i256
-    %18 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %18 {alignment = 1 : i64} : i256, !llvm.ptr
-    %19 = call @dora_fn_selfdestruct(%arg0, %18) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %20 = llvm.getelementptr %19[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %21 = llvm.load %20 : !llvm.ptr -> i64
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    %23 = arith.cmpi ult, %22, %21 : i64
-    scf.if %23 {
+    %17 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %17 {alignment = 1 : i64} : i256, !llvm.ptr
+    %18 = call @dora_fn_selfdestruct(%arg0, %17) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %19 = llvm.getelementptr %18[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %20 = llvm.load %19 : !llvm.ptr -> i64
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    %22 = arith.cmpi ult, %21, %20 : i64
+    scf.if %22 {
     } else {
-      %32 = arith.subi %22, %21 : i64
-      llvm.store %32, %arg1 : i64, !llvm.ptr
+      %31 = arith.subi %21, %20 : i64
+      llvm.store %31, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_2 = arith.constant 80 : i8
-    cf.cond_br %23, ^bb1(%c80_i8_2 : i8), ^bb9
+    %c80_i8_1 = arith.constant 80 : i8
+    cf.cond_br %22, ^bb1(%c80_i8_1 : i8), ^bb9
   ^bb9:  // pred: ^bb8
-    %c0_i64_3 = arith.constant 0 : i64
+    %c0_i64_2 = arith.constant 0 : i64
     %c2_i8 = arith.constant 2 : i8
-    %24 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %24, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %23 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_2, %c0_i64_2, %23, %c2_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c2_i8 : i8
   ^bb10:  // no predecessors
     cf.br ^bb14
   ^bb11:  // pred: ^bb13
-    %c1024_i64_4 = arith.constant 1024 : i64
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_3 = arith.constant 1024 : i64
+    %24 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %26 = arith.addi %25, %c-1_i64 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %27 = arith.cmpi ult, %25, %c1_i64_5 : i64
+    %25 = arith.addi %24, %c-1_i64 : i64
+    llvm.store %25, %arg3 : i64, !llvm.ptr
+    %c1_i64_4 = arith.constant 1 : i64
+    %26 = arith.cmpi ult, %24, %c1_i64_4 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %26, ^bb1(%c91_i8 : i8), ^bb7
   ^bb12:  // pred: ^bb3
-    %28 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_6 = arith.constant 0 : i64
+    %27 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_5 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %29 = arith.cmpi uge, %28, %c0_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %29, ^bb13, ^bb1(%c80_i8_7 : i8)
+    %28 = arith.cmpi uge, %27, %c0_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %28, ^bb13, ^bb1(%c80_i8_6 : i8)
   ^bb13:  // pred: ^bb12
-    %30 = arith.subi %28, %c0_i64_6 : i64
-    llvm.store %30, %arg1 : i64, !llvm.ptr
+    %29 = arith.subi %27, %c0_i64_5 : i64
+    llvm.store %29, %arg1 : i64, !llvm.ptr
     cf.br ^bb11
   ^bb14:  // pred: ^bb10
-    %c0_i64_8 = arith.constant 0 : i64
+    %c0_i64_7 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_7, %c0_i64_7, %30, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_stack_depth.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_stack_depth.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 13 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 13 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c10_i256 = arith.constant 10 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c10_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,149 +96,144 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c20_i256 = arith.constant 20 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c30_i256 = arith.constant 30 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c30_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c30_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
     %c40_i256 = arith.constant 40 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_13 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c40_i256, %31 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c40_i256, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_15 : i64
-    %35 = arith.cmpi ult, %c1024_i64_14, %34 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_12 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_12 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_11, %31 : i64
+    %c92_i8_13 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_13 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_17 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_14 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %40 = arith.subi %39, %c1_i64_19 : i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %40, %arg3 : i64, !llvm.ptr
-    %42 = llvm.load %41 : !llvm.ptr -> i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %37 = llvm.getelementptr %36[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %38 = llvm.load %37 : !llvm.ptr -> i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_20 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %44 = arith.addi %43, %c-1_i64 : i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %45 = arith.cmpi ult, %43, %c1_i64_21 : i64
+    %40 = arith.addi %39, %c-1_i64 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %c1_i64_17 = arith.constant 1 : i64
+    %41 = arith.cmpi ult, %39, %c1_i64_17 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %45, ^bb1(%c91_i8 : i8), ^bb19
+    cf.cond_br %41, ^bb1(%c91_i8 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
     %c2_i64 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c2_i64 : i64
-    %c80_i8_22 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb22, ^bb1(%c80_i8_22 : i8)
+    %43 = arith.cmpi uge, %42, %c2_i64 : i64
+    %c80_i8_18 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb22, ^bb1(%c80_i8_18 : i8)
   ^bb22:  // pred: ^bb21
-    %48 = arith.subi %46, %c2_i64 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c2_i64 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %50 = arith.subi %49, %c1_i64_23 : i64
-    %51 = llvm.getelementptr %arg2[%50] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    %52 = llvm.load %51 : !llvm.ptr -> i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %46 = llvm.getelementptr %45[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %47 = llvm.load %46 : !llvm.ptr -> i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb27
   ^bb24:  // pred: ^bb26
-    %c1024_i64_24 = arith.constant 1024 : i64
-    %53 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_25 = arith.constant -1 : i64
-    %54 = arith.addi %53, %c-1_i64_25 : i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %55 = arith.cmpi ult, %53, %c1_i64_26 : i64
-    %c91_i8_27 = arith.constant 91 : i8
-    cf.cond_br %55, ^bb1(%c91_i8_27 : i8), ^bb23
+    %c1024_i64_19 = arith.constant 1024 : i64
+    %48 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_20 = arith.constant -1 : i64
+    %49 = arith.addi %48, %c-1_i64_20 : i64
+    llvm.store %49, %arg3 : i64, !llvm.ptr
+    %c1_i64_21 = arith.constant 1 : i64
+    %50 = arith.cmpi ult, %48, %c1_i64_21 : i64
+    %c91_i8_22 = arith.constant 91 : i8
+    cf.cond_br %50, ^bb1(%c91_i8_22 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %56 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_28 = arith.constant 2 : i64
+    %51 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_23 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %57 = arith.cmpi uge, %56, %c2_i64_28 : i64
-    %c80_i8_29 = arith.constant 80 : i8
-    cf.cond_br %57, ^bb26, ^bb1(%c80_i8_29 : i8)
+    %52 = arith.cmpi uge, %51, %c2_i64_23 : i64
+    %c80_i8_24 = arith.constant 80 : i8
+    cf.cond_br %52, ^bb26, ^bb1(%c80_i8_24 : i8)
   ^bb26:  // pred: ^bb25
-    %58 = arith.subi %56, %c2_i64_28 : i64
-    llvm.store %58, %arg1 : i64, !llvm.ptr
+    %53 = arith.subi %51, %c2_i64_23 : i64
+    llvm.store %53, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb23
-    %c0_i64_30 = arith.constant 0 : i64
+    %c0_i64_25 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %59 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %59, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %54 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_25, %c0_i64_25, %54, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 31 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb27, ^bb28, ^bb30, ^bb31, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46, ^bb48, ^bb49, ^bb50, ^bb53, ^bb54
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 31 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb27, ^bb28, ^bb30, ^bb31, ^bb33, ^bb34, ^bb36, ^bb37, ^bb40, ^bb41, ^bb42, ^bb45, ^bb46, ^bb48, ^bb49, ^bb50, ^bb53, ^bb54
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c8000_i256 = arith.constant 8000 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c8000_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,410 +96,392 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c16384_i256 = arith.constant 16384 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c16384_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c16384_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c32_i256 = arith.constant 32 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %c32_i256_13 = arith.constant 32 : i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_14 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_14 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256_13, %31 : i256, !llvm.ptr
+    %c32_i256_11 = arith.constant 32 : i256
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256_11, %28 : i256, !llvm.ptr
+    %29 = llvm.getelementptr %28[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_15 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %34 = arith.addi %33, %c1_i64_16 : i64
-    %35 = arith.cmpi ult, %c1024_i64_15, %34 : i64
-    %c92_i8_17 = arith.constant 92 : i8
-    cf.cond_br %35, ^bb1(%c92_i8_17 : i8), ^bb15
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %31 = arith.addi %30, %c1_i64_13 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %32 = arith.cmpi ult, %c1024_i64_12, %31 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %32, ^bb1(%c92_i8_14 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_18 = arith.constant 3 : i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_18 : i64
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_19 : i8)
+    %34 = arith.cmpi uge, %33, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb18, ^bb1(%c80_i8_16 : i8)
   ^bb18:  // pred: ^bb17
-    %38 = arith.subi %36, %c3_i64_18 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c3_i64_15 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
     %c64_i256 = arith.constant 64 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_20 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256, %40 : i256, !llvm.ptr
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_22 : i64
-    %44 = arith.cmpi ult, %c1024_i64_21, %43 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_23 : i8), ^bb19
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_18 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_17, %39 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_19 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb22, ^bb1(%c80_i8_25 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb22, ^bb1(%c80_i8_21 : i8)
   ^bb22:  // pred: ^bb21
-    %47 = arith.subi %45, %c3_i64_24 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_20 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
-    %c64_i256_26 = arith.constant 64 : i256
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %49 = llvm.getelementptr %arg2[%48] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_27 = arith.constant 1 : i64
-    %50 = arith.addi %48, %c1_i64_27 : i64
-    llvm.store %50, %arg3 : i64, !llvm.ptr
-    llvm.store %c64_i256_26, %49 : i256, !llvm.ptr
+    %c64_i256_22 = arith.constant 64 : i256
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c64_i256_22, %44 : i256, !llvm.ptr
+    %45 = llvm.getelementptr %44[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb24:  // pred: ^bb26
-    %c1024_i64_28 = arith.constant 1024 : i64
-    %51 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_29 = arith.constant 1 : i64
-    %52 = arith.addi %51, %c1_i64_29 : i64
-    %53 = arith.cmpi ult, %c1024_i64_28, %52 : i64
-    %c92_i8_30 = arith.constant 92 : i8
-    cf.cond_br %53, ^bb1(%c92_i8_30 : i8), ^bb23
+    %c1024_i64_23 = arith.constant 1024 : i64
+    %46 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_24 = arith.constant 1 : i64
+    %47 = arith.addi %46, %c1_i64_24 : i64
+    llvm.store %47, %arg3 : i64, !llvm.ptr
+    %48 = arith.cmpi ult, %c1024_i64_23, %47 : i64
+    %c92_i8_25 = arith.constant 92 : i8
+    cf.cond_br %48, ^bb1(%c92_i8_25 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %54 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_31 = arith.constant 3 : i64
+    %49 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_26 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %55 = arith.cmpi uge, %54, %c3_i64_31 : i64
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %55, ^bb26, ^bb1(%c80_i8_32 : i8)
+    %50 = arith.cmpi uge, %49, %c3_i64_26 : i64
+    %c80_i8_27 = arith.constant 80 : i8
+    cf.cond_br %50, ^bb26, ^bb1(%c80_i8_27 : i8)
   ^bb26:  // pred: ^bb25
-    %56 = arith.subi %54, %c3_i64_31 : i64
-    llvm.store %56, %arg1 : i64, !llvm.ptr
+    %51 = arith.subi %49, %c3_i64_26 : i64
+    llvm.store %51, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb36
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_33 = arith.constant 1 : i64
-    %58 = arith.subi %57, %c1_i64_33 : i64
-    %59 = llvm.getelementptr %arg2[%58] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %58, %arg3 : i64, !llvm.ptr
+    %52 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %53 = llvm.getelementptr %52[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %54 = llvm.load %53 : !llvm.ptr -> i256
+    llvm.store %53, %0 : !llvm.ptr, !llvm.ptr
+    %55 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %56 = llvm.getelementptr %55[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %57 = llvm.load %56 : !llvm.ptr -> i256
+    llvm.store %56, %0 : !llvm.ptr, !llvm.ptr
+    %58 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %59 = llvm.getelementptr %58[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %60 = llvm.load %59 : !llvm.ptr -> i256
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %62 = arith.subi %61, %c1_i64_34 : i64
-    %63 = llvm.getelementptr %arg2[%62] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %62, %arg3 : i64, !llvm.ptr
-    %64 = llvm.load %63 : !llvm.ptr -> i256
-    %65 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %66 = arith.subi %65, %c1_i64_35 : i64
-    %67 = llvm.getelementptr %arg2[%66] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %66, %arg3 : i64, !llvm.ptr
-    %68 = llvm.load %67 : !llvm.ptr -> i256
-    %69 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_36 = arith.constant 1 : i64
-    %70 = arith.subi %69, %c1_i64_36 : i64
-    %71 = llvm.getelementptr %arg2[%70] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %70, %arg3 : i64, !llvm.ptr
-    %72 = llvm.load %71 : !llvm.ptr -> i256
-    %73 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_37 = arith.constant 1 : i64
-    %74 = arith.subi %73, %c1_i64_37 : i64
-    %75 = llvm.getelementptr %arg2[%74] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %74, %arg3 : i64, !llvm.ptr
-    %76 = llvm.load %75 : !llvm.ptr -> i256
-    %77 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_38 = arith.constant 1 : i64
-    %78 = arith.subi %77, %c1_i64_38 : i64
-    %79 = llvm.getelementptr %arg2[%78] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %78, %arg3 : i64, !llvm.ptr
-    %80 = llvm.load %79 : !llvm.ptr -> i256
+    llvm.store %59, %0 : !llvm.ptr, !llvm.ptr
+    %61 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %62 = llvm.getelementptr %61[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %63 = llvm.load %62 : !llvm.ptr -> i256
+    llvm.store %62, %0 : !llvm.ptr, !llvm.ptr
+    %64 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %65 = llvm.getelementptr %64[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %66 = llvm.load %65 : !llvm.ptr -> i256
+    llvm.store %65, %0 : !llvm.ptr, !llvm.ptr
+    %67 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %68 = llvm.getelementptr %67[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %69 = llvm.load %68 : !llvm.ptr -> i256
+    llvm.store %68, %0 : !llvm.ptr, !llvm.ptr
     %c0_i256 = arith.constant 0 : i256
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %81 = arith.cmpi sgt, %72, %c18446744073709551615_i256 : i256
+    %70 = arith.cmpi sgt, %63, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8 : i8), ^bb28
+    cf.cond_br %70, ^bb1(%c84_i8 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %82 = arith.trunci %72 : i256 to i64
-    %c0_i64_39 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_39 : i64
-    %c84_i8_40 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_40 : i8), ^bb29
+    %71 = arith.trunci %63 : i256 to i64
+    %c0_i64_28 = arith.constant 0 : i64
+    %72 = arith.cmpi slt, %71, %c0_i64_28 : i64
+    %c84_i8_29 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_29 : i8), ^bb29
   ^bb29:  // pred: ^bb28
-    %c0_i64_41 = arith.constant 0 : i64
-    %84 = arith.cmpi ne, %82, %c0_i64_41 : i64
-    cf.cond_br %84, ^bb40, ^bb30
+    %c0_i64_30 = arith.constant 0 : i64
+    %73 = arith.cmpi ne, %71, %c0_i64_30 : i64
+    cf.cond_br %73, ^bb40, ^bb30
   ^bb30:  // 2 preds: ^bb29, ^bb44
-    %c18446744073709551615_i256_42 = arith.constant 18446744073709551615 : i256
-    %85 = arith.cmpi sgt, %80, %c18446744073709551615_i256_42 : i256
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %85, ^bb1(%c84_i8_43 : i8), ^bb31
+    %c18446744073709551615_i256_31 = arith.constant 18446744073709551615 : i256
+    %74 = arith.cmpi sgt, %69, %c18446744073709551615_i256_31 : i256
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_32 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %86 = arith.trunci %80 : i256 to i64
-    %c0_i64_44 = arith.constant 0 : i64
-    %87 = arith.cmpi slt, %86, %c0_i64_44 : i64
-    %c84_i8_45 = arith.constant 84 : i8
-    cf.cond_br %87, ^bb1(%c84_i8_45 : i8), ^bb32
+    %75 = arith.trunci %69 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_34 : i8), ^bb32
   ^bb32:  // pred: ^bb31
-    %c0_i64_46 = arith.constant 0 : i64
-    %88 = arith.cmpi ne, %86, %c0_i64_46 : i64
-    cf.cond_br %88, ^bb48, ^bb33
+    %c0_i64_35 = arith.constant 0 : i64
+    %77 = arith.cmpi ne, %75, %c0_i64_35 : i64
+    cf.cond_br %77, ^bb48, ^bb33
   ^bb33:  // 2 preds: ^bb32, ^bb52
-    %89 = arith.trunci %68 : i256 to i64
-    %90 = arith.trunci %76 : i256 to i64
-    %91 = llvm.load %arg1 : !llvm.ptr -> i64
+    %78 = arith.trunci %60 : i256 to i64
+    %79 = arith.trunci %66 : i256 to i64
+    %80 = llvm.load %arg1 : !llvm.ptr -> i64
     %c1_i256 = arith.constant 1 : i256
-    %92 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %c0_i256, %92 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_47 = arith.constant 1 : i256
-    %93 = llvm.alloca %c1_i256_47 x i256 : (i256) -> !llvm.ptr
-    llvm.store %60, %93 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_48 = arith.constant 1 : i256
-    %94 = llvm.alloca %c1_i256_48 x i256 : (i256) -> !llvm.ptr
-    llvm.store %64, %94 {alignment = 1 : i64} : i256, !llvm.ptr
+    %81 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %c0_i256, %81 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_36 = arith.constant 1 : i256
+    %82 = llvm.alloca %c1_i256_36 x i256 : (i256) -> !llvm.ptr
+    llvm.store %54, %82 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_37 = arith.constant 1 : i256
+    %83 = llvm.alloca %c1_i256_37 x i256 : (i256) -> !llvm.ptr
+    llvm.store %57, %83 {alignment = 1 : i64} : i256, !llvm.ptr
     %c1_i8 = arith.constant 1 : i8
-    %95 = call @dora_fn_call(%arg0, %93, %94, %92, %89, %82, %90, %86, %91, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
-    %96 = llvm.getelementptr %95[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %97 = llvm.load %96 : !llvm.ptr -> i8
-    %98 = llvm.getelementptr %95[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %99 = llvm.load %98 : !llvm.ptr -> i8
+    %84 = call @dora_fn_call(%arg0, %82, %83, %81, %78, %71, %79, %75, %80, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
+    %85 = llvm.getelementptr %84[16] : (!llvm.ptr) -> !llvm.ptr, i8
+    %86 = llvm.load %85 : !llvm.ptr -> i8
+    %87 = llvm.getelementptr %84[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %88 = llvm.load %87 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %100 = arith.cmpi ne, %99, %c0_i8 : i8
-    cf.cond_br %100, ^bb1(%99 : i8), ^bb34
+    %89 = arith.cmpi ne, %88, %c0_i8 : i8
+    cf.cond_br %89, ^bb1(%88 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %101 = llvm.getelementptr %95[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %102 = llvm.load %101 : !llvm.ptr -> i64
-    %103 = llvm.load %arg1 : !llvm.ptr -> i64
-    %104 = arith.cmpi ult, %103, %102 : i64
-    scf.if %104 {
+    %90 = llvm.getelementptr %84[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %91 = llvm.load %90 : !llvm.ptr -> i64
+    %92 = llvm.load %arg1 : !llvm.ptr -> i64
+    %93 = arith.cmpi ult, %92, %91 : i64
+    scf.if %93 {
     } else {
-      %172 = arith.subi %103, %102 : i64
-      llvm.store %172, %arg1 : i64, !llvm.ptr
+      %160 = arith.subi %92, %91 : i64
+      llvm.store %160, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_49 = arith.constant 80 : i8
-    cf.cond_br %104, ^bb1(%c80_i8_49 : i8), ^bb35
+    %c80_i8_38 = arith.constant 80 : i8
+    cf.cond_br %93, ^bb1(%c80_i8_38 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %105 = arith.extui %97 : i8 to i256
-    %106 = llvm.load %arg3 : !llvm.ptr -> i64
-    %107 = llvm.getelementptr %arg2[%106] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_50 = arith.constant 1 : i64
-    %108 = arith.addi %106, %c1_i64_50 : i64
-    llvm.store %108, %arg3 : i64, !llvm.ptr
-    llvm.store %105, %107 : i256, !llvm.ptr
+    %94 = arith.extui %86 : i8 to i256
+    %95 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %94, %95 : i256, !llvm.ptr
+    %96 = llvm.getelementptr %95[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %96, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb39
   ^bb36:  // pred: ^bb38
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %109 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %97 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-5_i64 = arith.constant -5 : i64
-    %110 = arith.addi %109, %c-5_i64 : i64
+    %98 = arith.addi %97, %c-5_i64 : i64
+    llvm.store %98, %arg3 : i64, !llvm.ptr
     %c6_i64 = arith.constant 6 : i64
-    %111 = arith.cmpi ult, %109, %c6_i64 : i64
+    %99 = arith.cmpi ult, %97, %c6_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %111, ^bb1(%c91_i8 : i8), ^bb27
+    cf.cond_br %99, ^bb1(%c91_i8 : i8), ^bb27
   ^bb37:  // pred: ^bb23
-    %112 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_52 = arith.constant 0 : i64
+    %100 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_40 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %113 = arith.cmpi uge, %112, %c0_i64_52 : i64
-    %c80_i8_53 = arith.constant 80 : i8
-    cf.cond_br %113, ^bb38, ^bb1(%c80_i8_53 : i8)
+    %101 = arith.cmpi uge, %100, %c0_i64_40 : i64
+    %c80_i8_41 = arith.constant 80 : i8
+    cf.cond_br %101, ^bb38, ^bb1(%c80_i8_41 : i8)
   ^bb38:  // pred: ^bb37
-    %114 = arith.subi %112, %c0_i64_52 : i64
-    llvm.store %114, %arg1 : i64, !llvm.ptr
+    %102 = arith.subi %100, %c0_i64_40 : i64
+    llvm.store %102, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb35
-    %c0_i64_54 = arith.constant 0 : i64
-    %c1_i8_55 = arith.constant 1 : i8
-    %115 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_54, %c0_i64_54, %115, %c1_i8_55) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %c1_i8_55 : i8
+    %c0_i64_42 = arith.constant 0 : i64
+    %c1_i8_43 = arith.constant 1 : i8
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_42, %c0_i64_42, %103, %c1_i8_43) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %c1_i8_43 : i8
   ^bb40:  // pred: ^bb29
-    %c18446744073709551615_i256_56 = arith.constant 18446744073709551615 : i256
-    %116 = arith.cmpi sgt, %68, %c18446744073709551615_i256_56 : i256
-    %c84_i8_57 = arith.constant 84 : i8
-    cf.cond_br %116, ^bb1(%c84_i8_57 : i8), ^bb41
+    %c18446744073709551615_i256_44 = arith.constant 18446744073709551615 : i256
+    %104 = arith.cmpi sgt, %60, %c18446744073709551615_i256_44 : i256
+    %c84_i8_45 = arith.constant 84 : i8
+    cf.cond_br %104, ^bb1(%c84_i8_45 : i8), ^bb41
   ^bb41:  // pred: ^bb40
-    %117 = arith.trunci %68 : i256 to i64
-    %c0_i64_58 = arith.constant 0 : i64
-    %118 = arith.cmpi slt, %117, %c0_i64_58 : i64
-    %c84_i8_59 = arith.constant 84 : i8
-    cf.cond_br %118, ^bb1(%c84_i8_59 : i8), ^bb42
+    %105 = arith.trunci %60 : i256 to i64
+    %c0_i64_46 = arith.constant 0 : i64
+    %106 = arith.cmpi slt, %105, %c0_i64_46 : i64
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %106, ^bb1(%c84_i8_47 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %119 = arith.addi %117, %82 : i64
-    %c0_i64_60 = arith.constant 0 : i64
-    %120 = arith.cmpi slt, %119, %c0_i64_60 : i64
-    %c84_i8_61 = arith.constant 84 : i8
-    cf.cond_br %120, ^bb1(%c84_i8_61 : i8), ^bb43
+    %107 = arith.addi %105, %71 : i64
+    %c0_i64_48 = arith.constant 0 : i64
+    %108 = arith.cmpi slt, %107, %c0_i64_48 : i64
+    %c84_i8_49 = arith.constant 84 : i8
+    cf.cond_br %108, ^bb1(%c84_i8_49 : i8), ^bb43
   ^bb43:  // pred: ^bb42
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %121 = arith.addi %119, %c31_i64 : i64
-    %122 = arith.divui %121, %c32_i64 : i64
-    %c32_i64_62 = arith.constant 32 : i64
-    %123 = arith.muli %122, %c32_i64_62 : i64
-    %124 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_63 = arith.constant 31 : i64
-    %c32_i64_64 = arith.constant 32 : i64
-    %125 = arith.addi %124, %c31_i64_63 : i64
-    %126 = arith.divui %125, %c32_i64_64 : i64
-    %127 = arith.muli %126, %c32_i64_62 : i64
-    %128 = arith.cmpi ult, %127, %123 : i64
-    cf.cond_br %128, ^bb45, ^bb44
+    %109 = arith.addi %107, %c31_i64 : i64
+    %110 = arith.divui %109, %c32_i64 : i64
+    %c32_i64_50 = arith.constant 32 : i64
+    %111 = arith.muli %110, %c32_i64_50 : i64
+    %112 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_51 = arith.constant 31 : i64
+    %c32_i64_52 = arith.constant 32 : i64
+    %113 = arith.addi %112, %c31_i64_51 : i64
+    %114 = arith.divui %113, %c32_i64_52 : i64
+    %115 = arith.muli %114, %c32_i64_50 : i64
+    %116 = arith.cmpi ult, %115, %111 : i64
+    cf.cond_br %116, ^bb45, ^bb44
   ^bb44:  // 2 preds: ^bb43, ^bb47
     cf.br ^bb30
   ^bb45:  // pred: ^bb43
-    %c3_i64_65 = arith.constant 3 : i64
+    %c3_i64_53 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %129 = arith.muli %126, %126 : i64
-    %130 = arith.divui %129, %c512_i64 : i64
-    %131 = arith.muli %126, %c3_i64_65 : i64
-    %132 = arith.addi %130, %131 : i64
-    %c3_i64_66 = arith.constant 3 : i64
-    %c512_i64_67 = arith.constant 512 : i64
-    %133 = arith.muli %122, %122 : i64
-    %134 = arith.divui %133, %c512_i64_67 : i64
-    %135 = arith.muli %122, %c3_i64_66 : i64
-    %136 = arith.addi %134, %135 : i64
-    %137 = arith.subi %136, %132 : i64
-    %138 = llvm.load %arg1 : !llvm.ptr -> i64
-    %139 = arith.cmpi ult, %138, %137 : i64
-    scf.if %139 {
+    %117 = arith.muli %114, %114 : i64
+    %118 = arith.divui %117, %c512_i64 : i64
+    %119 = arith.muli %114, %c3_i64_53 : i64
+    %120 = arith.addi %118, %119 : i64
+    %c3_i64_54 = arith.constant 3 : i64
+    %c512_i64_55 = arith.constant 512 : i64
+    %121 = arith.muli %110, %110 : i64
+    %122 = arith.divui %121, %c512_i64_55 : i64
+    %123 = arith.muli %110, %c3_i64_54 : i64
+    %124 = arith.addi %122, %123 : i64
+    %125 = arith.subi %124, %120 : i64
+    %126 = llvm.load %arg1 : !llvm.ptr -> i64
+    %127 = arith.cmpi ult, %126, %125 : i64
+    scf.if %127 {
     } else {
-      %172 = arith.subi %138, %137 : i64
-      llvm.store %172, %arg1 : i64, !llvm.ptr
+      %160 = arith.subi %126, %125 : i64
+      llvm.store %160, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_68 = arith.constant 80 : i8
-    cf.cond_br %139, ^bb1(%c80_i8_68 : i8), ^bb46
+    %c80_i8_56 = arith.constant 80 : i8
+    cf.cond_br %127, ^bb1(%c80_i8_56 : i8), ^bb46
   ^bb46:  // pred: ^bb45
-    %140 = call @dora_fn_extend_memory(%arg0, %123) : (!llvm.ptr, i64) -> !llvm.ptr
-    %141 = llvm.getelementptr %140[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %142 = llvm.load %141 : !llvm.ptr -> i8
-    %c0_i8_69 = arith.constant 0 : i8
-    %143 = arith.cmpi ne, %142, %c0_i8_69 : i8
-    cf.cond_br %143, ^bb1(%142 : i8), ^bb47
+    %128 = call @dora_fn_extend_memory(%arg0, %111) : (!llvm.ptr, i64) -> !llvm.ptr
+    %129 = llvm.getelementptr %128[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %130 = llvm.load %129 : !llvm.ptr -> i8
+    %c0_i8_57 = arith.constant 0 : i8
+    %131 = arith.cmpi ne, %130, %c0_i8_57 : i8
+    cf.cond_br %131, ^bb1(%130 : i8), ^bb47
   ^bb47:  // pred: ^bb46
     cf.br ^bb44
   ^bb48:  // pred: ^bb32
-    %c18446744073709551615_i256_70 = arith.constant 18446744073709551615 : i256
-    %144 = arith.cmpi sgt, %76, %c18446744073709551615_i256_70 : i256
-    %c84_i8_71 = arith.constant 84 : i8
-    cf.cond_br %144, ^bb1(%c84_i8_71 : i8), ^bb49
+    %c18446744073709551615_i256_58 = arith.constant 18446744073709551615 : i256
+    %132 = arith.cmpi sgt, %66, %c18446744073709551615_i256_58 : i256
+    %c84_i8_59 = arith.constant 84 : i8
+    cf.cond_br %132, ^bb1(%c84_i8_59 : i8), ^bb49
   ^bb49:  // pred: ^bb48
-    %145 = arith.trunci %76 : i256 to i64
-    %c0_i64_72 = arith.constant 0 : i64
-    %146 = arith.cmpi slt, %145, %c0_i64_72 : i64
-    %c84_i8_73 = arith.constant 84 : i8
-    cf.cond_br %146, ^bb1(%c84_i8_73 : i8), ^bb50
+    %133 = arith.trunci %66 : i256 to i64
+    %c0_i64_60 = arith.constant 0 : i64
+    %134 = arith.cmpi slt, %133, %c0_i64_60 : i64
+    %c84_i8_61 = arith.constant 84 : i8
+    cf.cond_br %134, ^bb1(%c84_i8_61 : i8), ^bb50
   ^bb50:  // pred: ^bb49
-    %147 = arith.addi %145, %86 : i64
-    %c0_i64_74 = arith.constant 0 : i64
-    %148 = arith.cmpi slt, %147, %c0_i64_74 : i64
-    %c84_i8_75 = arith.constant 84 : i8
-    cf.cond_br %148, ^bb1(%c84_i8_75 : i8), ^bb51
+    %135 = arith.addi %133, %75 : i64
+    %c0_i64_62 = arith.constant 0 : i64
+    %136 = arith.cmpi slt, %135, %c0_i64_62 : i64
+    %c84_i8_63 = arith.constant 84 : i8
+    cf.cond_br %136, ^bb1(%c84_i8_63 : i8), ^bb51
   ^bb51:  // pred: ^bb50
-    %c31_i64_76 = arith.constant 31 : i64
-    %c32_i64_77 = arith.constant 32 : i64
-    %149 = arith.addi %147, %c31_i64_76 : i64
-    %150 = arith.divui %149, %c32_i64_77 : i64
-    %c32_i64_78 = arith.constant 32 : i64
-    %151 = arith.muli %150, %c32_i64_78 : i64
-    %152 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_79 = arith.constant 31 : i64
-    %c32_i64_80 = arith.constant 32 : i64
-    %153 = arith.addi %152, %c31_i64_79 : i64
-    %154 = arith.divui %153, %c32_i64_80 : i64
-    %155 = arith.muli %154, %c32_i64_78 : i64
-    %156 = arith.cmpi ult, %155, %151 : i64
-    cf.cond_br %156, ^bb53, ^bb52
+    %c31_i64_64 = arith.constant 31 : i64
+    %c32_i64_65 = arith.constant 32 : i64
+    %137 = arith.addi %135, %c31_i64_64 : i64
+    %138 = arith.divui %137, %c32_i64_65 : i64
+    %c32_i64_66 = arith.constant 32 : i64
+    %139 = arith.muli %138, %c32_i64_66 : i64
+    %140 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_67 = arith.constant 31 : i64
+    %c32_i64_68 = arith.constant 32 : i64
+    %141 = arith.addi %140, %c31_i64_67 : i64
+    %142 = arith.divui %141, %c32_i64_68 : i64
+    %143 = arith.muli %142, %c32_i64_66 : i64
+    %144 = arith.cmpi ult, %143, %139 : i64
+    cf.cond_br %144, ^bb53, ^bb52
   ^bb52:  // 2 preds: ^bb51, ^bb55
     cf.br ^bb33
   ^bb53:  // pred: ^bb51
-    %c3_i64_81 = arith.constant 3 : i64
-    %c512_i64_82 = arith.constant 512 : i64
-    %157 = arith.muli %154, %154 : i64
-    %158 = arith.divui %157, %c512_i64_82 : i64
-    %159 = arith.muli %154, %c3_i64_81 : i64
-    %160 = arith.addi %158, %159 : i64
-    %c3_i64_83 = arith.constant 3 : i64
-    %c512_i64_84 = arith.constant 512 : i64
-    %161 = arith.muli %150, %150 : i64
-    %162 = arith.divui %161, %c512_i64_84 : i64
-    %163 = arith.muli %150, %c3_i64_83 : i64
-    %164 = arith.addi %162, %163 : i64
-    %165 = arith.subi %164, %160 : i64
-    %166 = llvm.load %arg1 : !llvm.ptr -> i64
-    %167 = arith.cmpi ult, %166, %165 : i64
-    scf.if %167 {
+    %c3_i64_69 = arith.constant 3 : i64
+    %c512_i64_70 = arith.constant 512 : i64
+    %145 = arith.muli %142, %142 : i64
+    %146 = arith.divui %145, %c512_i64_70 : i64
+    %147 = arith.muli %142, %c3_i64_69 : i64
+    %148 = arith.addi %146, %147 : i64
+    %c3_i64_71 = arith.constant 3 : i64
+    %c512_i64_72 = arith.constant 512 : i64
+    %149 = arith.muli %138, %138 : i64
+    %150 = arith.divui %149, %c512_i64_72 : i64
+    %151 = arith.muli %138, %c3_i64_71 : i64
+    %152 = arith.addi %150, %151 : i64
+    %153 = arith.subi %152, %148 : i64
+    %154 = llvm.load %arg1 : !llvm.ptr -> i64
+    %155 = arith.cmpi ult, %154, %153 : i64
+    scf.if %155 {
     } else {
-      %172 = arith.subi %166, %165 : i64
-      llvm.store %172, %arg1 : i64, !llvm.ptr
+      %160 = arith.subi %154, %153 : i64
+      llvm.store %160, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_85 = arith.constant 80 : i8
-    cf.cond_br %167, ^bb1(%c80_i8_85 : i8), ^bb54
+    %c80_i8_73 = arith.constant 80 : i8
+    cf.cond_br %155, ^bb1(%c80_i8_73 : i8), ^bb54
   ^bb54:  // pred: ^bb53
-    %168 = call @dora_fn_extend_memory(%arg0, %151) : (!llvm.ptr, i64) -> !llvm.ptr
-    %169 = llvm.getelementptr %168[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %170 = llvm.load %169 : !llvm.ptr -> i8
-    %c0_i8_86 = arith.constant 0 : i8
-    %171 = arith.cmpi ne, %170, %c0_i8_86 : i8
-    cf.cond_br %171, ^bb1(%170 : i8), ^bb55
+    %156 = call @dora_fn_extend_memory(%arg0, %139) : (!llvm.ptr, i64) -> !llvm.ptr
+    %157 = llvm.getelementptr %156[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %158 = llvm.load %157 : !llvm.ptr -> i8
+    %c0_i8_74 = arith.constant 0 : i8
+    %159 = arith.cmpi ne, %158, %c0_i8_74 : i8
+    cf.cond_br %159, ^bb1(%158 : i8), ^bb55
   ^bb55:  // pred: ^bb54
     cf.br ^bb52
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_store_return.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_store_return.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 25 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb24, ^bb25, ^bb29, ^bb30, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb46, ^bb47
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 25 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22, ^bb24, ^bb25, ^bb29, ^bb30, ^bb33, ^bb34, ^bb35, ^bb38, ^bb39, ^bb41, ^bb42, ^bb43, ^bb46, ^bb47
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c26855045751621412909479635801631599578944495011106431764815136423936_i256 = arith.constant 26855045751621412909479635801631599578944495011106431764815136423936 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c26855045751621412909479635801631599578944495011106431764815136423936_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,323 +96,314 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c32_i64 = arith.constant 32 : i64
-    %c0_i64_9 = arith.constant 0 : i64
-    %29 = arith.cmpi ne, %c32_i64, %c0_i64_9 : i64
-    cf.cond_br %29, ^bb33, ^bb12
+    %c0_i64_6 = arith.constant 0 : i64
+    %26 = arith.cmpi ne, %c32_i64, %c0_i64_6 : i64
+    cf.cond_br %26, ^bb33, ^bb12
   ^bb12:  // 2 preds: ^bb11, ^bb37
-    %30 = arith.trunci %24 : i256 to i64
-    %31 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
-    %32 = llvm.getelementptr %31[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-    %33 = llvm.intr.bswap(%28)  : (i256) -> i256
-    llvm.store %33, %32 {alignment = 1 : i64} : i256, !llvm.ptr
+    %27 = arith.trunci %22 : i256 to i64
+    %28 = call @dora_fn_memory_ptr(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    %29 = llvm.getelementptr %28[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %30 = llvm.intr.bswap(%25)  : (i256) -> i256
+    llvm.store %30, %29 {alignment = 1 : i64} : i256, !llvm.ptr
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %31 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %35 = arith.addi %34, %c-2_i64 : i64
+    %32 = arith.addi %31, %c-2_i64 : i64
+    llvm.store %32, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %36 = arith.cmpi ult, %34, %c2_i64 : i64
+    %33 = arith.cmpi ult, %31, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %36, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %37 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %34 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %38 = arith.cmpi uge, %37, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %38, ^bb15, ^bb1(%c80_i8_12 : i8)
+    %35 = arith.cmpi uge, %34, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %35, ^bb15, ^bb1(%c80_i8_9 : i8)
   ^bb15:  // pred: ^bb14
-    %39 = arith.subi %37, %c3_i64_11 : i64
-    llvm.store %39, %arg1 : i64, !llvm.ptr
+    %36 = arith.subi %34, %c3_i64_8 : i64
+    llvm.store %36, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
     %c2_i256 = arith.constant 2 : i256
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %41 = llvm.getelementptr %arg2[%40] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %42 = arith.addi %40, %c1_i64_13 : i64
-    llvm.store %42, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %41 : i256, !llvm.ptr
+    %37 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %37 : i256, !llvm.ptr
+    %38 = llvm.getelementptr %37[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %38, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %43 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %44 = arith.addi %43, %c1_i64_15 : i64
-    %45 = arith.cmpi ult, %c1024_i64_14, %44 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %45, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %39 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %40 = arith.addi %39, %c1_i64_11 : i64
+    llvm.store %40, %arg3 : i64, !llvm.ptr
+    %41 = arith.cmpi ult, %c1024_i64_10, %40 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %41, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %42 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %47 = arith.cmpi uge, %46, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %47, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %43 = arith.cmpi uge, %42, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %43, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %48 = arith.subi %46, %c3_i64_17 : i64
-    llvm.store %48, %arg1 : i64, !llvm.ptr
+    %44 = arith.subi %42, %c3_i64_13 : i64
+    llvm.store %44, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %c0_i256_19 = arith.constant 0 : i256
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %51 = arith.addi %49, %c1_i64_20 : i64
-    llvm.store %51, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_19, %50 : i256, !llvm.ptr
+    %c0_i256_15 = arith.constant 0 : i256
+    %45 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_15, %45 : i256, !llvm.ptr
+    %46 = llvm.getelementptr %45[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %46, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb30
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_22 = arith.constant 1 : i64
-    %53 = arith.addi %52, %c1_i64_22 : i64
-    %54 = arith.cmpi ult, %c1024_i64_21, %53 : i64
-    %c92_i8_23 = arith.constant 92 : i8
-    cf.cond_br %54, ^bb1(%c92_i8_23 : i8), ^bb20
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %47 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_17 = arith.constant 1 : i64
+    %48 = arith.addi %47, %c1_i64_17 : i64
+    llvm.store %48, %arg3 : i64, !llvm.ptr
+    %49 = arith.cmpi ult, %c1024_i64_16, %48 : i64
+    %c92_i8_18 = arith.constant 92 : i8
+    cf.cond_br %49, ^bb1(%c92_i8_18 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %55 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %50 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %56 = arith.cmpi uge, %55, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %51 = arith.cmpi uge, %50, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %51, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %57 = arith.subi %55, %c3_i64_24 : i64
-    llvm.store %57, %arg1 : i64, !llvm.ptr
+    %52 = arith.subi %50, %c3_i64_19 : i64
+    llvm.store %52, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb29
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_26 = arith.constant 1 : i64
-    %59 = arith.subi %58, %c1_i64_26 : i64
-    %60 = llvm.getelementptr %arg2[%59] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    %61 = llvm.load %60 : !llvm.ptr -> i256
-    %62 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %63 = arith.subi %62, %c1_i64_27 : i64
-    %64 = llvm.getelementptr %arg2[%63] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    %65 = llvm.load %64 : !llvm.ptr -> i256
+    %53 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %54 = llvm.getelementptr %53[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %55 = llvm.load %54 : !llvm.ptr -> i256
+    llvm.store %54, %0 : !llvm.ptr, !llvm.ptr
+    %56 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %57 = llvm.getelementptr %56[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %58 = llvm.load %57 : !llvm.ptr -> i256
+    llvm.store %57, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %66 = arith.cmpi sgt, %65, %c18446744073709551615_i256 : i256
+    %59 = arith.cmpi sgt, %58, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %66, ^bb1(%c84_i8 : i8), ^bb25
+    cf.cond_br %59, ^bb1(%c84_i8 : i8), ^bb25
   ^bb25:  // pred: ^bb24
-    %67 = arith.trunci %65 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %68 = arith.cmpi slt, %67, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %68, ^bb1(%c84_i8_29 : i8), ^bb26
+    %60 = arith.trunci %58 : i256 to i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_21 : i64
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %c0_i64_30 = arith.constant 0 : i64
-    %69 = arith.cmpi ne, %67, %c0_i64_30 : i64
-    cf.cond_br %69, ^bb41, ^bb27
+    %c0_i64_23 = arith.constant 0 : i64
+    %62 = arith.cmpi ne, %60, %c0_i64_23 : i64
+    cf.cond_br %62, ^bb41, ^bb27
   ^bb27:  // 2 preds: ^bb26, ^bb45
     %c0_i8 = arith.constant 0 : i8
-    %70 = arith.trunci %61 : i256 to i64
-    %71 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %70, %67, %71, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %63 = arith.trunci %55 : i256 to i64
+    %64 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %63, %60, %64, %c0_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c0_i8 : i8
   ^bb28:  // no predecessors
     cf.br ^bb32
   ^bb29:  // pred: ^bb31
-    %c1024_i64_31 = arith.constant 1024 : i64
-    %72 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_32 = arith.constant -2 : i64
-    %73 = arith.addi %72, %c-2_i64_32 : i64
-    %c2_i64_33 = arith.constant 2 : i64
-    %74 = arith.cmpi ult, %72, %c2_i64_33 : i64
-    %c91_i8_34 = arith.constant 91 : i8
-    cf.cond_br %74, ^bb1(%c91_i8_34 : i8), ^bb24
+    %c1024_i64_24 = arith.constant 1024 : i64
+    %65 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_25 = arith.constant -2 : i64
+    %66 = arith.addi %65, %c-2_i64_25 : i64
+    llvm.store %66, %arg3 : i64, !llvm.ptr
+    %c2_i64_26 = arith.constant 2 : i64
+    %67 = arith.cmpi ult, %65, %c2_i64_26 : i64
+    %c91_i8_27 = arith.constant 91 : i8
+    cf.cond_br %67, ^bb1(%c91_i8_27 : i8), ^bb24
   ^bb30:  // pred: ^bb20
-    %75 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_35 = arith.constant 0 : i64
+    %68 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_28 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %76 = arith.cmpi uge, %75, %c0_i64_35 : i64
-    %c80_i8_36 = arith.constant 80 : i8
-    cf.cond_br %76, ^bb31, ^bb1(%c80_i8_36 : i8)
+    %69 = arith.cmpi uge, %68, %c0_i64_28 : i64
+    %c80_i8_29 = arith.constant 80 : i8
+    cf.cond_br %69, ^bb31, ^bb1(%c80_i8_29 : i8)
   ^bb31:  // pred: ^bb30
-    %77 = arith.subi %75, %c0_i64_35 : i64
-    llvm.store %77, %arg1 : i64, !llvm.ptr
+    %70 = arith.subi %68, %c0_i64_28 : i64
+    llvm.store %70, %arg1 : i64, !llvm.ptr
     cf.br ^bb29
   ^bb32:  // pred: ^bb28
-    %c0_i64_37 = arith.constant 0 : i64
+    %c0_i64_30 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %78 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_37, %c0_i64_37, %78, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %71 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_30, %c0_i64_30, %71, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb33:  // pred: ^bb11
-    %c18446744073709551615_i256_38 = arith.constant 18446744073709551615 : i256
-    %79 = arith.cmpi sgt, %24, %c18446744073709551615_i256_38 : i256
-    %c84_i8_39 = arith.constant 84 : i8
-    cf.cond_br %79, ^bb1(%c84_i8_39 : i8), ^bb34
+    %c18446744073709551615_i256_31 = arith.constant 18446744073709551615 : i256
+    %72 = arith.cmpi sgt, %22, %c18446744073709551615_i256_31 : i256
+    %c84_i8_32 = arith.constant 84 : i8
+    cf.cond_br %72, ^bb1(%c84_i8_32 : i8), ^bb34
   ^bb34:  // pred: ^bb33
-    %80 = arith.trunci %24 : i256 to i64
-    %c0_i64_40 = arith.constant 0 : i64
-    %81 = arith.cmpi slt, %80, %c0_i64_40 : i64
-    %c84_i8_41 = arith.constant 84 : i8
-    cf.cond_br %81, ^bb1(%c84_i8_41 : i8), ^bb35
+    %73 = arith.trunci %22 : i256 to i64
+    %c0_i64_33 = arith.constant 0 : i64
+    %74 = arith.cmpi slt, %73, %c0_i64_33 : i64
+    %c84_i8_34 = arith.constant 84 : i8
+    cf.cond_br %74, ^bb1(%c84_i8_34 : i8), ^bb35
   ^bb35:  // pred: ^bb34
-    %82 = arith.addi %80, %c32_i64 : i64
-    %c0_i64_42 = arith.constant 0 : i64
-    %83 = arith.cmpi slt, %82, %c0_i64_42 : i64
-    %c84_i8_43 = arith.constant 84 : i8
-    cf.cond_br %83, ^bb1(%c84_i8_43 : i8), ^bb36
+    %75 = arith.addi %73, %c32_i64 : i64
+    %c0_i64_35 = arith.constant 0 : i64
+    %76 = arith.cmpi slt, %75, %c0_i64_35 : i64
+    %c84_i8_36 = arith.constant 84 : i8
+    cf.cond_br %76, ^bb1(%c84_i8_36 : i8), ^bb36
   ^bb36:  // pred: ^bb35
     %c31_i64 = arith.constant 31 : i64
-    %c32_i64_44 = arith.constant 32 : i64
-    %84 = arith.addi %82, %c31_i64 : i64
-    %85 = arith.divui %84, %c32_i64_44 : i64
-    %c32_i64_45 = arith.constant 32 : i64
-    %86 = arith.muli %85, %c32_i64_45 : i64
-    %87 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_46 = arith.constant 31 : i64
-    %c32_i64_47 = arith.constant 32 : i64
-    %88 = arith.addi %87, %c31_i64_46 : i64
-    %89 = arith.divui %88, %c32_i64_47 : i64
-    %90 = arith.muli %89, %c32_i64_45 : i64
-    %91 = arith.cmpi ult, %90, %86 : i64
-    cf.cond_br %91, ^bb38, ^bb37
+    %c32_i64_37 = arith.constant 32 : i64
+    %77 = arith.addi %75, %c31_i64 : i64
+    %78 = arith.divui %77, %c32_i64_37 : i64
+    %c32_i64_38 = arith.constant 32 : i64
+    %79 = arith.muli %78, %c32_i64_38 : i64
+    %80 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_39 = arith.constant 31 : i64
+    %c32_i64_40 = arith.constant 32 : i64
+    %81 = arith.addi %80, %c31_i64_39 : i64
+    %82 = arith.divui %81, %c32_i64_40 : i64
+    %83 = arith.muli %82, %c32_i64_38 : i64
+    %84 = arith.cmpi ult, %83, %79 : i64
+    cf.cond_br %84, ^bb38, ^bb37
   ^bb37:  // 2 preds: ^bb36, ^bb40
     cf.br ^bb12
   ^bb38:  // pred: ^bb36
-    %c3_i64_48 = arith.constant 3 : i64
+    %c3_i64_41 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %92 = arith.muli %89, %89 : i64
-    %93 = arith.divui %92, %c512_i64 : i64
-    %94 = arith.muli %89, %c3_i64_48 : i64
-    %95 = arith.addi %93, %94 : i64
-    %c3_i64_49 = arith.constant 3 : i64
-    %c512_i64_50 = arith.constant 512 : i64
-    %96 = arith.muli %85, %85 : i64
-    %97 = arith.divui %96, %c512_i64_50 : i64
-    %98 = arith.muli %85, %c3_i64_49 : i64
-    %99 = arith.addi %97, %98 : i64
-    %100 = arith.subi %99, %95 : i64
-    %101 = llvm.load %arg1 : !llvm.ptr -> i64
-    %102 = arith.cmpi ult, %101, %100 : i64
-    scf.if %102 {
+    %85 = arith.muli %82, %82 : i64
+    %86 = arith.divui %85, %c512_i64 : i64
+    %87 = arith.muli %82, %c3_i64_41 : i64
+    %88 = arith.addi %86, %87 : i64
+    %c3_i64_42 = arith.constant 3 : i64
+    %c512_i64_43 = arith.constant 512 : i64
+    %89 = arith.muli %78, %78 : i64
+    %90 = arith.divui %89, %c512_i64_43 : i64
+    %91 = arith.muli %78, %c3_i64_42 : i64
+    %92 = arith.addi %90, %91 : i64
+    %93 = arith.subi %92, %88 : i64
+    %94 = llvm.load %arg1 : !llvm.ptr -> i64
+    %95 = arith.cmpi ult, %94, %93 : i64
+    scf.if %95 {
     } else {
-      %135 = arith.subi %101, %100 : i64
-      llvm.store %135, %arg1 : i64, !llvm.ptr
+      %128 = arith.subi %94, %93 : i64
+      llvm.store %128, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_51 = arith.constant 80 : i8
-    cf.cond_br %102, ^bb1(%c80_i8_51 : i8), ^bb39
+    %c80_i8_44 = arith.constant 80 : i8
+    cf.cond_br %95, ^bb1(%c80_i8_44 : i8), ^bb39
   ^bb39:  // pred: ^bb38
-    %103 = call @dora_fn_extend_memory(%arg0, %86) : (!llvm.ptr, i64) -> !llvm.ptr
-    %104 = llvm.getelementptr %103[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %105 = llvm.load %104 : !llvm.ptr -> i8
-    %c0_i8_52 = arith.constant 0 : i8
-    %106 = arith.cmpi ne, %105, %c0_i8_52 : i8
-    cf.cond_br %106, ^bb1(%105 : i8), ^bb40
+    %96 = call @dora_fn_extend_memory(%arg0, %79) : (!llvm.ptr, i64) -> !llvm.ptr
+    %97 = llvm.getelementptr %96[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %98 = llvm.load %97 : !llvm.ptr -> i8
+    %c0_i8_45 = arith.constant 0 : i8
+    %99 = arith.cmpi ne, %98, %c0_i8_45 : i8
+    cf.cond_br %99, ^bb1(%98 : i8), ^bb40
   ^bb40:  // pred: ^bb39
     cf.br ^bb37
   ^bb41:  // pred: ^bb26
-    %c18446744073709551615_i256_53 = arith.constant 18446744073709551615 : i256
-    %107 = arith.cmpi sgt, %61, %c18446744073709551615_i256_53 : i256
-    %c84_i8_54 = arith.constant 84 : i8
-    cf.cond_br %107, ^bb1(%c84_i8_54 : i8), ^bb42
+    %c18446744073709551615_i256_46 = arith.constant 18446744073709551615 : i256
+    %100 = arith.cmpi sgt, %55, %c18446744073709551615_i256_46 : i256
+    %c84_i8_47 = arith.constant 84 : i8
+    cf.cond_br %100, ^bb1(%c84_i8_47 : i8), ^bb42
   ^bb42:  // pred: ^bb41
-    %108 = arith.trunci %61 : i256 to i64
-    %c0_i64_55 = arith.constant 0 : i64
-    %109 = arith.cmpi slt, %108, %c0_i64_55 : i64
-    %c84_i8_56 = arith.constant 84 : i8
-    cf.cond_br %109, ^bb1(%c84_i8_56 : i8), ^bb43
+    %101 = arith.trunci %55 : i256 to i64
+    %c0_i64_48 = arith.constant 0 : i64
+    %102 = arith.cmpi slt, %101, %c0_i64_48 : i64
+    %c84_i8_49 = arith.constant 84 : i8
+    cf.cond_br %102, ^bb1(%c84_i8_49 : i8), ^bb43
   ^bb43:  // pred: ^bb42
-    %110 = arith.addi %108, %67 : i64
-    %c0_i64_57 = arith.constant 0 : i64
-    %111 = arith.cmpi slt, %110, %c0_i64_57 : i64
-    %c84_i8_58 = arith.constant 84 : i8
-    cf.cond_br %111, ^bb1(%c84_i8_58 : i8), ^bb44
+    %103 = arith.addi %101, %60 : i64
+    %c0_i64_50 = arith.constant 0 : i64
+    %104 = arith.cmpi slt, %103, %c0_i64_50 : i64
+    %c84_i8_51 = arith.constant 84 : i8
+    cf.cond_br %104, ^bb1(%c84_i8_51 : i8), ^bb44
   ^bb44:  // pred: ^bb43
-    %c31_i64_59 = arith.constant 31 : i64
-    %c32_i64_60 = arith.constant 32 : i64
-    %112 = arith.addi %110, %c31_i64_59 : i64
-    %113 = arith.divui %112, %c32_i64_60 : i64
-    %c32_i64_61 = arith.constant 32 : i64
-    %114 = arith.muli %113, %c32_i64_61 : i64
-    %115 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_62 = arith.constant 31 : i64
-    %c32_i64_63 = arith.constant 32 : i64
-    %116 = arith.addi %115, %c31_i64_62 : i64
-    %117 = arith.divui %116, %c32_i64_63 : i64
-    %118 = arith.muli %117, %c32_i64_61 : i64
-    %119 = arith.cmpi ult, %118, %114 : i64
-    cf.cond_br %119, ^bb46, ^bb45
+    %c31_i64_52 = arith.constant 31 : i64
+    %c32_i64_53 = arith.constant 32 : i64
+    %105 = arith.addi %103, %c31_i64_52 : i64
+    %106 = arith.divui %105, %c32_i64_53 : i64
+    %c32_i64_54 = arith.constant 32 : i64
+    %107 = arith.muli %106, %c32_i64_54 : i64
+    %108 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_55 = arith.constant 31 : i64
+    %c32_i64_56 = arith.constant 32 : i64
+    %109 = arith.addi %108, %c31_i64_55 : i64
+    %110 = arith.divui %109, %c32_i64_56 : i64
+    %111 = arith.muli %110, %c32_i64_54 : i64
+    %112 = arith.cmpi ult, %111, %107 : i64
+    cf.cond_br %112, ^bb46, ^bb45
   ^bb45:  // 2 preds: ^bb44, ^bb48
     cf.br ^bb27
   ^bb46:  // pred: ^bb44
-    %c3_i64_64 = arith.constant 3 : i64
-    %c512_i64_65 = arith.constant 512 : i64
-    %120 = arith.muli %117, %117 : i64
-    %121 = arith.divui %120, %c512_i64_65 : i64
-    %122 = arith.muli %117, %c3_i64_64 : i64
-    %123 = arith.addi %121, %122 : i64
-    %c3_i64_66 = arith.constant 3 : i64
-    %c512_i64_67 = arith.constant 512 : i64
-    %124 = arith.muli %113, %113 : i64
-    %125 = arith.divui %124, %c512_i64_67 : i64
-    %126 = arith.muli %113, %c3_i64_66 : i64
-    %127 = arith.addi %125, %126 : i64
-    %128 = arith.subi %127, %123 : i64
-    %129 = llvm.load %arg1 : !llvm.ptr -> i64
-    %130 = arith.cmpi ult, %129, %128 : i64
-    scf.if %130 {
+    %c3_i64_57 = arith.constant 3 : i64
+    %c512_i64_58 = arith.constant 512 : i64
+    %113 = arith.muli %110, %110 : i64
+    %114 = arith.divui %113, %c512_i64_58 : i64
+    %115 = arith.muli %110, %c3_i64_57 : i64
+    %116 = arith.addi %114, %115 : i64
+    %c3_i64_59 = arith.constant 3 : i64
+    %c512_i64_60 = arith.constant 512 : i64
+    %117 = arith.muli %106, %106 : i64
+    %118 = arith.divui %117, %c512_i64_60 : i64
+    %119 = arith.muli %106, %c3_i64_59 : i64
+    %120 = arith.addi %118, %119 : i64
+    %121 = arith.subi %120, %116 : i64
+    %122 = llvm.load %arg1 : !llvm.ptr -> i64
+    %123 = arith.cmpi ult, %122, %121 : i64
+    scf.if %123 {
     } else {
-      %135 = arith.subi %129, %128 : i64
-      llvm.store %135, %arg1 : i64, !llvm.ptr
+      %128 = arith.subi %122, %121 : i64
+      llvm.store %128, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_68 = arith.constant 80 : i8
-    cf.cond_br %130, ^bb1(%c80_i8_68 : i8), ^bb47
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %123, ^bb1(%c80_i8_61 : i8), ^bb47
   ^bb47:  // pred: ^bb46
-    %131 = call @dora_fn_extend_memory(%arg0, %114) : (!llvm.ptr, i64) -> !llvm.ptr
-    %132 = llvm.getelementptr %131[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %133 = llvm.load %132 : !llvm.ptr -> i8
-    %c0_i8_69 = arith.constant 0 : i8
-    %134 = arith.cmpi ne, %133, %c0_i8_69 : i8
-    cf.cond_br %134, ^bb1(%133 : i8), ^bb48
+    %124 = call @dora_fn_extend_memory(%arg0, %107) : (!llvm.ptr, i64) -> !llvm.ptr
+    %125 = llvm.getelementptr %124[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %126 = llvm.load %125 : !llvm.ptr -> i8
+    %c0_i8_62 = arith.constant 0 : i8
+    %127 = arith.cmpi ne, %126, %c0_i8_62 : i8
+    cf.cond_br %127, ^bb1(%126 : i8), ^bb48
   ^bb48:  // pred: ^bb47
     cf.br ^bb45
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c2_i256 = arith.constant 2 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c2_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,67 +96,66 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c1_i256 = arith.constant 1 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %23 = llvm.getelementptr %22[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %24 = llvm.getelementptr %22[-2] : (!llvm.ptr) -> !llvm.ptr, i256
-    %25 = llvm.load %23 : !llvm.ptr -> i256
-    %26 = llvm.load %24 : !llvm.ptr -> i256
-    llvm.store %25, %24 : i256, !llvm.ptr
-    llvm.store %26, %23 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.getelementptr %20[-2] : (!llvm.ptr) -> !llvm.ptr, i256
+    %23 = llvm.load %21 : !llvm.ptr -> i256
+    %24 = llvm.load %22 : !llvm.ptr -> i256
+    llvm.store %23, %22 : i256, !llvm.ptr
+    llvm.store %24, %21 : i256, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_7 = arith.constant 1024 : i64
-    %27 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_8 = arith.constant 0 : i64
-    %28 = arith.addi %27, %c0_i64_8 : i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_7 = arith.constant 0 : i64
+    %26 = arith.addi %25, %c0_i64_7 : i64
+    llvm.store %26, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %29 = arith.cmpi ult, %27, %c2_i64 : i64
+    %27 = arith.cmpi ult, %25, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %29, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %30 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_9 = arith.constant 3 : i64
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_8 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %31 = arith.cmpi uge, %30, %c3_i64_9 : i64
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %31, ^bb14, ^bb1(%c80_i8_10 : i8)
+    %29 = arith.cmpi uge, %28, %c3_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %29, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %32 = arith.subi %30, %c3_i64_9 : i64
-    llvm.store %32, %arg1 : i64, !llvm.ptr
+    %30 = arith.subi %28, %c3_i64_8 : i64
+    llvm.store %30, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_11 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %33, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap2.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_swap2.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c2_i256 = arith.constant 2 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c2_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,95 +96,93 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c1_i256 = arith.constant 1 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
-    %33 = llvm.getelementptr %31[-3] : (!llvm.ptr) -> !llvm.ptr, i256
-    %34 = llvm.load %32 : !llvm.ptr -> i256
-    %35 = llvm.load %33 : !llvm.ptr -> i256
-    llvm.store %34, %33 : i256, !llvm.ptr
-    llvm.store %35, %32 : i256, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.getelementptr %28[-3] : (!llvm.ptr) -> !llvm.ptr, i256
+    %31 = llvm.load %29 : !llvm.ptr -> i256
+    %32 = llvm.load %30 : !llvm.ptr -> i256
+    llvm.store %31, %30 : i256, !llvm.ptr
+    llvm.store %32, %29 : i256, !llvm.ptr
     cf.br ^bb19
   ^bb16:  // pred: ^bb18
-    %c1024_i64_13 = arith.constant 1024 : i64
-    %36 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_14 = arith.constant 0 : i64
-    %37 = arith.addi %36, %c0_i64_14 : i64
-    %c3_i64_15 = arith.constant 3 : i64
-    %38 = arith.cmpi ult, %36, %c3_i64_15 : i64
+    %c1024_i64_11 = arith.constant 1024 : i64
+    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %34 = arith.addi %33, %c0_i64_12 : i64
+    llvm.store %34, %arg3 : i64, !llvm.ptr
+    %c3_i64_13 = arith.constant 3 : i64
+    %35 = arith.cmpi ult, %33, %c3_i64_13 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %38, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_16 = arith.constant 3 : i64
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_14 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %40 = arith.cmpi uge, %39, %c3_i64_16 : i64
-    %c80_i8_17 = arith.constant 80 : i8
-    cf.cond_br %40, ^bb18, ^bb1(%c80_i8_17 : i8)
+    %37 = arith.cmpi uge, %36, %c3_i64_14 : i64
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %37, ^bb18, ^bb1(%c80_i8_15 : i8)
   ^bb18:  // pred: ^bb17
-    %41 = arith.subi %39, %c3_i64_16 : i64
-    llvm.store %41, %arg1 : i64, !llvm.ptr
+    %38 = arith.subi %36, %c3_i64_14 : i64
+    llvm.store %38, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb15
-    %c0_i64_18 = arith.constant 0 : i64
+    %c0_i64_16 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %42 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_18, %c0_i64_18, %42, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_16, %c0_i64_16, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_0.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c65535_i256 = arith.constant 65535 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c65535_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,84 +96,80 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %30 = arith.cmpi ne, %29, %c0_i8 : i8
+    %27 = arith.cmpi ne, %26, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %30, ^bb1(%c87_i8 : i8), ^bb12
+    cf.cond_br %27, ^bb1(%c87_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
     %c1_i256 = arith.constant 1 : i256
-    %31 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %31 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %32 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %32 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_tstore(%arg0, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %28 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %28 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %29 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %29 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_tstore(%arg0, %28, %29) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %34 = arith.addi %33, %c-2_i64 : i64
+    %31 = arith.addi %30, %c-2_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c100_i64 = arith.constant 100 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c100_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb15, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c100_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %38 = arith.subi %36, %c100_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c100_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_1.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 8 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c65535_i256 = arith.constant 65535 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c65535_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,84 +96,80 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c8965_i256 = arith.constant 8965 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c8965_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c8965_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %30 = arith.cmpi ne, %29, %c0_i8 : i8
+    %27 = arith.cmpi ne, %26, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %30, ^bb1(%c87_i8 : i8), ^bb12
+    cf.cond_br %27, ^bb1(%c87_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
     %c1_i256 = arith.constant 1 : i256
-    %31 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %31 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %32 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %32 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_tstore(%arg0, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %28 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %28 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %29 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %29 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_tstore(%arg0, %28, %29) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb16
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %34 = arith.addi %33, %c-2_i64 : i64
+    %31 = arith.addi %30, %c-2_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c100_i64 = arith.constant 100 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c100_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb15, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c100_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %38 = arith.subi %36, %c100_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c100_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb12
-    %c0_i64_12 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_12, %c0_i64_12, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_tload.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_tstore_tload.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 12 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb13, ^bb14, ^bb17, ^bb18, ^bb21, ^bb22
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c46_i256 = arith.constant 46 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c46_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,153 +96,145 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb14
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb13
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = call @dora_fn_is_static(%arg0) : (!llvm.ptr) -> i8
     %c0_i8 = arith.constant 0 : i8
-    %30 = arith.cmpi ne, %29, %c0_i8 : i8
+    %27 = arith.cmpi ne, %26, %c0_i8 : i8
     %c87_i8 = arith.constant 87 : i8
-    cf.cond_br %30, ^bb1(%c87_i8 : i8), ^bb12
+    cf.cond_br %27, ^bb1(%c87_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
     %c1_i256 = arith.constant 1 : i256
-    %31 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %31 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %32 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %32 {alignment = 1 : i64} : i256, !llvm.ptr
-    call @dora_fn_tstore(%arg0, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %28 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %28 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %29 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %29 {alignment = 1 : i64} : i256, !llvm.ptr
+    call @dora_fn_tstore(%arg0, %28, %29) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     cf.br ^bb18
   ^bb13:  // pred: ^bb15
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %30 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %34 = arith.addi %33, %c-2_i64 : i64
+    %31 = arith.addi %30, %c-2_i64 : i64
+    llvm.store %31, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %32 = arith.cmpi ult, %30, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %32, ^bb1(%c91_i8 : i8), ^bb11
   ^bb14:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
     %c100_i64 = arith.constant 100 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c100_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb15, ^bb1(%c80_i8_11 : i8)
+    %34 = arith.cmpi uge, %33, %c100_i64 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %34, ^bb15, ^bb1(%c80_i8_8 : i8)
   ^bb15:  // pred: ^bb14
-    %38 = arith.subi %36, %c100_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %35 = arith.subi %33, %c100_i64 : i64
+    llvm.store %35, %arg1 : i64, !llvm.ptr
     cf.br ^bb13
   ^bb16:  // pred: ^bb17
-    %c0_i256_12 = arith.constant 0 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_13 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_12, %40 : i256, !llvm.ptr
+    %c0_i256_9 = arith.constant 0 : i256
+    %36 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_9, %36 : i256, !llvm.ptr
+    %37 = llvm.getelementptr %36[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %37, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb17:  // pred: ^bb19
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_15 : i64
-    %44 = arith.cmpi ult, %c1024_i64_14, %43 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_16 : i8), ^bb16
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %38 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %39 = arith.addi %38, %c1_i64_11 : i64
+    llvm.store %39, %arg3 : i64, !llvm.ptr
+    %40 = arith.cmpi ult, %c1024_i64_10, %39 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %40, ^bb1(%c92_i8_12 : i8), ^bb16
   ^bb18:  // pred: ^bb12
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %41 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb19, ^bb1(%c80_i8_18 : i8)
+    %42 = arith.cmpi uge, %41, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %42, ^bb19, ^bb1(%c80_i8_14 : i8)
   ^bb19:  // pred: ^bb18
-    %47 = arith.subi %45, %c3_i64_17 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %43 = arith.subi %41, %c3_i64_13 : i64
+    llvm.store %43, %arg1 : i64, !llvm.ptr
     cf.br ^bb17
   ^bb20:  // pred: ^bb21
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %49 = arith.subi %48, %c1_i64_19 : i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %49, %arg3 : i64, !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i256
-    %c1_i256_20 = arith.constant 1 : i256
-    %52 = llvm.alloca %c1_i256_20 x i256 : (i256) -> !llvm.ptr
-    llvm.store %51, %52 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_21 = arith.constant 1 : i256
-    %53 = llvm.alloca %c1_i256_21 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_tload(%arg0, %52, %53) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-    %54 = llvm.load %53 : !llvm.ptr -> i256
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %56 = llvm.getelementptr %arg2[%55] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_22 = arith.constant 1 : i64
-    %57 = arith.addi %55, %c1_i64_22 : i64
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    llvm.store %54, %56 : i256, !llvm.ptr
+    %44 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %45 = llvm.getelementptr %44[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %46 = llvm.load %45 : !llvm.ptr -> i256
+    llvm.store %45, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_15 = arith.constant 1 : i256
+    %47 = llvm.alloca %c1_i256_15 x i256 : (i256) -> !llvm.ptr
+    llvm.store %46, %47 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_16 = arith.constant 1 : i256
+    %48 = llvm.alloca %c1_i256_16 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_tload(%arg0, %47, %48) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %49 = llvm.load %48 : !llvm.ptr -> i256
+    %50 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %49, %50 : i256, !llvm.ptr
+    %51 = llvm.getelementptr %50[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %51, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_23 = arith.constant 1024 : i64
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_24 = arith.constant 0 : i64
-    %59 = arith.addi %58, %c0_i64_24 : i64
-    %c1_i64_25 = arith.constant 1 : i64
-    %60 = arith.cmpi ult, %58, %c1_i64_25 : i64
-    %c91_i8_26 = arith.constant 91 : i8
-    cf.cond_br %60, ^bb1(%c91_i8_26 : i8), ^bb20
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %52 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_18 = arith.constant 0 : i64
+    %53 = arith.addi %52, %c0_i64_18 : i64
+    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %c1_i64_19 = arith.constant 1 : i64
+    %54 = arith.cmpi ult, %52, %c1_i64_19 : i64
+    %c91_i8_20 = arith.constant 91 : i8
+    cf.cond_br %54, ^bb1(%c91_i8_20 : i8), ^bb20
   ^bb22:  // pred: ^bb16
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c100_i64_27 = arith.constant 100 : i64
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c100_i64_21 = arith.constant 100 : i64
     call @dora_fn_nop() : () -> ()
-    %62 = arith.cmpi uge, %61, %c100_i64_27 : i64
-    %c80_i8_28 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb23, ^bb1(%c80_i8_28 : i8)
+    %56 = arith.cmpi uge, %55, %c100_i64_21 : i64
+    %c80_i8_22 = arith.constant 80 : i8
+    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_22 : i8)
   ^bb23:  // pred: ^bb22
-    %63 = arith.subi %61, %c100_i64_27 : i64
-    llvm.store %63, %arg1 : i64, !llvm.ptr
+    %57 = arith.subi %55, %c100_i64_21 : i64
+    llvm.store %57, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_29 = arith.constant 0 : i64
+    %c0_i64_23 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_29, %c0_i64_29, %64, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_23, %c0_i64_23, %58, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,212 +96,205 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256_1 = arith.constant 0 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_2 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_1, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_1, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_4 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_4 : i64
-    %17 = arith.cmpi ult, %c1024_i64_3, %16 : i64
-    %c92_i8_5 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_5 : i8), ^bb7
+    %c1024_i64_2 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_3 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_3 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_2, %15 : i64
+    %c92_i8_4 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_4 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_6 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_5 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_6 : i64
-    %c80_i8_7 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_7 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_5 : i64
+    %c80_i8_6 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_6 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_6 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_5 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c32_i256 = arith.constant 32 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_8 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_8 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_10 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_10 : i64
-    %26 = arith.cmpi ult, %c1024_i64_9, %25 : i64
-    %c92_i8_11 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_11 : i8), ^bb11
+    %c1024_i64_7 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_8 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_8 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_7, %23 : i64
+    %c92_i8_9 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_9 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_12 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_10 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_13 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_10 : i64
+    %c80_i8_11 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_11 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_12 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_10 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb21
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_14 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_15 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_16 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_16 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_17 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_17 : i64
-    %c84_i8_18 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_18 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_12 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_12 : i64
+    %c84_i8_13 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_13 : i8), ^bb17
   ^bb17:  // pred: ^bb16
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %45 = arith.addi %43, %c31_i64 : i64
-    %46 = arith.divui %45, %c32_i64 : i64
-    %c3_i64_19 = arith.constant 3 : i64
-    %47 = arith.muli %46, %c3_i64_19 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %47 : i64
-    scf.if %49 {
+    %40 = arith.addi %38, %c31_i64 : i64
+    %41 = arith.divui %40, %c32_i64 : i64
+    %c3_i64_14 = arith.constant 3 : i64
+    %42 = arith.muli %41, %c3_i64_14 : i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %42 : i64
+    scf.if %44 {
     } else {
-      %92 = arith.subi %48, %47 : i64
-      llvm.store %92, %arg1 : i64, !llvm.ptr
+      %87 = arith.subi %43, %42 : i64
+      llvm.store %87, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_20 : i8), ^bb18
+    %c80_i8_15 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_15 : i8), ^bb18
   ^bb18:  // pred: ^bb17
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i64_21 = arith.constant 0 : i64
-    %51 = arith.cmpi ne, %43, %c0_i64_21 : i64
-    cf.cond_br %51, ^bb25, ^bb19
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i64_16 = arith.constant 0 : i64
+    %46 = arith.cmpi ne, %38, %c0_i64_16 : i64
+    cf.cond_br %46, ^bb25, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb29
-    %52 = arith.trunci %33 : i256 to i64
-    %53 = call @dora_fn_returndata_copy(%arg0, %52, %50, %43) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %47 = arith.trunci %30 : i256 to i64
+    %48 = call @dora_fn_returndata_copy(%arg0, %47, %45, %38) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb20
+    %51 = arith.cmpi ne, %50, %c0_i8 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %52 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %58 = arith.addi %57, %c-3_i64 : i64
-    %c3_i64_23 = arith.constant 3 : i64
-    %59 = arith.cmpi ult, %57, %c3_i64_23 : i64
+    %53 = arith.addi %52, %c-3_i64 : i64
+    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %c3_i64_18 = arith.constant 3 : i64
+    %54 = arith.cmpi ult, %52, %c3_i64_18 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %59, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %54, ^bb1(%c91_i8 : i8), ^bb15
   ^bb22:  // pred: ^bb11
-    %60 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_24 = arith.constant 3 : i64
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_19 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %61 = arith.cmpi uge, %60, %c3_i64_24 : i64
-    %c80_i8_25 = arith.constant 80 : i8
-    cf.cond_br %61, ^bb23, ^bb1(%c80_i8_25 : i8)
+    %56 = arith.cmpi uge, %55, %c3_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_20 : i8)
   ^bb23:  // pred: ^bb22
-    %62 = arith.subi %60, %c3_i64_24 : i64
-    llvm.store %62, %arg1 : i64, !llvm.ptr
+    %57 = arith.subi %55, %c3_i64_19 : i64
+    llvm.store %57, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_26 = arith.constant 0 : i64
+    %c0_i64_21 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %63, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_21, %c0_i64_21, %58, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb25:  // pred: ^bb18
-    %c18446744073709551615_i256_27 = arith.constant 18446744073709551615 : i256
-    %64 = arith.cmpi sgt, %33, %c18446744073709551615_i256_27 : i256
-    %c84_i8_28 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_28 : i8), ^bb26
+    %c18446744073709551615_i256_22 = arith.constant 18446744073709551615 : i256
+    %59 = arith.cmpi sgt, %30, %c18446744073709551615_i256_22 : i256
+    %c84_i8_23 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_23 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %65 = arith.trunci %33 : i256 to i64
-    %c0_i64_29 = arith.constant 0 : i64
-    %66 = arith.cmpi slt, %65, %c0_i64_29 : i64
-    %c84_i8_30 = arith.constant 84 : i8
-    cf.cond_br %66, ^bb1(%c84_i8_30 : i8), ^bb27
+    %60 = arith.trunci %30 : i256 to i64
+    %c0_i64_24 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_24 : i64
+    %c84_i8_25 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_25 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %67 = arith.addi %65, %43 : i64
-    %c0_i64_31 = arith.constant 0 : i64
-    %68 = arith.cmpi slt, %67, %c0_i64_31 : i64
-    %c84_i8_32 = arith.constant 84 : i8
-    cf.cond_br %68, ^bb1(%c84_i8_32 : i8), ^bb28
+    %62 = arith.addi %60, %38 : i64
+    %c0_i64_26 = arith.constant 0 : i64
+    %63 = arith.cmpi slt, %62, %c0_i64_26 : i64
+    %c84_i8_27 = arith.constant 84 : i8
+    cf.cond_br %63, ^bb1(%c84_i8_27 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %c31_i64_33 = arith.constant 31 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %69 = arith.addi %67, %c31_i64_33 : i64
-    %70 = arith.divui %69, %c32_i64_34 : i64
-    %c32_i64_35 = arith.constant 32 : i64
-    %71 = arith.muli %70, %c32_i64_35 : i64
-    %72 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_36 = arith.constant 31 : i64
-    %c32_i64_37 = arith.constant 32 : i64
-    %73 = arith.addi %72, %c31_i64_36 : i64
-    %74 = arith.divui %73, %c32_i64_37 : i64
-    %75 = arith.muli %74, %c32_i64_35 : i64
-    %76 = arith.cmpi ult, %75, %71 : i64
-    cf.cond_br %76, ^bb30, ^bb29
+    %c31_i64_28 = arith.constant 31 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %64 = arith.addi %62, %c31_i64_28 : i64
+    %65 = arith.divui %64, %c32_i64_29 : i64
+    %c32_i64_30 = arith.constant 32 : i64
+    %66 = arith.muli %65, %c32_i64_30 : i64
+    %67 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_31 = arith.constant 31 : i64
+    %c32_i64_32 = arith.constant 32 : i64
+    %68 = arith.addi %67, %c31_i64_31 : i64
+    %69 = arith.divui %68, %c32_i64_32 : i64
+    %70 = arith.muli %69, %c32_i64_30 : i64
+    %71 = arith.cmpi ult, %70, %66 : i64
+    cf.cond_br %71, ^bb30, ^bb29
   ^bb29:  // 2 preds: ^bb28, ^bb32
     cf.br ^bb19
   ^bb30:  // pred: ^bb28
-    %c3_i64_38 = arith.constant 3 : i64
+    %c3_i64_33 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %77 = arith.muli %74, %74 : i64
-    %78 = arith.divui %77, %c512_i64 : i64
-    %79 = arith.muli %74, %c3_i64_38 : i64
-    %80 = arith.addi %78, %79 : i64
-    %c3_i64_39 = arith.constant 3 : i64
-    %c512_i64_40 = arith.constant 512 : i64
-    %81 = arith.muli %70, %70 : i64
-    %82 = arith.divui %81, %c512_i64_40 : i64
-    %83 = arith.muli %70, %c3_i64_39 : i64
-    %84 = arith.addi %82, %83 : i64
-    %85 = arith.subi %84, %80 : i64
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %87 = arith.cmpi ult, %86, %85 : i64
-    scf.if %87 {
+    %72 = arith.muli %69, %69 : i64
+    %73 = arith.divui %72, %c512_i64 : i64
+    %74 = arith.muli %69, %c3_i64_33 : i64
+    %75 = arith.addi %73, %74 : i64
+    %c3_i64_34 = arith.constant 3 : i64
+    %c512_i64_35 = arith.constant 512 : i64
+    %76 = arith.muli %65, %65 : i64
+    %77 = arith.divui %76, %c512_i64_35 : i64
+    %78 = arith.muli %65, %c3_i64_34 : i64
+    %79 = arith.addi %77, %78 : i64
+    %80 = arith.subi %79, %75 : i64
+    %81 = llvm.load %arg1 : !llvm.ptr -> i64
+    %82 = arith.cmpi ult, %81, %80 : i64
+    scf.if %82 {
     } else {
-      %92 = arith.subi %86, %85 : i64
-      llvm.store %92, %arg1 : i64, !llvm.ptr
+      %87 = arith.subi %81, %80 : i64
+      llvm.store %87, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb1(%c80_i8_41 : i8), ^bb31
+    %c80_i8_36 = arith.constant 80 : i8
+    cf.cond_br %82, ^bb1(%c80_i8_36 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %88 = call @dora_fn_extend_memory(%arg0, %71) : (!llvm.ptr, i64) -> !llvm.ptr
-    %89 = llvm.getelementptr %88[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %90 = llvm.load %89 : !llvm.ptr -> i8
-    %c0_i8_42 = arith.constant 0 : i8
-    %91 = arith.cmpi ne, %90, %c0_i8_42 : i8
-    cf.cond_br %91, ^bb1(%90 : i8), ^bb32
+    %83 = call @dora_fn_extend_memory(%arg0, %66) : (!llvm.ptr, i64) -> !llvm.ptr
+    %84 = llvm.getelementptr %83[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %85 = llvm.load %84 : !llvm.ptr -> i8
+    %c0_i8_37 = arith.constant 0 : i8
+    %86 = arith.cmpi ne, %85, %c0_i8_37 : i8
+    cf.cond_br %86, ^bb1(%85 : i8), ^bb32
   ^bb32:  // pred: ^bb31
     cf.br ^bb29
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_out_of_bounds.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_out_of_bounds.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,212 +96,205 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c50_i256 = arith.constant 50 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c50_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c50_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c10_i256 = arith.constant 10 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb21
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_17 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_12 : i8), ^bb17
   ^bb17:  // pred: ^bb16
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %45 = arith.addi %43, %c31_i64 : i64
-    %46 = arith.divui %45, %c32_i64 : i64
-    %c3_i64_18 = arith.constant 3 : i64
-    %47 = arith.muli %46, %c3_i64_18 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %47 : i64
-    scf.if %49 {
+    %40 = arith.addi %38, %c31_i64 : i64
+    %41 = arith.divui %40, %c32_i64 : i64
+    %c3_i64_13 = arith.constant 3 : i64
+    %42 = arith.muli %41, %c3_i64_13 : i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %42 : i64
+    scf.if %44 {
     } else {
-      %92 = arith.subi %48, %47 : i64
-      llvm.store %92, %arg1 : i64, !llvm.ptr
+      %87 = arith.subi %43, %42 : i64
+      llvm.store %87, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_19 : i8), ^bb18
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_14 : i8), ^bb18
   ^bb18:  // pred: ^bb17
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i64_20 = arith.constant 0 : i64
-    %51 = arith.cmpi ne, %43, %c0_i64_20 : i64
-    cf.cond_br %51, ^bb25, ^bb19
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i64_15 = arith.constant 0 : i64
+    %46 = arith.cmpi ne, %38, %c0_i64_15 : i64
+    cf.cond_br %46, ^bb25, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb29
-    %52 = arith.trunci %33 : i256 to i64
-    %53 = call @dora_fn_returndata_copy(%arg0, %52, %50, %43) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %47 = arith.trunci %30 : i256 to i64
+    %48 = call @dora_fn_returndata_copy(%arg0, %47, %45, %38) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb20
+    %51 = arith.cmpi ne, %50, %c0_i8 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %52 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %58 = arith.addi %57, %c-3_i64 : i64
-    %c3_i64_22 = arith.constant 3 : i64
-    %59 = arith.cmpi ult, %57, %c3_i64_22 : i64
+    %53 = arith.addi %52, %c-3_i64 : i64
+    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %c3_i64_17 = arith.constant 3 : i64
+    %54 = arith.cmpi ult, %52, %c3_i64_17 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %59, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %54, ^bb1(%c91_i8 : i8), ^bb15
   ^bb22:  // pred: ^bb11
-    %60 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %61 = arith.cmpi uge, %60, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %61, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %56 = arith.cmpi uge, %55, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %62 = arith.subi %60, %c3_i64_23 : i64
-    llvm.store %62, %arg1 : i64, !llvm.ptr
+    %57 = arith.subi %55, %c3_i64_18 : i64
+    llvm.store %57, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_25 = arith.constant 0 : i64
+    %c0_i64_20 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_25, %c0_i64_25, %63, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_20, %c0_i64_20, %58, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb25:  // pred: ^bb18
-    %c18446744073709551615_i256_26 = arith.constant 18446744073709551615 : i256
-    %64 = arith.cmpi sgt, %33, %c18446744073709551615_i256_26 : i256
-    %c84_i8_27 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_27 : i8), ^bb26
+    %c18446744073709551615_i256_21 = arith.constant 18446744073709551615 : i256
+    %59 = arith.cmpi sgt, %30, %c18446744073709551615_i256_21 : i256
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %65 = arith.trunci %33 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %66 = arith.cmpi slt, %65, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %66, ^bb1(%c84_i8_29 : i8), ^bb27
+    %60 = arith.trunci %30 : i256 to i64
+    %c0_i64_23 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_23 : i64
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_24 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %67 = arith.addi %65, %43 : i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %68 = arith.cmpi slt, %67, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %68, ^bb1(%c84_i8_31 : i8), ^bb28
+    %62 = arith.addi %60, %38 : i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %63 = arith.cmpi slt, %62, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %63, ^bb1(%c84_i8_26 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %69 = arith.addi %67, %c31_i64_32 : i64
-    %70 = arith.divui %69, %c32_i64_33 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %71 = arith.muli %70, %c32_i64_34 : i64
-    %72 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %73 = arith.addi %72, %c31_i64_35 : i64
-    %74 = arith.divui %73, %c32_i64_36 : i64
-    %75 = arith.muli %74, %c32_i64_34 : i64
-    %76 = arith.cmpi ult, %75, %71 : i64
-    cf.cond_br %76, ^bb30, ^bb29
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %64 = arith.addi %62, %c31_i64_27 : i64
+    %65 = arith.divui %64, %c32_i64_28 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %66 = arith.muli %65, %c32_i64_29 : i64
+    %67 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_30 = arith.constant 31 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %68 = arith.addi %67, %c31_i64_30 : i64
+    %69 = arith.divui %68, %c32_i64_31 : i64
+    %70 = arith.muli %69, %c32_i64_29 : i64
+    %71 = arith.cmpi ult, %70, %66 : i64
+    cf.cond_br %71, ^bb30, ^bb29
   ^bb29:  // 2 preds: ^bb28, ^bb32
     cf.br ^bb19
   ^bb30:  // pred: ^bb28
-    %c3_i64_37 = arith.constant 3 : i64
+    %c3_i64_32 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %77 = arith.muli %74, %74 : i64
-    %78 = arith.divui %77, %c512_i64 : i64
-    %79 = arith.muli %74, %c3_i64_37 : i64
-    %80 = arith.addi %78, %79 : i64
-    %c3_i64_38 = arith.constant 3 : i64
-    %c512_i64_39 = arith.constant 512 : i64
-    %81 = arith.muli %70, %70 : i64
-    %82 = arith.divui %81, %c512_i64_39 : i64
-    %83 = arith.muli %70, %c3_i64_38 : i64
-    %84 = arith.addi %82, %83 : i64
-    %85 = arith.subi %84, %80 : i64
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %87 = arith.cmpi ult, %86, %85 : i64
-    scf.if %87 {
+    %72 = arith.muli %69, %69 : i64
+    %73 = arith.divui %72, %c512_i64 : i64
+    %74 = arith.muli %69, %c3_i64_32 : i64
+    %75 = arith.addi %73, %74 : i64
+    %c3_i64_33 = arith.constant 3 : i64
+    %c512_i64_34 = arith.constant 512 : i64
+    %76 = arith.muli %65, %65 : i64
+    %77 = arith.divui %76, %c512_i64_34 : i64
+    %78 = arith.muli %65, %c3_i64_33 : i64
+    %79 = arith.addi %77, %78 : i64
+    %80 = arith.subi %79, %75 : i64
+    %81 = llvm.load %arg1 : !llvm.ptr -> i64
+    %82 = arith.cmpi ult, %81, %80 : i64
+    scf.if %82 {
     } else {
-      %92 = arith.subi %86, %85 : i64
-      llvm.store %92, %arg1 : i64, !llvm.ptr
+      %87 = arith.subi %81, %80 : i64
+      llvm.store %87, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb1(%c80_i8_40 : i8), ^bb31
+    %c80_i8_35 = arith.constant 80 : i8
+    cf.cond_br %82, ^bb1(%c80_i8_35 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %88 = call @dora_fn_extend_memory(%arg0, %71) : (!llvm.ptr, i64) -> !llvm.ptr
-    %89 = llvm.getelementptr %88[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %90 = llvm.load %89 : !llvm.ptr -> i8
-    %c0_i8_41 = arith.constant 0 : i8
-    %91 = arith.cmpi ne, %90, %c0_i8_41 : i8
-    cf.cond_br %91, ^bb1(%90 : i8), ^bb32
+    %83 = call @dora_fn_extend_memory(%arg0, %66) : (!llvm.ptr, i64) -> !llvm.ptr
+    %84 = llvm.getelementptr %83[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %85 = llvm.load %84 : !llvm.ptr -> i8
+    %c0_i8_36 = arith.constant 0 : i8
+    %86 = arith.cmpi ne, %85, %c0_i8_36 : i8
+    cf.cond_br %86, ^bb1(%85 : i8), ^bb32
   ^bb32:  // pred: ^bb31
     cf.br ^bb29
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_partial.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__returndatacopy_partial.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 18 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb15, ^bb16, ^bb17, ^bb19, ^bb21, ^bb22, ^bb25, ^bb26, ^bb27, ^bb30, ^bb31
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,212 +96,205 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c10_i256 = arith.constant 10 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c10_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c10_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
     %c20_i256 = arith.constant 20 : i256
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %22 = llvm.getelementptr %arg2[%21] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.addi %21, %c1_i64_7 : i64
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    llvm.store %c20_i256, %22 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c20_i256, %20 : i256, !llvm.ptr
+    %21 = llvm.getelementptr %20[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb22
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %25 = arith.addi %24, %c1_i64_9 : i64
-    %26 = arith.cmpi ult, %c1024_i64_8, %25 : i64
-    %c92_i8_10 = arith.constant 92 : i8
-    cf.cond_br %26, ^bb1(%c92_i8_10 : i8), ^bb11
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %22 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_7 = arith.constant 1 : i64
+    %23 = arith.addi %22, %c1_i64_7 : i64
+    llvm.store %23, %arg3 : i64, !llvm.ptr
+    %24 = arith.cmpi ult, %c1024_i64_6, %23 : i64
+    %c92_i8_8 = arith.constant 92 : i8
+    cf.cond_br %24, ^bb1(%c92_i8_8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %27 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %25 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_9 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %28 = arith.cmpi uge, %27, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %28, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %26 = arith.cmpi uge, %25, %c3_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %26, ^bb14, ^bb1(%c80_i8_10 : i8)
   ^bb14:  // pred: ^bb13
-    %29 = arith.subi %27, %c3_i64_11 : i64
-    llvm.store %29, %arg1 : i64, !llvm.ptr
+    %27 = arith.subi %25, %c3_i64_9 : i64
+    llvm.store %27, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb21
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_13 = arith.constant 1 : i64
-    %31 = arith.subi %30, %c1_i64_13 : i64
-    %32 = llvm.getelementptr %arg2[%31] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %31, %arg3 : i64, !llvm.ptr
+    %28 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %29 = llvm.getelementptr %28[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %30 = llvm.load %29 : !llvm.ptr -> i256
+    llvm.store %29, %0 : !llvm.ptr, !llvm.ptr
+    %31 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %32 = llvm.getelementptr %31[-1] : (!llvm.ptr) -> !llvm.ptr, i256
     %33 = llvm.load %32 : !llvm.ptr -> i256
-    %34 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_14 = arith.constant 1 : i64
-    %35 = arith.subi %34, %c1_i64_14 : i64
-    %36 = llvm.getelementptr %arg2[%35] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %35, %arg3 : i64, !llvm.ptr
-    %37 = llvm.load %36 : !llvm.ptr -> i256
-    %38 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %39 = arith.subi %38, %c1_i64_15 : i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    %41 = llvm.load %40 : !llvm.ptr -> i256
+    llvm.store %32, %0 : !llvm.ptr, !llvm.ptr
+    %34 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %35 = llvm.getelementptr %34[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %36 = llvm.load %35 : !llvm.ptr -> i256
+    llvm.store %35, %0 : !llvm.ptr, !llvm.ptr
     %c18446744073709551615_i256 = arith.constant 18446744073709551615 : i256
-    %42 = arith.cmpi sgt, %41, %c18446744073709551615_i256 : i256
+    %37 = arith.cmpi sgt, %36, %c18446744073709551615_i256 : i256
     %c84_i8 = arith.constant 84 : i8
-    cf.cond_br %42, ^bb1(%c84_i8 : i8), ^bb16
+    cf.cond_br %37, ^bb1(%c84_i8 : i8), ^bb16
   ^bb16:  // pred: ^bb15
-    %43 = arith.trunci %41 : i256 to i64
-    %c0_i64_16 = arith.constant 0 : i64
-    %44 = arith.cmpi slt, %43, %c0_i64_16 : i64
-    %c84_i8_17 = arith.constant 84 : i8
-    cf.cond_br %44, ^bb1(%c84_i8_17 : i8), ^bb17
+    %38 = arith.trunci %36 : i256 to i64
+    %c0_i64_11 = arith.constant 0 : i64
+    %39 = arith.cmpi slt, %38, %c0_i64_11 : i64
+    %c84_i8_12 = arith.constant 84 : i8
+    cf.cond_br %39, ^bb1(%c84_i8_12 : i8), ^bb17
   ^bb17:  // pred: ^bb16
     %c31_i64 = arith.constant 31 : i64
     %c32_i64 = arith.constant 32 : i64
-    %45 = arith.addi %43, %c31_i64 : i64
-    %46 = arith.divui %45, %c32_i64 : i64
-    %c3_i64_18 = arith.constant 3 : i64
-    %47 = arith.muli %46, %c3_i64_18 : i64
-    %48 = llvm.load %arg1 : !llvm.ptr -> i64
-    %49 = arith.cmpi ult, %48, %47 : i64
-    scf.if %49 {
+    %40 = arith.addi %38, %c31_i64 : i64
+    %41 = arith.divui %40, %c32_i64 : i64
+    %c3_i64_13 = arith.constant 3 : i64
+    %42 = arith.muli %41, %c3_i64_13 : i64
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    %44 = arith.cmpi ult, %43, %42 : i64
+    scf.if %44 {
     } else {
-      %92 = arith.subi %48, %47 : i64
-      llvm.store %92, %arg1 : i64, !llvm.ptr
+      %87 = arith.subi %43, %42 : i64
+      llvm.store %87, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_19 = arith.constant 80 : i8
-    cf.cond_br %49, ^bb1(%c80_i8_19 : i8), ^bb18
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %44, ^bb1(%c80_i8_14 : i8), ^bb18
   ^bb18:  // pred: ^bb17
     %c1_i256 = arith.constant 1 : i256
-    %50 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %37, %50 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c0_i64_20 = arith.constant 0 : i64
-    %51 = arith.cmpi ne, %43, %c0_i64_20 : i64
-    cf.cond_br %51, ^bb25, ^bb19
+    %45 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %33, %45 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c0_i64_15 = arith.constant 0 : i64
+    %46 = arith.cmpi ne, %38, %c0_i64_15 : i64
+    cf.cond_br %46, ^bb25, ^bb19
   ^bb19:  // 2 preds: ^bb18, ^bb29
-    %52 = arith.trunci %33 : i256 to i64
-    %53 = call @dora_fn_returndata_copy(%arg0, %52, %50, %43) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
-    %54 = llvm.getelementptr %53[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %55 = llvm.load %54 : !llvm.ptr -> i8
+    %47 = arith.trunci %30 : i256 to i64
+    %48 = call @dora_fn_returndata_copy(%arg0, %47, %45, %38) : (!llvm.ptr, i64, !llvm.ptr, i64) -> !llvm.ptr
+    %49 = llvm.getelementptr %48[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %50 = llvm.load %49 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %56 = arith.cmpi ne, %55, %c0_i8 : i8
-    cf.cond_br %56, ^bb1(%55 : i8), ^bb20
+    %51 = arith.cmpi ne, %50, %c0_i8 : i8
+    cf.cond_br %51, ^bb1(%50 : i8), ^bb20
   ^bb20:  // pred: ^bb19
     cf.br ^bb24
   ^bb21:  // pred: ^bb23
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_16 = arith.constant 1024 : i64
+    %52 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-3_i64 = arith.constant -3 : i64
-    %58 = arith.addi %57, %c-3_i64 : i64
-    %c3_i64_22 = arith.constant 3 : i64
-    %59 = arith.cmpi ult, %57, %c3_i64_22 : i64
+    %53 = arith.addi %52, %c-3_i64 : i64
+    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %c3_i64_17 = arith.constant 3 : i64
+    %54 = arith.cmpi ult, %52, %c3_i64_17 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %59, ^bb1(%c91_i8 : i8), ^bb15
+    cf.cond_br %54, ^bb1(%c91_i8 : i8), ^bb15
   ^bb22:  // pred: ^bb11
-    %60 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_23 = arith.constant 3 : i64
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_18 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %61 = arith.cmpi uge, %60, %c3_i64_23 : i64
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %61, ^bb23, ^bb1(%c80_i8_24 : i8)
+    %56 = arith.cmpi uge, %55, %c3_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %56, ^bb23, ^bb1(%c80_i8_19 : i8)
   ^bb23:  // pred: ^bb22
-    %62 = arith.subi %60, %c3_i64_23 : i64
-    llvm.store %62, %arg1 : i64, !llvm.ptr
+    %57 = arith.subi %55, %c3_i64_18 : i64
+    llvm.store %57, %arg1 : i64, !llvm.ptr
     cf.br ^bb21
   ^bb24:  // pred: ^bb20
-    %c0_i64_25 = arith.constant 0 : i64
+    %c0_i64_20 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_25, %c0_i64_25, %63, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_20, %c0_i64_20, %58, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb25:  // pred: ^bb18
-    %c18446744073709551615_i256_26 = arith.constant 18446744073709551615 : i256
-    %64 = arith.cmpi sgt, %33, %c18446744073709551615_i256_26 : i256
-    %c84_i8_27 = arith.constant 84 : i8
-    cf.cond_br %64, ^bb1(%c84_i8_27 : i8), ^bb26
+    %c18446744073709551615_i256_21 = arith.constant 18446744073709551615 : i256
+    %59 = arith.cmpi sgt, %30, %c18446744073709551615_i256_21 : i256
+    %c84_i8_22 = arith.constant 84 : i8
+    cf.cond_br %59, ^bb1(%c84_i8_22 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %65 = arith.trunci %33 : i256 to i64
-    %c0_i64_28 = arith.constant 0 : i64
-    %66 = arith.cmpi slt, %65, %c0_i64_28 : i64
-    %c84_i8_29 = arith.constant 84 : i8
-    cf.cond_br %66, ^bb1(%c84_i8_29 : i8), ^bb27
+    %60 = arith.trunci %30 : i256 to i64
+    %c0_i64_23 = arith.constant 0 : i64
+    %61 = arith.cmpi slt, %60, %c0_i64_23 : i64
+    %c84_i8_24 = arith.constant 84 : i8
+    cf.cond_br %61, ^bb1(%c84_i8_24 : i8), ^bb27
   ^bb27:  // pred: ^bb26
-    %67 = arith.addi %65, %43 : i64
-    %c0_i64_30 = arith.constant 0 : i64
-    %68 = arith.cmpi slt, %67, %c0_i64_30 : i64
-    %c84_i8_31 = arith.constant 84 : i8
-    cf.cond_br %68, ^bb1(%c84_i8_31 : i8), ^bb28
+    %62 = arith.addi %60, %38 : i64
+    %c0_i64_25 = arith.constant 0 : i64
+    %63 = arith.cmpi slt, %62, %c0_i64_25 : i64
+    %c84_i8_26 = arith.constant 84 : i8
+    cf.cond_br %63, ^bb1(%c84_i8_26 : i8), ^bb28
   ^bb28:  // pred: ^bb27
-    %c31_i64_32 = arith.constant 31 : i64
-    %c32_i64_33 = arith.constant 32 : i64
-    %69 = arith.addi %67, %c31_i64_32 : i64
-    %70 = arith.divui %69, %c32_i64_33 : i64
-    %c32_i64_34 = arith.constant 32 : i64
-    %71 = arith.muli %70, %c32_i64_34 : i64
-    %72 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
-    %c31_i64_35 = arith.constant 31 : i64
-    %c32_i64_36 = arith.constant 32 : i64
-    %73 = arith.addi %72, %c31_i64_35 : i64
-    %74 = arith.divui %73, %c32_i64_36 : i64
-    %75 = arith.muli %74, %c32_i64_34 : i64
-    %76 = arith.cmpi ult, %75, %71 : i64
-    cf.cond_br %76, ^bb30, ^bb29
+    %c31_i64_27 = arith.constant 31 : i64
+    %c32_i64_28 = arith.constant 32 : i64
+    %64 = arith.addi %62, %c31_i64_27 : i64
+    %65 = arith.divui %64, %c32_i64_28 : i64
+    %c32_i64_29 = arith.constant 32 : i64
+    %66 = arith.muli %65, %c32_i64_29 : i64
+    %67 = call @dora_fn_memory_size(%arg0) : (!llvm.ptr) -> i64
+    %c31_i64_30 = arith.constant 31 : i64
+    %c32_i64_31 = arith.constant 32 : i64
+    %68 = arith.addi %67, %c31_i64_30 : i64
+    %69 = arith.divui %68, %c32_i64_31 : i64
+    %70 = arith.muli %69, %c32_i64_29 : i64
+    %71 = arith.cmpi ult, %70, %66 : i64
+    cf.cond_br %71, ^bb30, ^bb29
   ^bb29:  // 2 preds: ^bb28, ^bb32
     cf.br ^bb19
   ^bb30:  // pred: ^bb28
-    %c3_i64_37 = arith.constant 3 : i64
+    %c3_i64_32 = arith.constant 3 : i64
     %c512_i64 = arith.constant 512 : i64
-    %77 = arith.muli %74, %74 : i64
-    %78 = arith.divui %77, %c512_i64 : i64
-    %79 = arith.muli %74, %c3_i64_37 : i64
-    %80 = arith.addi %78, %79 : i64
-    %c3_i64_38 = arith.constant 3 : i64
-    %c512_i64_39 = arith.constant 512 : i64
-    %81 = arith.muli %70, %70 : i64
-    %82 = arith.divui %81, %c512_i64_39 : i64
-    %83 = arith.muli %70, %c3_i64_38 : i64
-    %84 = arith.addi %82, %83 : i64
-    %85 = arith.subi %84, %80 : i64
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %87 = arith.cmpi ult, %86, %85 : i64
-    scf.if %87 {
+    %72 = arith.muli %69, %69 : i64
+    %73 = arith.divui %72, %c512_i64 : i64
+    %74 = arith.muli %69, %c3_i64_32 : i64
+    %75 = arith.addi %73, %74 : i64
+    %c3_i64_33 = arith.constant 3 : i64
+    %c512_i64_34 = arith.constant 512 : i64
+    %76 = arith.muli %65, %65 : i64
+    %77 = arith.divui %76, %c512_i64_34 : i64
+    %78 = arith.muli %65, %c3_i64_33 : i64
+    %79 = arith.addi %77, %78 : i64
+    %80 = arith.subi %79, %75 : i64
+    %81 = llvm.load %arg1 : !llvm.ptr -> i64
+    %82 = arith.cmpi ult, %81, %80 : i64
+    scf.if %82 {
     } else {
-      %92 = arith.subi %86, %85 : i64
-      llvm.store %92, %arg1 : i64, !llvm.ptr
+      %87 = arith.subi %81, %80 : i64
+      llvm.store %87, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_40 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb1(%c80_i8_40 : i8), ^bb31
+    %c80_i8_35 = arith.constant 80 : i8
+    cf.cond_br %82, ^bb1(%c80_i8_35 : i8), ^bb31
   ^bb31:  // pred: ^bb30
-    %88 = call @dora_fn_extend_memory(%arg0, %71) : (!llvm.ptr, i64) -> !llvm.ptr
-    %89 = llvm.getelementptr %88[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %90 = llvm.load %89 : !llvm.ptr -> i8
-    %c0_i8_41 = arith.constant 0 : i8
-    %91 = arith.cmpi ne, %90, %c0_i8_41 : i8
-    cf.cond_br %91, ^bb1(%90 : i8), ^bb32
+    %83 = call @dora_fn_extend_memory(%arg0, %66) : (!llvm.ptr, i64) -> !llvm.ptr
+    %84 = llvm.getelementptr %83[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %85 = llvm.load %84 : !llvm.ptr -> i8
+    %c0_i8_36 = arith.constant 0 : i8
+    %86 = arith.cmpi ne, %85, %c0_i8_36 : i8
+    cf.cond_br %86, ^bb1(%85 : i8), ^bb32
   ^bb32:  // pred: ^bb31
     cf.br ^bb29
   }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__selfbalance.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__selfbalance.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    %4 = call @dora_fn_store_in_selfbalance_ptr(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %5 = llvm.load %3 : !llvm.ptr -> i256
-    %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %7 = llvm.getelementptr %arg2[%6] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %8 = arith.addi %6, %c1_i64 : i64
-    llvm.store %8, %arg3 : i64, !llvm.ptr
-    llvm.store %5, %7 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    %5 = call @dora_fn_store_in_selfbalance_ptr(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %6 = llvm.load %4 : !llvm.ptr -> i256
+    %7 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %6, %7 : i256, !llvm.ptr
+    %8 = llvm.getelementptr %7[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %8, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %9 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %10 = arith.addi %9, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %10 = arith.addi %9, %c1_i64 : i64
+    llvm.store %10, %arg3 : i64, !llvm.ptr
     %11 = arith.cmpi ult, %c1024_i64, %10 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %11, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb21, ^bb23, ^bb24
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb21, ^bb23, ^bb24
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,178 +96,170 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c400_i256 = arith.constant 400 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c400_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c400_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %77 = arith.subi %38, %37 : i64
-      llvm.store %77, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %35, %34 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
-    %c0_i256_14 = arith.constant 0 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_15 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_14, %47 : i256, !llvm.ptr
+    %c0_i256_11 = arith.constant 0 : i256
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb18:  // pred: ^bb20
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_17 : i64
-    %51 = arith.cmpi ult, %c1024_i64_16, %50 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_18 : i8), ^bb17
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_13 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_12, %46 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_14 : i8), ^bb17
   ^bb19:  // pred: ^bb13
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb20, ^bb1(%c80_i8_20 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb20, ^bb1(%c80_i8_16 : i8)
   ^bb20:  // pred: ^bb19
-    %54 = arith.subi %52, %c3_i64_19 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_15 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb23
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %56 = arith.subi %55, %c1_i64_21 : i64
-    %57 = llvm.getelementptr %arg2[%56] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %56, %arg3 : i64, !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i256
-    %c1_i256_22 = arith.constant 1 : i256
-    %59 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
-    llvm.store %58, %59 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_23 = arith.constant 1 : i256
-    %60 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
-    %61 = call @dora_fn_sload(%arg0, %59, %60) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %62 = llvm.getelementptr %61[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %63 = llvm.load %62 : !llvm.ptr -> i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %53 = llvm.load %52 : !llvm.ptr -> i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_17 = arith.constant 1 : i256
+    %54 = llvm.alloca %c1_i256_17 x i256 : (i256) -> !llvm.ptr
+    llvm.store %53, %54 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_18 = arith.constant 1 : i256
+    %55 = llvm.alloca %c1_i256_18 x i256 : (i256) -> !llvm.ptr
+    %56 = call @dora_fn_sload(%arg0, %54, %55) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %57 = llvm.getelementptr %56[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %60 = arith.cmpi ult, %59, %58 : i64
+    scf.if %60 {
     } else {
-      %77 = arith.subi %64, %63 : i64
-      llvm.store %77, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %59, %58 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_24 : i8), ^bb22
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb1(%c80_i8_19 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %66 = llvm.load %60 : !llvm.ptr -> i256
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %68 = llvm.getelementptr %arg2[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_25 = arith.constant 1 : i64
-    %69 = arith.addi %67, %c1_i64_25 : i64
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    llvm.store %66, %68 : i256, !llvm.ptr
+    %61 = llvm.load %55 : !llvm.ptr -> i256
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %61, %62 : i256, !llvm.ptr
+    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_26 = arith.constant 1024 : i64
-    %70 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_27 = arith.constant 0 : i64
-    %71 = arith.addi %70, %c0_i64_27 : i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %72 = arith.cmpi ult, %70, %c1_i64_28 : i64
-    %c91_i8_29 = arith.constant 91 : i8
-    cf.cond_br %72, ^bb1(%c91_i8_29 : i8), ^bb21
+    %c1024_i64_20 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %65 = arith.addi %64, %c0_i64_21 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c1_i64_22 = arith.constant 1 : i64
+    %66 = arith.cmpi ult, %64, %c1_i64_22 : i64
+    %c91_i8_23 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_23 : i8), ^bb21
   ^bb24:  // pred: ^bb17
-    %73 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_30 = arith.constant 0 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_24 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %74 = arith.cmpi uge, %73, %c0_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %74, ^bb25, ^bb1(%c80_i8_31 : i8)
+    %68 = arith.cmpi uge, %67, %c0_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb25, ^bb1(%c80_i8_25 : i8)
   ^bb25:  // pred: ^bb24
-    %75 = arith.subi %73, %c0_i64_30 : i64
-    llvm.store %75, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c0_i64_24 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_32 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_32, %c0_i64_32, %76, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %70, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_high_slot.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_high_slot.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb21, ^bb23, ^bb24
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 14 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb21, ^bb23, ^bb24
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c-1_i256 = arith.constant -1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c-1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,178 +96,170 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c123_i256 = arith.constant 123 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c123_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c123_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %77 = arith.subi %38, %37 : i64
-      llvm.store %77, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %35, %34 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
-    %c-1_i256_14 = arith.constant -1 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_15 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c-1_i256_14, %47 : i256, !llvm.ptr
+    %c-1_i256_11 = arith.constant -1 : i256
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c-1_i256_11, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb24
   ^bb18:  // pred: ^bb20
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_17 : i64
-    %51 = arith.cmpi ult, %c1024_i64_16, %50 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_18 : i8), ^bb17
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_13 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_12, %46 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_14 : i8), ^bb17
   ^bb19:  // pred: ^bb13
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb20, ^bb1(%c80_i8_20 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb20, ^bb1(%c80_i8_16 : i8)
   ^bb20:  // pred: ^bb19
-    %54 = arith.subi %52, %c3_i64_19 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_15 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb23
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_21 = arith.constant 1 : i64
-    %56 = arith.subi %55, %c1_i64_21 : i64
-    %57 = llvm.getelementptr %arg2[%56] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %56, %arg3 : i64, !llvm.ptr
-    %58 = llvm.load %57 : !llvm.ptr -> i256
-    %c1_i256_22 = arith.constant 1 : i256
-    %59 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
-    llvm.store %58, %59 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_23 = arith.constant 1 : i256
-    %60 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
-    %61 = call @dora_fn_sload(%arg0, %59, %60) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %62 = llvm.getelementptr %61[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %63 = llvm.load %62 : !llvm.ptr -> i64
-    %64 = llvm.load %arg1 : !llvm.ptr -> i64
-    %65 = arith.cmpi ult, %64, %63 : i64
-    scf.if %65 {
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %52 = llvm.getelementptr %51[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %53 = llvm.load %52 : !llvm.ptr -> i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_17 = arith.constant 1 : i256
+    %54 = llvm.alloca %c1_i256_17 x i256 : (i256) -> !llvm.ptr
+    llvm.store %53, %54 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_18 = arith.constant 1 : i256
+    %55 = llvm.alloca %c1_i256_18 x i256 : (i256) -> !llvm.ptr
+    %56 = call @dora_fn_sload(%arg0, %54, %55) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %57 = llvm.getelementptr %56[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %58 = llvm.load %57 : !llvm.ptr -> i64
+    %59 = llvm.load %arg1 : !llvm.ptr -> i64
+    %60 = arith.cmpi ult, %59, %58 : i64
+    scf.if %60 {
     } else {
-      %77 = arith.subi %64, %63 : i64
-      llvm.store %77, %arg1 : i64, !llvm.ptr
+      %71 = arith.subi %59, %58 : i64
+      llvm.store %71, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_24 = arith.constant 80 : i8
-    cf.cond_br %65, ^bb1(%c80_i8_24 : i8), ^bb22
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %60, ^bb1(%c80_i8_19 : i8), ^bb22
   ^bb22:  // pred: ^bb21
-    %66 = llvm.load %60 : !llvm.ptr -> i256
-    %67 = llvm.load %arg3 : !llvm.ptr -> i64
-    %68 = llvm.getelementptr %arg2[%67] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_25 = arith.constant 1 : i64
-    %69 = arith.addi %67, %c1_i64_25 : i64
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    llvm.store %66, %68 : i256, !llvm.ptr
+    %61 = llvm.load %55 : !llvm.ptr -> i256
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %61, %62 : i256, !llvm.ptr
+    %63 = llvm.getelementptr %62[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb26
   ^bb23:  // pred: ^bb25
-    %c1024_i64_26 = arith.constant 1024 : i64
-    %70 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_27 = arith.constant 0 : i64
-    %71 = arith.addi %70, %c0_i64_27 : i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %72 = arith.cmpi ult, %70, %c1_i64_28 : i64
-    %c91_i8_29 = arith.constant 91 : i8
-    cf.cond_br %72, ^bb1(%c91_i8_29 : i8), ^bb21
+    %c1024_i64_20 = arith.constant 1024 : i64
+    %64 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_21 = arith.constant 0 : i64
+    %65 = arith.addi %64, %c0_i64_21 : i64
+    llvm.store %65, %arg3 : i64, !llvm.ptr
+    %c1_i64_22 = arith.constant 1 : i64
+    %66 = arith.cmpi ult, %64, %c1_i64_22 : i64
+    %c91_i8_23 = arith.constant 91 : i8
+    cf.cond_br %66, ^bb1(%c91_i8_23 : i8), ^bb21
   ^bb24:  // pred: ^bb17
-    %73 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_30 = arith.constant 0 : i64
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_24 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %74 = arith.cmpi uge, %73, %c0_i64_30 : i64
-    %c80_i8_31 = arith.constant 80 : i8
-    cf.cond_br %74, ^bb25, ^bb1(%c80_i8_31 : i8)
+    %68 = arith.cmpi uge, %67, %c0_i64_24 : i64
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %68, ^bb25, ^bb1(%c80_i8_25 : i8)
   ^bb25:  // pred: ^bb24
-    %75 = arith.subi %73, %c0_i64_30 : i64
-    llvm.store %75, %arg1 : i64, !llvm.ptr
+    %69 = arith.subi %67, %c0_i64_24 : i64
+    llvm.store %69, %arg1 : i64, !llvm.ptr
     cf.br ^bb23
   ^bb26:  // pred: ^bb22
-    %c0_i64_32 = arith.constant 0 : i64
+    %c0_i64_26 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %76 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_32, %c0_i64_32, %76, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %70 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_26, %c0_i64_26, %70, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_multiple_slots.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_multiple_slots.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 27 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb22, ^bb23, ^bb25, ^bb26, ^bb28, ^bb29, ^bb32, ^bb33, ^bb35, ^bb37, ^bb38, ^bb41, ^bb42, ^bb44, ^bb46, ^bb47
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 27 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb22, ^bb23, ^bb25, ^bb26, ^bb28, ^bb29, ^bb32, ^bb33, ^bb35, ^bb37, ^bb38, ^bb41, ^bb42, ^bb44, ^bb46, ^bb47
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,375 +96,358 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c100_i256 = arith.constant 100 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c100_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c100_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %150 = arith.subi %38, %37 : i64
-      llvm.store %150, %arg1 : i64, !llvm.ptr
+      %137 = arith.subi %35, %34 : i64
+      llvm.store %137, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
-    %c1_i256_14 = arith.constant 1 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_15 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_14, %47 : i256, !llvm.ptr
+    %c1_i256_11 = arith.constant 1 : i256
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_11, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb18:  // pred: ^bb20
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_17 : i64
-    %51 = arith.cmpi ult, %c1024_i64_16, %50 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_18 : i8), ^bb17
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_13 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_12, %46 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_14 : i8), ^bb17
   ^bb19:  // pred: ^bb13
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb20, ^bb1(%c80_i8_20 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb20, ^bb1(%c80_i8_16 : i8)
   ^bb20:  // pred: ^bb19
-    %54 = arith.subi %52, %c3_i64_19 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_15 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb22
     %c200_i256 = arith.constant 200 : i256
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %56 = llvm.getelementptr %arg2[%55] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %57 = arith.addi %55, %c1_i64_21 : i64
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    llvm.store %c200_i256, %56 : i256, !llvm.ptr
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c200_i256, %51 : i256, !llvm.ptr
+    %52 = llvm.getelementptr %51[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb22:  // pred: ^bb24
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %59 = arith.addi %58, %c1_i64_23 : i64
-    %60 = arith.cmpi ult, %c1024_i64_22, %59 : i64
-    %c92_i8_24 = arith.constant 92 : i8
-    cf.cond_br %60, ^bb1(%c92_i8_24 : i8), ^bb21
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %54 = arith.addi %53, %c1_i64_18 : i64
+    llvm.store %54, %arg3 : i64, !llvm.ptr
+    %55 = arith.cmpi ult, %c1024_i64_17, %54 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %55, ^bb1(%c92_i8_19 : i8), ^bb21
   ^bb23:  // pred: ^bb17
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_25 = arith.constant 3 : i64
+    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %62 = arith.cmpi uge, %61, %c3_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb24, ^bb1(%c80_i8_26 : i8)
+    %57 = arith.cmpi uge, %56, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %57, ^bb24, ^bb1(%c80_i8_21 : i8)
   ^bb24:  // pred: ^bb23
-    %63 = arith.subi %61, %c3_i64_25 : i64
-    llvm.store %63, %arg1 : i64, !llvm.ptr
+    %58 = arith.subi %56, %c3_i64_20 : i64
+    llvm.store %58, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb28
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %65 = arith.subi %64, %c1_i64_27 : i64
-    %66 = llvm.getelementptr %arg2[%65] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %65, %arg3 : i64, !llvm.ptr
-    %67 = llvm.load %66 : !llvm.ptr -> i256
-    %68 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %69 = arith.subi %68, %c1_i64_28 : i64
-    %70 = llvm.getelementptr %arg2[%69] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> i256
-    %c1_i256_29 = arith.constant 1 : i256
-    %72 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %67, %72 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_30 = arith.constant 1 : i256
-    %73 = llvm.alloca %c1_i256_30 x i256 : (i256) -> !llvm.ptr
-    llvm.store %71, %73 {alignment = 1 : i64} : i256, !llvm.ptr
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %75 = call @dora_fn_sstore(%arg0, %72, %73, %74) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8_31 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %77, %c0_i8_31 : i8
-    cf.cond_br %78, ^bb1(%77 : i8), ^bb26
+    %59 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %0 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %63 = llvm.getelementptr %62[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %64 = llvm.load %63 : !llvm.ptr -> i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_22 = arith.constant 1 : i256
+    %65 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %61, %65 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %66 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %64, %66 {alignment = 1 : i64} : i256, !llvm.ptr
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %68 = call @dora_fn_sstore(%arg0, %65, %66, %67) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %69 = llvm.getelementptr %68[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = llvm.load %69 : !llvm.ptr -> i8
+    %c0_i8_24 = arith.constant 0 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8_24 : i8
+    cf.cond_br %71, ^bb1(%70 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %79 = llvm.getelementptr %75[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %80 = llvm.load %79 : !llvm.ptr -> i64
-    %81 = llvm.load %arg1 : !llvm.ptr -> i64
-    %82 = arith.cmpi ult, %81, %80 : i64
-    scf.if %82 {
+    %72 = llvm.getelementptr %68[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %73 = llvm.load %72 : !llvm.ptr -> i64
+    %74 = llvm.load %arg1 : !llvm.ptr -> i64
+    %75 = arith.cmpi ult, %74, %73 : i64
+    scf.if %75 {
     } else {
-      %150 = arith.subi %81, %80 : i64
-      llvm.store %150, %arg1 : i64, !llvm.ptr
+      %137 = arith.subi %74, %73 : i64
+      llvm.store %137, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %82, ^bb1(%c80_i8_32 : i8), ^bb27
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %75, ^bb1(%c80_i8_25 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb33
   ^bb28:  // pred: ^bb30
-    %c1024_i64_33 = arith.constant 1024 : i64
-    %83 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_34 = arith.constant -2 : i64
-    %84 = arith.addi %83, %c-2_i64_34 : i64
-    %c2_i64_35 = arith.constant 2 : i64
-    %85 = arith.cmpi ult, %83, %c2_i64_35 : i64
-    %c91_i8_36 = arith.constant 91 : i8
-    cf.cond_br %85, ^bb1(%c91_i8_36 : i8), ^bb25
+    %c1024_i64_26 = arith.constant 1024 : i64
+    %76 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_27 = arith.constant -2 : i64
+    %77 = arith.addi %76, %c-2_i64_27 : i64
+    llvm.store %77, %arg3 : i64, !llvm.ptr
+    %c2_i64_28 = arith.constant 2 : i64
+    %78 = arith.cmpi ult, %76, %c2_i64_28 : i64
+    %c91_i8_29 = arith.constant 91 : i8
+    cf.cond_br %78, ^bb1(%c91_i8_29 : i8), ^bb25
   ^bb29:  // pred: ^bb21
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_37 = arith.constant 0 : i64
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_30 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %87 = arith.cmpi uge, %86, %c0_i64_37 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb30, ^bb1(%c80_i8_38 : i8)
+    %80 = arith.cmpi uge, %79, %c0_i64_30 : i64
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %80, ^bb30, ^bb1(%c80_i8_31 : i8)
   ^bb30:  // pred: ^bb29
-    %88 = arith.subi %86, %c0_i64_37 : i64
-    llvm.store %88, %arg1 : i64, !llvm.ptr
+    %81 = arith.subi %79, %c0_i64_30 : i64
+    llvm.store %81, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb32
-    %c0_i256_39 = arith.constant 0 : i256
-    %89 = llvm.load %arg3 : !llvm.ptr -> i64
-    %90 = llvm.getelementptr %arg2[%89] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_40 = arith.constant 1 : i64
-    %91 = arith.addi %89, %c1_i64_40 : i64
-    llvm.store %91, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_39, %90 : i256, !llvm.ptr
+    %c0_i256_32 = arith.constant 0 : i256
+    %82 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_32, %82 : i256, !llvm.ptr
+    %83 = llvm.getelementptr %82[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %83, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb38
   ^bb32:  // pred: ^bb34
-    %c1024_i64_41 = arith.constant 1024 : i64
-    %92 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_42 = arith.constant 1 : i64
-    %93 = arith.addi %92, %c1_i64_42 : i64
-    %94 = arith.cmpi ult, %c1024_i64_41, %93 : i64
-    %c92_i8_43 = arith.constant 92 : i8
-    cf.cond_br %94, ^bb1(%c92_i8_43 : i8), ^bb31
+    %c1024_i64_33 = arith.constant 1024 : i64
+    %84 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %85 = arith.addi %84, %c1_i64_34 : i64
+    llvm.store %85, %arg3 : i64, !llvm.ptr
+    %86 = arith.cmpi ult, %c1024_i64_33, %85 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %86, ^bb1(%c92_i8_35 : i8), ^bb31
   ^bb33:  // pred: ^bb27
-    %95 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_44 = arith.constant 3 : i64
+    %87 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_36 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %96 = arith.cmpi uge, %95, %c3_i64_44 : i64
-    %c80_i8_45 = arith.constant 80 : i8
-    cf.cond_br %96, ^bb34, ^bb1(%c80_i8_45 : i8)
+    %88 = arith.cmpi uge, %87, %c3_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %88, ^bb34, ^bb1(%c80_i8_37 : i8)
   ^bb34:  // pred: ^bb33
-    %97 = arith.subi %95, %c3_i64_44 : i64
-    llvm.store %97, %arg1 : i64, !llvm.ptr
+    %89 = arith.subi %87, %c3_i64_36 : i64
+    llvm.store %89, %arg1 : i64, !llvm.ptr
     cf.br ^bb32
   ^bb35:  // pred: ^bb37
-    %98 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_46 = arith.constant 1 : i64
-    %99 = arith.subi %98, %c1_i64_46 : i64
-    %100 = llvm.getelementptr %arg2[%99] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %99, %arg3 : i64, !llvm.ptr
-    %101 = llvm.load %100 : !llvm.ptr -> i256
-    %c1_i256_47 = arith.constant 1 : i256
-    %102 = llvm.alloca %c1_i256_47 x i256 : (i256) -> !llvm.ptr
-    llvm.store %101, %102 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_48 = arith.constant 1 : i256
-    %103 = llvm.alloca %c1_i256_48 x i256 : (i256) -> !llvm.ptr
-    %104 = call @dora_fn_sload(%arg0, %102, %103) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %105 = llvm.getelementptr %104[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %106 = llvm.load %105 : !llvm.ptr -> i64
-    %107 = llvm.load %arg1 : !llvm.ptr -> i64
-    %108 = arith.cmpi ult, %107, %106 : i64
-    scf.if %108 {
+    %90 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %91 = llvm.getelementptr %90[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %92 = llvm.load %91 : !llvm.ptr -> i256
+    llvm.store %91, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_38 = arith.constant 1 : i256
+    %93 = llvm.alloca %c1_i256_38 x i256 : (i256) -> !llvm.ptr
+    llvm.store %92, %93 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_39 = arith.constant 1 : i256
+    %94 = llvm.alloca %c1_i256_39 x i256 : (i256) -> !llvm.ptr
+    %95 = call @dora_fn_sload(%arg0, %93, %94) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %96 = llvm.getelementptr %95[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %97 = llvm.load %96 : !llvm.ptr -> i64
+    %98 = llvm.load %arg1 : !llvm.ptr -> i64
+    %99 = arith.cmpi ult, %98, %97 : i64
+    scf.if %99 {
     } else {
-      %150 = arith.subi %107, %106 : i64
-      llvm.store %150, %arg1 : i64, !llvm.ptr
+      %137 = arith.subi %98, %97 : i64
+      llvm.store %137, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_49 = arith.constant 80 : i8
-    cf.cond_br %108, ^bb1(%c80_i8_49 : i8), ^bb36
+    %c80_i8_40 = arith.constant 80 : i8
+    cf.cond_br %99, ^bb1(%c80_i8_40 : i8), ^bb36
   ^bb36:  // pred: ^bb35
-    %109 = llvm.load %103 : !llvm.ptr -> i256
-    %110 = llvm.load %arg3 : !llvm.ptr -> i64
-    %111 = llvm.getelementptr %arg2[%110] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_50 = arith.constant 1 : i64
-    %112 = arith.addi %110, %c1_i64_50 : i64
-    llvm.store %112, %arg3 : i64, !llvm.ptr
-    llvm.store %109, %111 : i256, !llvm.ptr
+    %100 = llvm.load %94 : !llvm.ptr -> i256
+    %101 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %100, %101 : i256, !llvm.ptr
+    %102 = llvm.getelementptr %101[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %102, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb42
   ^bb37:  // pred: ^bb39
-    %c1024_i64_51 = arith.constant 1024 : i64
-    %113 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_52 = arith.constant 0 : i64
-    %114 = arith.addi %113, %c0_i64_52 : i64
-    %c1_i64_53 = arith.constant 1 : i64
-    %115 = arith.cmpi ult, %113, %c1_i64_53 : i64
-    %c91_i8_54 = arith.constant 91 : i8
-    cf.cond_br %115, ^bb1(%c91_i8_54 : i8), ^bb35
+    %c1024_i64_41 = arith.constant 1024 : i64
+    %103 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_42 = arith.constant 0 : i64
+    %104 = arith.addi %103, %c0_i64_42 : i64
+    llvm.store %104, %arg3 : i64, !llvm.ptr
+    %c1_i64_43 = arith.constant 1 : i64
+    %105 = arith.cmpi ult, %103, %c1_i64_43 : i64
+    %c91_i8_44 = arith.constant 91 : i8
+    cf.cond_br %105, ^bb1(%c91_i8_44 : i8), ^bb35
   ^bb38:  // pred: ^bb31
-    %116 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_55 = arith.constant 0 : i64
+    %106 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_45 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %117 = arith.cmpi uge, %116, %c0_i64_55 : i64
-    %c80_i8_56 = arith.constant 80 : i8
-    cf.cond_br %117, ^bb39, ^bb1(%c80_i8_56 : i8)
+    %107 = arith.cmpi uge, %106, %c0_i64_45 : i64
+    %c80_i8_46 = arith.constant 80 : i8
+    cf.cond_br %107, ^bb39, ^bb1(%c80_i8_46 : i8)
   ^bb39:  // pred: ^bb38
-    %118 = arith.subi %116, %c0_i64_55 : i64
-    llvm.store %118, %arg1 : i64, !llvm.ptr
+    %108 = arith.subi %106, %c0_i64_45 : i64
+    llvm.store %108, %arg1 : i64, !llvm.ptr
     cf.br ^bb37
   ^bb40:  // pred: ^bb41
-    %c1_i256_57 = arith.constant 1 : i256
-    %119 = llvm.load %arg3 : !llvm.ptr -> i64
-    %120 = llvm.getelementptr %arg2[%119] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_58 = arith.constant 1 : i64
-    %121 = arith.addi %119, %c1_i64_58 : i64
-    llvm.store %121, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_57, %120 : i256, !llvm.ptr
+    %c1_i256_47 = arith.constant 1 : i256
+    %109 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_47, %109 : i256, !llvm.ptr
+    %110 = llvm.getelementptr %109[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %110, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb47
   ^bb41:  // pred: ^bb43
-    %c1024_i64_59 = arith.constant 1024 : i64
-    %122 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_60 = arith.constant 1 : i64
-    %123 = arith.addi %122, %c1_i64_60 : i64
-    %124 = arith.cmpi ult, %c1024_i64_59, %123 : i64
-    %c92_i8_61 = arith.constant 92 : i8
-    cf.cond_br %124, ^bb1(%c92_i8_61 : i8), ^bb40
+    %c1024_i64_48 = arith.constant 1024 : i64
+    %111 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_49 = arith.constant 1 : i64
+    %112 = arith.addi %111, %c1_i64_49 : i64
+    llvm.store %112, %arg3 : i64, !llvm.ptr
+    %113 = arith.cmpi ult, %c1024_i64_48, %112 : i64
+    %c92_i8_50 = arith.constant 92 : i8
+    cf.cond_br %113, ^bb1(%c92_i8_50 : i8), ^bb40
   ^bb42:  // pred: ^bb36
-    %125 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_62 = arith.constant 3 : i64
+    %114 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_51 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %126 = arith.cmpi uge, %125, %c3_i64_62 : i64
-    %c80_i8_63 = arith.constant 80 : i8
-    cf.cond_br %126, ^bb43, ^bb1(%c80_i8_63 : i8)
+    %115 = arith.cmpi uge, %114, %c3_i64_51 : i64
+    %c80_i8_52 = arith.constant 80 : i8
+    cf.cond_br %115, ^bb43, ^bb1(%c80_i8_52 : i8)
   ^bb43:  // pred: ^bb42
-    %127 = arith.subi %125, %c3_i64_62 : i64
-    llvm.store %127, %arg1 : i64, !llvm.ptr
+    %116 = arith.subi %114, %c3_i64_51 : i64
+    llvm.store %116, %arg1 : i64, !llvm.ptr
     cf.br ^bb41
   ^bb44:  // pred: ^bb46
-    %128 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_64 = arith.constant 1 : i64
-    %129 = arith.subi %128, %c1_i64_64 : i64
-    %130 = llvm.getelementptr %arg2[%129] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %129, %arg3 : i64, !llvm.ptr
-    %131 = llvm.load %130 : !llvm.ptr -> i256
-    %c1_i256_65 = arith.constant 1 : i256
-    %132 = llvm.alloca %c1_i256_65 x i256 : (i256) -> !llvm.ptr
-    llvm.store %131, %132 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_66 = arith.constant 1 : i256
-    %133 = llvm.alloca %c1_i256_66 x i256 : (i256) -> !llvm.ptr
-    %134 = call @dora_fn_sload(%arg0, %132, %133) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %135 = llvm.getelementptr %134[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %136 = llvm.load %135 : !llvm.ptr -> i64
-    %137 = llvm.load %arg1 : !llvm.ptr -> i64
-    %138 = arith.cmpi ult, %137, %136 : i64
-    scf.if %138 {
+    %117 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %118 = llvm.getelementptr %117[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %119 = llvm.load %118 : !llvm.ptr -> i256
+    llvm.store %118, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_53 = arith.constant 1 : i256
+    %120 = llvm.alloca %c1_i256_53 x i256 : (i256) -> !llvm.ptr
+    llvm.store %119, %120 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_54 = arith.constant 1 : i256
+    %121 = llvm.alloca %c1_i256_54 x i256 : (i256) -> !llvm.ptr
+    %122 = call @dora_fn_sload(%arg0, %120, %121) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %123 = llvm.getelementptr %122[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %124 = llvm.load %123 : !llvm.ptr -> i64
+    %125 = llvm.load %arg1 : !llvm.ptr -> i64
+    %126 = arith.cmpi ult, %125, %124 : i64
+    scf.if %126 {
     } else {
-      %150 = arith.subi %137, %136 : i64
-      llvm.store %150, %arg1 : i64, !llvm.ptr
+      %137 = arith.subi %125, %124 : i64
+      llvm.store %137, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_67 = arith.constant 80 : i8
-    cf.cond_br %138, ^bb1(%c80_i8_67 : i8), ^bb45
+    %c80_i8_55 = arith.constant 80 : i8
+    cf.cond_br %126, ^bb1(%c80_i8_55 : i8), ^bb45
   ^bb45:  // pred: ^bb44
-    %139 = llvm.load %133 : !llvm.ptr -> i256
-    %140 = llvm.load %arg3 : !llvm.ptr -> i64
-    %141 = llvm.getelementptr %arg2[%140] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_68 = arith.constant 1 : i64
-    %142 = arith.addi %140, %c1_i64_68 : i64
-    llvm.store %142, %arg3 : i64, !llvm.ptr
-    llvm.store %139, %141 : i256, !llvm.ptr
+    %127 = llvm.load %121 : !llvm.ptr -> i256
+    %128 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %127, %128 : i256, !llvm.ptr
+    %129 = llvm.getelementptr %128[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %129, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb49
   ^bb46:  // pred: ^bb48
-    %c1024_i64_69 = arith.constant 1024 : i64
-    %143 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_70 = arith.constant 0 : i64
-    %144 = arith.addi %143, %c0_i64_70 : i64
-    %c1_i64_71 = arith.constant 1 : i64
-    %145 = arith.cmpi ult, %143, %c1_i64_71 : i64
-    %c91_i8_72 = arith.constant 91 : i8
-    cf.cond_br %145, ^bb1(%c91_i8_72 : i8), ^bb44
+    %c1024_i64_56 = arith.constant 1024 : i64
+    %130 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_57 = arith.constant 0 : i64
+    %131 = arith.addi %130, %c0_i64_57 : i64
+    llvm.store %131, %arg3 : i64, !llvm.ptr
+    %c1_i64_58 = arith.constant 1 : i64
+    %132 = arith.cmpi ult, %130, %c1_i64_58 : i64
+    %c91_i8_59 = arith.constant 91 : i8
+    cf.cond_br %132, ^bb1(%c91_i8_59 : i8), ^bb44
   ^bb47:  // pred: ^bb40
-    %146 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_73 = arith.constant 0 : i64
+    %133 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_60 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %147 = arith.cmpi uge, %146, %c0_i64_73 : i64
-    %c80_i8_74 = arith.constant 80 : i8
-    cf.cond_br %147, ^bb48, ^bb1(%c80_i8_74 : i8)
+    %134 = arith.cmpi uge, %133, %c0_i64_60 : i64
+    %c80_i8_61 = arith.constant 80 : i8
+    cf.cond_br %134, ^bb48, ^bb1(%c80_i8_61 : i8)
   ^bb48:  // pred: ^bb47
-    %148 = arith.subi %146, %c0_i64_73 : i64
-    llvm.store %148, %arg1 : i64, !llvm.ptr
+    %135 = arith.subi %133, %c0_i64_60 : i64
+    llvm.store %135, %arg1 : i64, !llvm.ptr
     cf.br ^bb46
   ^bb49:  // pred: ^bb45
-    %c0_i64_75 = arith.constant 0 : i64
+    %c0_i64_62 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %149 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_75, %c0_i64_75, %149, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %136 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_62, %c0_i64_62, %136, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_uninitialized.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sload_uninitialized.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 6 preds: ^bb2, ^bb4, ^bb5, ^bb7, ^bb9, ^bb10
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb10
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,63 +95,60 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb9
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %16 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %15, %16 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_2 = arith.constant 1 : i256
-    %17 = llvm.alloca %c1_i256_2 x i256 : (i256) -> !llvm.ptr
-    %18 = call @dora_fn_sload(%arg0, %16, %17) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
-    %19 = llvm.getelementptr %18[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %20 = llvm.load %19 : !llvm.ptr -> i64
-    %21 = llvm.load %arg1 : !llvm.ptr -> i64
-    %22 = arith.cmpi ult, %21, %20 : i64
-    scf.if %22 {
+    %15 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %14, %15 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_1 = arith.constant 1 : i256
+    %16 = llvm.alloca %c1_i256_1 x i256 : (i256) -> !llvm.ptr
+    %17 = call @dora_fn_sload(%arg0, %15, %16) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> !llvm.ptr
+    %18 = llvm.getelementptr %17[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %19 = llvm.load %18 : !llvm.ptr -> i64
+    %20 = llvm.load %arg1 : !llvm.ptr -> i64
+    %21 = arith.cmpi ult, %20, %19 : i64
+    scf.if %21 {
     } else {
-      %34 = arith.subi %21, %20 : i64
-      llvm.store %34, %arg1 : i64, !llvm.ptr
+      %32 = arith.subi %20, %19 : i64
+      llvm.store %32, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_3 = arith.constant 80 : i8
-    cf.cond_br %22, ^bb1(%c80_i8_3 : i8), ^bb8
+    %c80_i8_2 = arith.constant 80 : i8
+    cf.cond_br %21, ^bb1(%c80_i8_2 : i8), ^bb8
   ^bb8:  // pred: ^bb7
-    %23 = llvm.load %17 : !llvm.ptr -> i256
-    %24 = llvm.load %arg3 : !llvm.ptr -> i64
-    %25 = llvm.getelementptr %arg2[%24] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_4 = arith.constant 1 : i64
-    %26 = arith.addi %24, %c1_i64_4 : i64
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    llvm.store %23, %25 : i256, !llvm.ptr
+    %22 = llvm.load %16 : !llvm.ptr -> i256
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %22, %23 : i256, !llvm.ptr
+    %24 = llvm.getelementptr %23[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb12
   ^bb9:  // pred: ^bb11
-    %c1024_i64_5 = arith.constant 1024 : i64
-    %27 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_6 = arith.constant 0 : i64
-    %28 = arith.addi %27, %c0_i64_6 : i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %29 = arith.cmpi ult, %27, %c1_i64_7 : i64
+    %c1024_i64_3 = arith.constant 1024 : i64
+    %25 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_4 = arith.constant 0 : i64
+    %26 = arith.addi %25, %c0_i64_4 : i64
+    llvm.store %26, %arg3 : i64, !llvm.ptr
+    %c1_i64_5 = arith.constant 1 : i64
+    %27 = arith.cmpi ult, %25, %c1_i64_5 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %29, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %27, ^bb1(%c91_i8 : i8), ^bb7
   ^bb10:  // pred: ^bb3
-    %30 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_8 = arith.constant 0 : i64
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_6 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %31 = arith.cmpi uge, %30, %c0_i64_8 : i64
-    %c80_i8_9 = arith.constant 80 : i8
-    cf.cond_br %31, ^bb11, ^bb1(%c80_i8_9 : i8)
+    %29 = arith.cmpi uge, %28, %c0_i64_6 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %29, ^bb11, ^bb1(%c80_i8_7 : i8)
   ^bb11:  // pred: ^bb10
-    %32 = arith.subi %30, %c0_i64_8 : i64
-    llvm.store %32, %arg1 : i64, !llvm.ptr
+    %30 = arith.subi %28, %c0_i64_6 : i64
+    llvm.store %30, %arg1 : i64, !llvm.ptr
     cf.br ^bb9
   ^bb12:  // pred: ^bb8
-    %c0_i64_10 = arith.constant 0 : i64
+    %c0_i64_8 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %33, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_8, %c0_i64_8, %31, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_basic.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_basic.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,97 +96,93 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c100_i256 = arith.constant 100 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c100_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c100_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %47 = arith.subi %38, %37 : i64
-      llvm.store %47, %arg1 : i64, !llvm.ptr
+      %44 = arith.subi %35, %34 : i64
+      llvm.store %44, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb17
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb13
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %46, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %43, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_high_slot.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_high_slot.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 9 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c-1_i256 = arith.constant -1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c-1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,97 +96,93 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c777_i256 = arith.constant 777 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c777_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c777_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %47 = arith.subi %38, %37 : i64
-      llvm.store %47, %arg1 : i64, !llvm.ptr
+      %44 = arith.subi %35, %34 : i64
+      llvm.store %44, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb17
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb13
-    %c0_i64_14 = arith.constant 0 : i64
+    %c0_i64_11 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %46 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_14, %c0_i64_14, %46, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %43 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_11, %c0_i64_11, %43, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_multiple_slots.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_multiple_slots.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb22, ^bb23, ^bb25, ^bb26, ^bb28, ^bb29
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb22, ^bb23, ^bb25, ^bb26, ^bb28, ^bb29
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,213 +96,204 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c500_i256 = arith.constant 500 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c500_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c500_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %90 = arith.subi %38, %37 : i64
-      llvm.store %90, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %35, %34 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
-    %c1_i256_14 = arith.constant 1 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_15 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c1_i256_14, %47 : i256, !llvm.ptr
+    %c1_i256_11 = arith.constant 1 : i256
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c1_i256_11, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb18:  // pred: ^bb20
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_17 : i64
-    %51 = arith.cmpi ult, %c1024_i64_16, %50 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_18 : i8), ^bb17
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_13 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_12, %46 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_14 : i8), ^bb17
   ^bb19:  // pred: ^bb13
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb20, ^bb1(%c80_i8_20 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb20, ^bb1(%c80_i8_16 : i8)
   ^bb20:  // pred: ^bb19
-    %54 = arith.subi %52, %c3_i64_19 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_15 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb22
     %c600_i256 = arith.constant 600 : i256
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %56 = llvm.getelementptr %arg2[%55] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %57 = arith.addi %55, %c1_i64_21 : i64
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    llvm.store %c600_i256, %56 : i256, !llvm.ptr
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c600_i256, %51 : i256, !llvm.ptr
+    %52 = llvm.getelementptr %51[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb22:  // pred: ^bb24
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %59 = arith.addi %58, %c1_i64_23 : i64
-    %60 = arith.cmpi ult, %c1024_i64_22, %59 : i64
-    %c92_i8_24 = arith.constant 92 : i8
-    cf.cond_br %60, ^bb1(%c92_i8_24 : i8), ^bb21
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %54 = arith.addi %53, %c1_i64_18 : i64
+    llvm.store %54, %arg3 : i64, !llvm.ptr
+    %55 = arith.cmpi ult, %c1024_i64_17, %54 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %55, ^bb1(%c92_i8_19 : i8), ^bb21
   ^bb23:  // pred: ^bb17
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_25 = arith.constant 3 : i64
+    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %62 = arith.cmpi uge, %61, %c3_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb24, ^bb1(%c80_i8_26 : i8)
+    %57 = arith.cmpi uge, %56, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %57, ^bb24, ^bb1(%c80_i8_21 : i8)
   ^bb24:  // pred: ^bb23
-    %63 = arith.subi %61, %c3_i64_25 : i64
-    llvm.store %63, %arg1 : i64, !llvm.ptr
+    %58 = arith.subi %56, %c3_i64_20 : i64
+    llvm.store %58, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb28
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %65 = arith.subi %64, %c1_i64_27 : i64
-    %66 = llvm.getelementptr %arg2[%65] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %65, %arg3 : i64, !llvm.ptr
-    %67 = llvm.load %66 : !llvm.ptr -> i256
-    %68 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %69 = arith.subi %68, %c1_i64_28 : i64
-    %70 = llvm.getelementptr %arg2[%69] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> i256
-    %c1_i256_29 = arith.constant 1 : i256
-    %72 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %67, %72 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_30 = arith.constant 1 : i256
-    %73 = llvm.alloca %c1_i256_30 x i256 : (i256) -> !llvm.ptr
-    llvm.store %71, %73 {alignment = 1 : i64} : i256, !llvm.ptr
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %75 = call @dora_fn_sstore(%arg0, %72, %73, %74) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8_31 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %77, %c0_i8_31 : i8
-    cf.cond_br %78, ^bb1(%77 : i8), ^bb26
+    %59 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %0 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %63 = llvm.getelementptr %62[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %64 = llvm.load %63 : !llvm.ptr -> i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_22 = arith.constant 1 : i256
+    %65 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %61, %65 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %66 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %64, %66 {alignment = 1 : i64} : i256, !llvm.ptr
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %68 = call @dora_fn_sstore(%arg0, %65, %66, %67) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %69 = llvm.getelementptr %68[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = llvm.load %69 : !llvm.ptr -> i8
+    %c0_i8_24 = arith.constant 0 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8_24 : i8
+    cf.cond_br %71, ^bb1(%70 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %79 = llvm.getelementptr %75[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %80 = llvm.load %79 : !llvm.ptr -> i64
-    %81 = llvm.load %arg1 : !llvm.ptr -> i64
-    %82 = arith.cmpi ult, %81, %80 : i64
-    scf.if %82 {
+    %72 = llvm.getelementptr %68[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %73 = llvm.load %72 : !llvm.ptr -> i64
+    %74 = llvm.load %arg1 : !llvm.ptr -> i64
+    %75 = arith.cmpi ult, %74, %73 : i64
+    scf.if %75 {
     } else {
-      %90 = arith.subi %81, %80 : i64
-      llvm.store %90, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %74, %73 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %82, ^bb1(%c80_i8_32 : i8), ^bb27
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %75, ^bb1(%c80_i8_25 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb31
   ^bb28:  // pred: ^bb30
-    %c1024_i64_33 = arith.constant 1024 : i64
-    %83 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_34 = arith.constant -2 : i64
-    %84 = arith.addi %83, %c-2_i64_34 : i64
-    %c2_i64_35 = arith.constant 2 : i64
-    %85 = arith.cmpi ult, %83, %c2_i64_35 : i64
-    %c91_i8_36 = arith.constant 91 : i8
-    cf.cond_br %85, ^bb1(%c91_i8_36 : i8), ^bb25
+    %c1024_i64_26 = arith.constant 1024 : i64
+    %76 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_27 = arith.constant -2 : i64
+    %77 = arith.addi %76, %c-2_i64_27 : i64
+    llvm.store %77, %arg3 : i64, !llvm.ptr
+    %c2_i64_28 = arith.constant 2 : i64
+    %78 = arith.cmpi ult, %76, %c2_i64_28 : i64
+    %c91_i8_29 = arith.constant 91 : i8
+    cf.cond_br %78, ^bb1(%c91_i8_29 : i8), ^bb25
   ^bb29:  // pred: ^bb21
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_37 = arith.constant 0 : i64
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_30 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %87 = arith.cmpi uge, %86, %c0_i64_37 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb30, ^bb1(%c80_i8_38 : i8)
+    %80 = arith.cmpi uge, %79, %c0_i64_30 : i64
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %80, ^bb30, ^bb1(%c80_i8_31 : i8)
   ^bb30:  // pred: ^bb29
-    %88 = arith.subi %86, %c0_i64_37 : i64
-    llvm.store %88, %arg1 : i64, !llvm.ptr
+    %81 = arith.subi %79, %c0_i64_30 : i64
+    llvm.store %81, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb27
-    %c0_i64_39 = arith.constant 0 : i64
+    %c0_i64_32 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %89 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_39, %c0_i64_39, %89, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %82 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_32, %c0_i64_32, %82, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_overwrite.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__sstore_overwrite.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb22, ^bb23, ^bb25, ^bb26, ^bb28, ^bb29
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 17 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb11, ^bb12, ^bb14, ^bb15, ^bb18, ^bb19, ^bb22, ^bb23, ^bb25, ^bb26, ^bb28, ^bb29
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,213 +96,204 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c200_i256 = arith.constant 200 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c200_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c200_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb14
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
     %c1_i256 = arith.constant 1 : i256
-    %29 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    llvm.store %24, %29 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_9 = arith.constant 1 : i256
-    %30 = llvm.alloca %c1_i256_9 x i256 : (i256) -> !llvm.ptr
-    llvm.store %28, %30 {alignment = 1 : i64} : i256, !llvm.ptr
-    %31 = llvm.load %arg1 : !llvm.ptr -> i64
-    %32 = call @dora_fn_sstore(%arg0, %29, %30, %31) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %33 = llvm.getelementptr %32[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %34 = llvm.load %33 : !llvm.ptr -> i8
+    %26 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    llvm.store %22, %26 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_6 = arith.constant 1 : i256
+    %27 = llvm.alloca %c1_i256_6 x i256 : (i256) -> !llvm.ptr
+    llvm.store %25, %27 {alignment = 1 : i64} : i256, !llvm.ptr
+    %28 = llvm.load %arg1 : !llvm.ptr -> i64
+    %29 = call @dora_fn_sstore(%arg0, %26, %27, %28) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %30 = llvm.getelementptr %29[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %31 = llvm.load %30 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
-    %35 = arith.cmpi ne, %34, %c0_i8 : i8
-    cf.cond_br %35, ^bb1(%34 : i8), ^bb12
+    %32 = arith.cmpi ne, %31, %c0_i8 : i8
+    cf.cond_br %32, ^bb1(%31 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %36 = llvm.getelementptr %32[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i64
-    %38 = llvm.load %arg1 : !llvm.ptr -> i64
-    %39 = arith.cmpi ult, %38, %37 : i64
-    scf.if %39 {
+    %33 = llvm.getelementptr %29[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %34 = llvm.load %33 : !llvm.ptr -> i64
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    %36 = arith.cmpi ult, %35, %34 : i64
+    scf.if %36 {
     } else {
-      %90 = arith.subi %38, %37 : i64
-      llvm.store %90, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %35, %34 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_10 = arith.constant 80 : i8
-    cf.cond_br %39, ^bb1(%c80_i8_10 : i8), ^bb13
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %36, ^bb1(%c80_i8_7 : i8), ^bb13
   ^bb13:  // pred: ^bb12
     cf.br ^bb19
   ^bb14:  // pred: ^bb16
-    %c1024_i64_11 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_8 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %41 = arith.addi %40, %c-2_i64 : i64
+    %38 = arith.addi %37, %c-2_i64 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %42 = arith.cmpi ult, %40, %c2_i64 : i64
+    %39 = arith.cmpi ult, %37, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %42, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %39, ^bb1(%c91_i8 : i8), ^bb11
   ^bb15:  // pred: ^bb7
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_12 = arith.constant 0 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_9 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c0_i64_12 : i64
-    %c80_i8_13 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb16, ^bb1(%c80_i8_13 : i8)
+    %41 = arith.cmpi uge, %40, %c0_i64_9 : i64
+    %c80_i8_10 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb16, ^bb1(%c80_i8_10 : i8)
   ^bb16:  // pred: ^bb15
-    %45 = arith.subi %43, %c0_i64_12 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c0_i64_9 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb14
   ^bb17:  // pred: ^bb18
-    %c0_i256_14 = arith.constant 0 : i256
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %47 = llvm.getelementptr %arg2[%46] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_15 = arith.constant 1 : i64
-    %48 = arith.addi %46, %c1_i64_15 : i64
-    llvm.store %48, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_14, %47 : i256, !llvm.ptr
+    %c0_i256_11 = arith.constant 0 : i256
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_11, %43 : i256, !llvm.ptr
+    %44 = llvm.getelementptr %43[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb18:  // pred: ^bb20
-    %c1024_i64_16 = arith.constant 1024 : i64
-    %49 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_17 = arith.constant 1 : i64
-    %50 = arith.addi %49, %c1_i64_17 : i64
-    %51 = arith.cmpi ult, %c1024_i64_16, %50 : i64
-    %c92_i8_18 = arith.constant 92 : i8
-    cf.cond_br %51, ^bb1(%c92_i8_18 : i8), ^bb17
+    %c1024_i64_12 = arith.constant 1024 : i64
+    %45 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_13 = arith.constant 1 : i64
+    %46 = arith.addi %45, %c1_i64_13 : i64
+    llvm.store %46, %arg3 : i64, !llvm.ptr
+    %47 = arith.cmpi ult, %c1024_i64_12, %46 : i64
+    %c92_i8_14 = arith.constant 92 : i8
+    cf.cond_br %47, ^bb1(%c92_i8_14 : i8), ^bb17
   ^bb19:  // pred: ^bb13
-    %52 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_19 = arith.constant 3 : i64
+    %48 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_15 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %53 = arith.cmpi uge, %52, %c3_i64_19 : i64
-    %c80_i8_20 = arith.constant 80 : i8
-    cf.cond_br %53, ^bb20, ^bb1(%c80_i8_20 : i8)
+    %49 = arith.cmpi uge, %48, %c3_i64_15 : i64
+    %c80_i8_16 = arith.constant 80 : i8
+    cf.cond_br %49, ^bb20, ^bb1(%c80_i8_16 : i8)
   ^bb20:  // pred: ^bb19
-    %54 = arith.subi %52, %c3_i64_19 : i64
-    llvm.store %54, %arg1 : i64, !llvm.ptr
+    %50 = arith.subi %48, %c3_i64_15 : i64
+    llvm.store %50, %arg1 : i64, !llvm.ptr
     cf.br ^bb18
   ^bb21:  // pred: ^bb22
     %c300_i256 = arith.constant 300 : i256
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %56 = llvm.getelementptr %arg2[%55] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %57 = arith.addi %55, %c1_i64_21 : i64
-    llvm.store %57, %arg3 : i64, !llvm.ptr
-    llvm.store %c300_i256, %56 : i256, !llvm.ptr
+    %51 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c300_i256, %51 : i256, !llvm.ptr
+    %52 = llvm.getelementptr %51[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %52, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb22:  // pred: ^bb24
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %58 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %59 = arith.addi %58, %c1_i64_23 : i64
-    %60 = arith.cmpi ult, %c1024_i64_22, %59 : i64
-    %c92_i8_24 = arith.constant 92 : i8
-    cf.cond_br %60, ^bb1(%c92_i8_24 : i8), ^bb21
+    %c1024_i64_17 = arith.constant 1024 : i64
+    %53 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_18 = arith.constant 1 : i64
+    %54 = arith.addi %53, %c1_i64_18 : i64
+    llvm.store %54, %arg3 : i64, !llvm.ptr
+    %55 = arith.cmpi ult, %c1024_i64_17, %54 : i64
+    %c92_i8_19 = arith.constant 92 : i8
+    cf.cond_br %55, ^bb1(%c92_i8_19 : i8), ^bb21
   ^bb23:  // pred: ^bb17
-    %61 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_25 = arith.constant 3 : i64
+    %56 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_20 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %62 = arith.cmpi uge, %61, %c3_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %62, ^bb24, ^bb1(%c80_i8_26 : i8)
+    %57 = arith.cmpi uge, %56, %c3_i64_20 : i64
+    %c80_i8_21 = arith.constant 80 : i8
+    cf.cond_br %57, ^bb24, ^bb1(%c80_i8_21 : i8)
   ^bb24:  // pred: ^bb23
-    %63 = arith.subi %61, %c3_i64_25 : i64
-    llvm.store %63, %arg1 : i64, !llvm.ptr
+    %58 = arith.subi %56, %c3_i64_20 : i64
+    llvm.store %58, %arg1 : i64, !llvm.ptr
     cf.br ^bb22
   ^bb25:  // pred: ^bb28
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_27 = arith.constant 1 : i64
-    %65 = arith.subi %64, %c1_i64_27 : i64
-    %66 = llvm.getelementptr %arg2[%65] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %65, %arg3 : i64, !llvm.ptr
-    %67 = llvm.load %66 : !llvm.ptr -> i256
-    %68 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_28 = arith.constant 1 : i64
-    %69 = arith.subi %68, %c1_i64_28 : i64
-    %70 = llvm.getelementptr %arg2[%69] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %69, %arg3 : i64, !llvm.ptr
-    %71 = llvm.load %70 : !llvm.ptr -> i256
-    %c1_i256_29 = arith.constant 1 : i256
-    %72 = llvm.alloca %c1_i256_29 x i256 : (i256) -> !llvm.ptr
-    llvm.store %67, %72 {alignment = 1 : i64} : i256, !llvm.ptr
-    %c1_i256_30 = arith.constant 1 : i256
-    %73 = llvm.alloca %c1_i256_30 x i256 : (i256) -> !llvm.ptr
-    llvm.store %71, %73 {alignment = 1 : i64} : i256, !llvm.ptr
-    %74 = llvm.load %arg1 : !llvm.ptr -> i64
-    %75 = call @dora_fn_sstore(%arg0, %72, %73, %74) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
-    %76 = llvm.getelementptr %75[0] : (!llvm.ptr) -> !llvm.ptr, i8
-    %77 = llvm.load %76 : !llvm.ptr -> i8
-    %c0_i8_31 = arith.constant 0 : i8
-    %78 = arith.cmpi ne, %77, %c0_i8_31 : i8
-    cf.cond_br %78, ^bb1(%77 : i8), ^bb26
+    %59 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %60 = llvm.getelementptr %59[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %61 = llvm.load %60 : !llvm.ptr -> i256
+    llvm.store %60, %0 : !llvm.ptr, !llvm.ptr
+    %62 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %63 = llvm.getelementptr %62[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %64 = llvm.load %63 : !llvm.ptr -> i256
+    llvm.store %63, %0 : !llvm.ptr, !llvm.ptr
+    %c1_i256_22 = arith.constant 1 : i256
+    %65 = llvm.alloca %c1_i256_22 x i256 : (i256) -> !llvm.ptr
+    llvm.store %61, %65 {alignment = 1 : i64} : i256, !llvm.ptr
+    %c1_i256_23 = arith.constant 1 : i256
+    %66 = llvm.alloca %c1_i256_23 x i256 : (i256) -> !llvm.ptr
+    llvm.store %64, %66 {alignment = 1 : i64} : i256, !llvm.ptr
+    %67 = llvm.load %arg1 : !llvm.ptr -> i64
+    %68 = call @dora_fn_sstore(%arg0, %65, %66, %67) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> !llvm.ptr
+    %69 = llvm.getelementptr %68[0] : (!llvm.ptr) -> !llvm.ptr, i8
+    %70 = llvm.load %69 : !llvm.ptr -> i8
+    %c0_i8_24 = arith.constant 0 : i8
+    %71 = arith.cmpi ne, %70, %c0_i8_24 : i8
+    cf.cond_br %71, ^bb1(%70 : i8), ^bb26
   ^bb26:  // pred: ^bb25
-    %79 = llvm.getelementptr %75[8] : (!llvm.ptr) -> !llvm.ptr, i8
-    %80 = llvm.load %79 : !llvm.ptr -> i64
-    %81 = llvm.load %arg1 : !llvm.ptr -> i64
-    %82 = arith.cmpi ult, %81, %80 : i64
-    scf.if %82 {
+    %72 = llvm.getelementptr %68[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    %73 = llvm.load %72 : !llvm.ptr -> i64
+    %74 = llvm.load %arg1 : !llvm.ptr -> i64
+    %75 = arith.cmpi ult, %74, %73 : i64
+    scf.if %75 {
     } else {
-      %90 = arith.subi %81, %80 : i64
-      llvm.store %90, %arg1 : i64, !llvm.ptr
+      %83 = arith.subi %74, %73 : i64
+      llvm.store %83, %arg1 : i64, !llvm.ptr
     }
-    %c80_i8_32 = arith.constant 80 : i8
-    cf.cond_br %82, ^bb1(%c80_i8_32 : i8), ^bb27
+    %c80_i8_25 = arith.constant 80 : i8
+    cf.cond_br %75, ^bb1(%c80_i8_25 : i8), ^bb27
   ^bb27:  // pred: ^bb26
     cf.br ^bb31
   ^bb28:  // pred: ^bb30
-    %c1024_i64_33 = arith.constant 1024 : i64
-    %83 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_34 = arith.constant -2 : i64
-    %84 = arith.addi %83, %c-2_i64_34 : i64
-    %c2_i64_35 = arith.constant 2 : i64
-    %85 = arith.cmpi ult, %83, %c2_i64_35 : i64
-    %c91_i8_36 = arith.constant 91 : i8
-    cf.cond_br %85, ^bb1(%c91_i8_36 : i8), ^bb25
+    %c1024_i64_26 = arith.constant 1024 : i64
+    %76 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_27 = arith.constant -2 : i64
+    %77 = arith.addi %76, %c-2_i64_27 : i64
+    llvm.store %77, %arg3 : i64, !llvm.ptr
+    %c2_i64_28 = arith.constant 2 : i64
+    %78 = arith.cmpi ult, %76, %c2_i64_28 : i64
+    %c91_i8_29 = arith.constant 91 : i8
+    cf.cond_br %78, ^bb1(%c91_i8_29 : i8), ^bb25
   ^bb29:  // pred: ^bb21
-    %86 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_37 = arith.constant 0 : i64
+    %79 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_30 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %87 = arith.cmpi uge, %86, %c0_i64_37 : i64
-    %c80_i8_38 = arith.constant 80 : i8
-    cf.cond_br %87, ^bb30, ^bb1(%c80_i8_38 : i8)
+    %80 = arith.cmpi uge, %79, %c0_i64_30 : i64
+    %c80_i8_31 = arith.constant 80 : i8
+    cf.cond_br %80, ^bb30, ^bb1(%c80_i8_31 : i8)
   ^bb30:  // pred: ^bb29
-    %88 = arith.subi %86, %c0_i64_37 : i64
-    llvm.store %88, %arg1 : i64, !llvm.ptr
+    %81 = arith.subi %79, %c0_i64_30 : i64
+    llvm.store %81, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb27
-    %c0_i64_39 = arith.constant 0 : i64
+    %c0_i64_32 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %89 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_39, %c0_i64_39, %89, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %82 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_32, %c0_i64_32, %82, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__stop.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__stop.snap
@@ -53,47 +53,51 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb6
-  ^bb1(%0: i8):  // 2 preds: ^bb2, ^bb6
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb6
+  ^bb1(%1: i8):  // 2 preds: ^bb2, ^bb6
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb5
-    %c0_i64_0 = arith.constant 0 : i64
+    %c0_i64_1 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %3 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %3, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %4 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_1, %c0_i64_1, %4, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   ^bb4:  // no predecessors
     cf.br ^bb8
   ^bb5:  // pred: ^bb7
     %c1024_i64 = arith.constant 1024 : i64
-    %4 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_1 = arith.constant 0 : i64
-    %5 = arith.addi %4, %c0_i64_1 : i64
+    %5 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %6 = arith.addi %5, %c0_i64_2 : i64
+    llvm.store %6, %arg3 : i64, !llvm.ptr
     cf.br ^bb3
   ^bb6:  // pred: ^bb0
-    %6 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_2 = arith.constant 0 : i64
+    %7 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_3 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %7 = arith.cmpi uge, %6, %c0_i64_2 : i64
+    %8 = arith.cmpi uge, %7, %c0_i64_3 : i64
     %c80_i8 = arith.constant 80 : i8
-    cf.cond_br %7, ^bb7, ^bb1(%c80_i8 : i8)
+    cf.cond_br %8, ^bb7, ^bb1(%c80_i8 : i8)
   ^bb7:  // pred: ^bb6
-    %8 = arith.subi %6, %c0_i64_2 : i64
-    llvm.store %8, %arg1 : i64, !llvm.ptr
+    %9 = arith.subi %7, %c0_i64_3 : i64
+    llvm.store %9, %arg1 : i64, !llvm.ptr
     cf.br ^bb5
   ^bb8:  // pred: ^bb4
-    %c0_i64_3 = arith.constant 0 : i64
-    %c1_i8_4 = arith.constant 1 : i8
-    %9 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_3, %c0_i64_3, %9, %c1_i8_4) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %c1_i8_4 : i8
+    %c0_i64_4 = arith.constant 0 : i64
+    %c1_i8_5 = arith.constant 1 : i8
+    %10 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_4, %c0_i64_4, %10, %c1_i8_5) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %c1_i8_5 : i8
   }
 }

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__timestamp.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__timestamp.snap
@@ -53,34 +53,36 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 3 preds: ^bb2, ^bb4, ^bb5
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
-    call @dora_fn_store_in_timestamp_ptr(%arg0, %3) : (!llvm.ptr, !llvm.ptr) -> ()
-    %4 = llvm.load %3 : !llvm.ptr -> i256
-    %5 = llvm.load %arg3 : !llvm.ptr -> i64
-    %6 = llvm.getelementptr %arg2[%5] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %7 = arith.addi %5, %c1_i64 : i64
-    llvm.store %7, %arg3 : i64, !llvm.ptr
-    llvm.store %4, %6 : i256, !llvm.ptr
+    %4 = llvm.alloca %c1_i256 x i256 : (i256) -> !llvm.ptr
+    call @dora_fn_store_in_timestamp_ptr(%arg0, %4) : (!llvm.ptr, !llvm.ptr) -> ()
+    %5 = llvm.load %4 : !llvm.ptr -> i256
+    %6 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %5, %6 : i256, !llvm.ptr
+    %7 = llvm.getelementptr %6[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb7
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %8 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %9 = arith.addi %8, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %9 = arith.addi %8, %c1_i64 : i64
+    llvm.store %9, %arg3 : i64, !llvm.ptr
     %10 = arith.cmpi ult, %c1024_i64, %9 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %10, ^bb1(%c92_i8 : i8), ^bb3

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__storage__storage_pass.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__storage__storage_pass.snap
@@ -180,31 +180,33 @@ module {
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
     %c16 = arith.constant 16 : index
     %0 = call @dora_u256_map_new(%c16) : (index) -> memref<?x3xi256>
-    cf.br ^bb5
-  ^bb1(%1: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb32, ^bb33, ^bb36, ^bb37, ^bb41, ^bb42
     %c0_i64 = arith.constant 0 : i64
-    %2 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %1 : i8
-  ^bb2(%3: i256):  // no predecessors
+    %1 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %1 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%2: i8):  // 21 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21, ^bb24, ^bb25, ^bb28, ^bb29, ^bb32, ^bb33, ^bb36, ^bb37, ^bb41, ^bb42
+    %c0_i64_0 = arith.constant 0 : i64
+    %3 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %3, %2) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %2 : i8
+  ^bb2(%4: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %3 : i256, [
+    cf.switch %4 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c100_i256 = arith.constant 100 : i256
-    %4 = llvm.load %arg3 : !llvm.ptr -> i64
-    %5 = llvm.getelementptr %arg2[%4] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %6 = arith.addi %4, %c1_i64 : i64
-    llvm.store %6, %arg3 : i64, !llvm.ptr
+    %5 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
     llvm.store %c100_i256, %5 : i256, !llvm.ptr
+    %6 = llvm.getelementptr %5[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %6, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %7 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %8 = arith.addi %7, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %8 = arith.addi %7, %c1_i64 : i64
+    llvm.store %8, %arg3 : i64, !llvm.ptr
     %9 = arith.cmpi ult, %c1024_i64, %8 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %9, ^bb1(%c92_i8 : i8), ^bb3
@@ -221,297 +223,280 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c0_i256 = arith.constant 0 : i256
-    %13 = llvm.load %arg3 : !llvm.ptr -> i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %15 = arith.addi %13, %c1_i64_1 : i64
-    llvm.store %15, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256, %14 : i256, !llvm.ptr
+    %13 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256, %13 : i256, !llvm.ptr
+    %14 = llvm.getelementptr %13[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %14, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %17 = arith.addi %16, %c1_i64_3 : i64
-    %18 = arith.cmpi ult, %c1024_i64_2, %17 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %18, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %16 = arith.addi %15, %c1_i64_2 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %17 = arith.cmpi ult, %c1024_i64_1, %16 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %17, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %19 = arith.cmpi uge, %18, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %21 = arith.subi %19, %c3_i64_5 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c3_i64_4 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %22 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %23 = arith.subi %22, %c1_i64_7 : i64
-    %24 = llvm.getelementptr %arg2[%23] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %23, %arg3 : i64, !llvm.ptr
-    %25 = llvm.load %24 : !llvm.ptr -> i256
-    %26 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %27 = arith.subi %26, %c1_i64_8 : i64
-    %28 = llvm.getelementptr %arg2[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    %29 = llvm.load %28 : !llvm.ptr -> i256
-    %30 = call @dora_u256_map_insert(%0, %25, %29) : (memref<?x3xi256>, i256, i256) -> memref<?x3xi256>
-    "dora.sstore"(%25, %29) : (i256, i256) -> ()
+    %21 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %22 = llvm.getelementptr %21[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %23 = llvm.load %22 : !llvm.ptr -> i256
+    llvm.store %22, %1 : !llvm.ptr, !llvm.ptr
+    %24 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %25 = llvm.getelementptr %24[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %26 = llvm.load %25 : !llvm.ptr -> i256
+    llvm.store %25, %1 : !llvm.ptr, !llvm.ptr
+    %27 = call @dora_u256_map_insert(%0, %23, %26) : (memref<?x3xi256>, i256, i256) -> memref<?x3xi256>
+    "dora.sstore"(%23, %26) : (i256, i256) -> ()
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_9 = arith.constant 1024 : i64
-    %31 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %28 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-2_i64 = arith.constant -2 : i64
-    %32 = arith.addi %31, %c-2_i64 : i64
+    %29 = arith.addi %28, %c-2_i64 : i64
+    llvm.store %29, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %33 = arith.cmpi ult, %31, %c2_i64 : i64
+    %30 = arith.cmpi ult, %28, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %33, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %30, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %34 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_10 = arith.constant 0 : i64
+    %31 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_7 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %35 = arith.cmpi uge, %34, %c0_i64_10 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %35, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %32 = arith.cmpi uge, %31, %c0_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %32, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %36 = arith.subi %34, %c0_i64_10 : i64
-    llvm.store %36, %arg1 : i64, !llvm.ptr
+    %33 = arith.subi %31, %c0_i64_7 : i64
+    llvm.store %33, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %c0_i256_12 = arith.constant 0 : i256
-    %37 = llvm.load %arg3 : !llvm.ptr -> i64
-    %38 = llvm.getelementptr %arg2[%37] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %39 = arith.addi %37, %c1_i64_13 : i64
-    llvm.store %39, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_12, %38 : i256, !llvm.ptr
+    %c0_i256_9 = arith.constant 0 : i256
+    %34 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_9, %34 : i256, !llvm.ptr
+    %35 = llvm.getelementptr %34[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %35, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %40 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %41 = arith.addi %40, %c1_i64_15 : i64
-    %42 = arith.cmpi ult, %c1024_i64_14, %41 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %42, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_10 = arith.constant 1024 : i64
+    %36 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_11 = arith.constant 1 : i64
+    %37 = arith.addi %36, %c1_i64_11 : i64
+    llvm.store %37, %arg3 : i64, !llvm.ptr
+    %38 = arith.cmpi ult, %c1024_i64_10, %37 : i64
+    %c92_i8_12 = arith.constant 92 : i8
+    cf.cond_br %38, ^bb1(%c92_i8_12 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %43 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %39 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_13 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %44 = arith.cmpi uge, %43, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %44, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %40 = arith.cmpi uge, %39, %c3_i64_13 : i64
+    %c80_i8_14 = arith.constant 80 : i8
+    cf.cond_br %40, ^bb18, ^bb1(%c80_i8_14 : i8)
   ^bb18:  // pred: ^bb17
-    %45 = arith.subi %43, %c3_i64_17 : i64
-    llvm.store %45, %arg1 : i64, !llvm.ptr
+    %41 = arith.subi %39, %c3_i64_13 : i64
+    llvm.store %41, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %46 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %47 = arith.subi %46, %c1_i64_19 : i64
-    %48 = llvm.getelementptr %arg2[%47] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %47, %arg3 : i64, !llvm.ptr
-    %49 = llvm.load %48 : !llvm.ptr -> i256
-    %50:2 = call @dora_u256_map_get(%30, %49) : (memref<?x3xi256>, i256) -> (i256, i1)
-    %51 = scf.if %50#1 -> (i256) {
-      scf.yield %50#0 : i256
+    %42 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %43 = llvm.getelementptr %42[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %44 = llvm.load %43 : !llvm.ptr -> i256
+    llvm.store %43, %1 : !llvm.ptr, !llvm.ptr
+    %45:2 = call @dora_u256_map_get(%27, %44) : (memref<?x3xi256>, i256) -> (i256, i1)
+    %46 = scf.if %45#1 -> (i256) {
+      scf.yield %45#0 : i256
     } else {
-      %117 = "dora.sload"(%49) : (i256) -> i256
-      scf.yield %117 : i256
+      %104 = "dora.sload"(%44) : (i256) -> i256
+      scf.yield %104 : i256
     }
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %53 = llvm.getelementptr %arg2[%52] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_20 = arith.constant 1 : i64
-    %54 = arith.addi %52, %c1_i64_20 : i64
-    llvm.store %54, %arg3 : i64, !llvm.ptr
-    llvm.store %51, %53 : i256, !llvm.ptr
+    %47 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    llvm.store %46, %47 : i256, !llvm.ptr
+    %48 = llvm.getelementptr %47[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %48, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb25
   ^bb20:  // pred: ^bb22
-    %c1024_i64_21 = arith.constant 1024 : i64
-    %55 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_22 = arith.constant 0 : i64
-    %56 = arith.addi %55, %c0_i64_22 : i64
-    %c1_i64_23 = arith.constant 1 : i64
-    %57 = arith.cmpi ult, %55, %c1_i64_23 : i64
-    %c91_i8_24 = arith.constant 91 : i8
-    cf.cond_br %57, ^bb1(%c91_i8_24 : i8), ^bb19
+    %c1024_i64_15 = arith.constant 1024 : i64
+    %49 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_16 = arith.constant 0 : i64
+    %50 = arith.addi %49, %c0_i64_16 : i64
+    llvm.store %50, %arg3 : i64, !llvm.ptr
+    %c1_i64_17 = arith.constant 1 : i64
+    %51 = arith.cmpi ult, %49, %c1_i64_17 : i64
+    %c91_i8_18 = arith.constant 91 : i8
+    cf.cond_br %51, ^bb1(%c91_i8_18 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %58 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_25 = arith.constant 0 : i64
+    %52 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_19 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %59 = arith.cmpi uge, %58, %c0_i64_25 : i64
-    %c80_i8_26 = arith.constant 80 : i8
-    cf.cond_br %59, ^bb22, ^bb1(%c80_i8_26 : i8)
+    %53 = arith.cmpi uge, %52, %c0_i64_19 : i64
+    %c80_i8_20 = arith.constant 80 : i8
+    cf.cond_br %53, ^bb22, ^bb1(%c80_i8_20 : i8)
   ^bb22:  // pred: ^bb21
-    %60 = arith.subi %58, %c0_i64_25 : i64
-    llvm.store %60, %arg1 : i64, !llvm.ptr
+    %54 = arith.subi %52, %c0_i64_19 : i64
+    llvm.store %54, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb24
-    %c0_i256_27 = arith.constant 0 : i256
-    %61 = llvm.load %arg3 : !llvm.ptr -> i64
-    %62 = llvm.getelementptr %arg2[%61] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_28 = arith.constant 1 : i64
-    %63 = arith.addi %61, %c1_i64_28 : i64
-    llvm.store %63, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_27, %62 : i256, !llvm.ptr
+    %c0_i256_21 = arith.constant 0 : i256
+    %55 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_21, %55 : i256, !llvm.ptr
+    %56 = llvm.getelementptr %55[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %56, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb29
   ^bb24:  // pred: ^bb26
-    %c1024_i64_29 = arith.constant 1024 : i64
-    %64 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_30 = arith.constant 1 : i64
-    %65 = arith.addi %64, %c1_i64_30 : i64
-    %66 = arith.cmpi ult, %c1024_i64_29, %65 : i64
-    %c92_i8_31 = arith.constant 92 : i8
-    cf.cond_br %66, ^bb1(%c92_i8_31 : i8), ^bb23
+    %c1024_i64_22 = arith.constant 1024 : i64
+    %57 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_23 = arith.constant 1 : i64
+    %58 = arith.addi %57, %c1_i64_23 : i64
+    llvm.store %58, %arg3 : i64, !llvm.ptr
+    %59 = arith.cmpi ult, %c1024_i64_22, %58 : i64
+    %c92_i8_24 = arith.constant 92 : i8
+    cf.cond_br %59, ^bb1(%c92_i8_24 : i8), ^bb23
   ^bb25:  // pred: ^bb19
-    %67 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_32 = arith.constant 2 : i64
+    %60 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_25 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %68 = arith.cmpi uge, %67, %c2_i64_32 : i64
-    %c80_i8_33 = arith.constant 80 : i8
-    cf.cond_br %68, ^bb26, ^bb1(%c80_i8_33 : i8)
+    %61 = arith.cmpi uge, %60, %c2_i64_25 : i64
+    %c80_i8_26 = arith.constant 80 : i8
+    cf.cond_br %61, ^bb26, ^bb1(%c80_i8_26 : i8)
   ^bb26:  // pred: ^bb25
-    %69 = arith.subi %67, %c2_i64_32 : i64
-    llvm.store %69, %arg1 : i64, !llvm.ptr
+    %62 = arith.subi %60, %c2_i64_25 : i64
+    llvm.store %62, %arg1 : i64, !llvm.ptr
     cf.br ^bb24
   ^bb27:  // pred: ^bb28
-    %70 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_34 = arith.constant 1 : i64
-    %71 = arith.subi %70, %c1_i64_34 : i64
-    %72 = llvm.getelementptr %arg2[%71] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %71, %arg3 : i64, !llvm.ptr
-    %73 = llvm.load %72 : !llvm.ptr -> i256
-    %74 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_35 = arith.constant 1 : i64
-    %75 = arith.subi %74, %c1_i64_35 : i64
-    %76 = llvm.getelementptr %arg2[%75] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %75, %arg3 : i64, !llvm.ptr
-    %77 = llvm.load %76 : !llvm.ptr -> i256
-    "dora.mstore"(%73, %77) : (i256, i256) -> ()
+    %63 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %64 = llvm.getelementptr %63[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %65 = llvm.load %64 : !llvm.ptr -> i256
+    llvm.store %64, %1 : !llvm.ptr, !llvm.ptr
+    %66 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %67 = llvm.getelementptr %66[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %68 = llvm.load %67 : !llvm.ptr -> i256
+    llvm.store %67, %1 : !llvm.ptr, !llvm.ptr
+    "dora.mstore"(%65, %68) : (i256, i256) -> ()
     cf.br ^bb33
   ^bb28:  // pred: ^bb30
-    %c1024_i64_36 = arith.constant 1024 : i64
-    %78 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_37 = arith.constant -2 : i64
-    %79 = arith.addi %78, %c-2_i64_37 : i64
-    %c2_i64_38 = arith.constant 2 : i64
-    %80 = arith.cmpi ult, %78, %c2_i64_38 : i64
-    %c91_i8_39 = arith.constant 91 : i8
-    cf.cond_br %80, ^bb1(%c91_i8_39 : i8), ^bb27
+    %c1024_i64_27 = arith.constant 1024 : i64
+    %69 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_28 = arith.constant -2 : i64
+    %70 = arith.addi %69, %c-2_i64_28 : i64
+    llvm.store %70, %arg3 : i64, !llvm.ptr
+    %c2_i64_29 = arith.constant 2 : i64
+    %71 = arith.cmpi ult, %69, %c2_i64_29 : i64
+    %c91_i8_30 = arith.constant 91 : i8
+    cf.cond_br %71, ^bb1(%c91_i8_30 : i8), ^bb27
   ^bb29:  // pred: ^bb23
-    %81 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_40 = arith.constant 3 : i64
+    %72 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_31 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %82 = arith.cmpi uge, %81, %c3_i64_40 : i64
-    %c80_i8_41 = arith.constant 80 : i8
-    cf.cond_br %82, ^bb30, ^bb1(%c80_i8_41 : i8)
+    %73 = arith.cmpi uge, %72, %c3_i64_31 : i64
+    %c80_i8_32 = arith.constant 80 : i8
+    cf.cond_br %73, ^bb30, ^bb1(%c80_i8_32 : i8)
   ^bb30:  // pred: ^bb29
-    %83 = arith.subi %81, %c3_i64_40 : i64
-    llvm.store %83, %arg1 : i64, !llvm.ptr
+    %74 = arith.subi %72, %c3_i64_31 : i64
+    llvm.store %74, %arg1 : i64, !llvm.ptr
     cf.br ^bb28
   ^bb31:  // pred: ^bb32
     %c32_i256 = arith.constant 32 : i256
-    %84 = llvm.load %arg3 : !llvm.ptr -> i64
-    %85 = llvm.getelementptr %arg2[%84] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_42 = arith.constant 1 : i64
-    %86 = arith.addi %84, %c1_i64_42 : i64
-    llvm.store %86, %arg3 : i64, !llvm.ptr
-    llvm.store %c32_i256, %85 : i256, !llvm.ptr
+    %75 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c32_i256, %75 : i256, !llvm.ptr
+    %76 = llvm.getelementptr %75[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %76, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb37
   ^bb32:  // pred: ^bb34
-    %c1024_i64_43 = arith.constant 1024 : i64
-    %87 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_44 = arith.constant 1 : i64
-    %88 = arith.addi %87, %c1_i64_44 : i64
-    %89 = arith.cmpi ult, %c1024_i64_43, %88 : i64
-    %c92_i8_45 = arith.constant 92 : i8
-    cf.cond_br %89, ^bb1(%c92_i8_45 : i8), ^bb31
+    %c1024_i64_33 = arith.constant 1024 : i64
+    %77 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_34 = arith.constant 1 : i64
+    %78 = arith.addi %77, %c1_i64_34 : i64
+    llvm.store %78, %arg3 : i64, !llvm.ptr
+    %79 = arith.cmpi ult, %c1024_i64_33, %78 : i64
+    %c92_i8_35 = arith.constant 92 : i8
+    cf.cond_br %79, ^bb1(%c92_i8_35 : i8), ^bb31
   ^bb33:  // pred: ^bb27
-    %90 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_46 = arith.constant 3 : i64
+    %80 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_36 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %91 = arith.cmpi uge, %90, %c3_i64_46 : i64
-    %c80_i8_47 = arith.constant 80 : i8
-    cf.cond_br %91, ^bb34, ^bb1(%c80_i8_47 : i8)
+    %81 = arith.cmpi uge, %80, %c3_i64_36 : i64
+    %c80_i8_37 = arith.constant 80 : i8
+    cf.cond_br %81, ^bb34, ^bb1(%c80_i8_37 : i8)
   ^bb34:  // pred: ^bb33
-    %92 = arith.subi %90, %c3_i64_46 : i64
-    llvm.store %92, %arg1 : i64, !llvm.ptr
+    %82 = arith.subi %80, %c3_i64_36 : i64
+    llvm.store %82, %arg1 : i64, !llvm.ptr
     cf.br ^bb32
   ^bb35:  // pred: ^bb36
-    %c0_i256_48 = arith.constant 0 : i256
-    %93 = llvm.load %arg3 : !llvm.ptr -> i64
-    %94 = llvm.getelementptr %arg2[%93] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_49 = arith.constant 1 : i64
-    %95 = arith.addi %93, %c1_i64_49 : i64
-    llvm.store %95, %arg3 : i64, !llvm.ptr
-    llvm.store %c0_i256_48, %94 : i256, !llvm.ptr
+    %c0_i256_38 = arith.constant 0 : i256
+    %83 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c0_i256_38, %83 : i256, !llvm.ptr
+    %84 = llvm.getelementptr %83[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %84, %1 : !llvm.ptr, !llvm.ptr
     cf.br ^bb42
   ^bb36:  // pred: ^bb38
-    %c1024_i64_50 = arith.constant 1024 : i64
-    %96 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_51 = arith.constant 1 : i64
-    %97 = arith.addi %96, %c1_i64_51 : i64
-    %98 = arith.cmpi ult, %c1024_i64_50, %97 : i64
-    %c92_i8_52 = arith.constant 92 : i8
-    cf.cond_br %98, ^bb1(%c92_i8_52 : i8), ^bb35
+    %c1024_i64_39 = arith.constant 1024 : i64
+    %85 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_40 = arith.constant 1 : i64
+    %86 = arith.addi %85, %c1_i64_40 : i64
+    llvm.store %86, %arg3 : i64, !llvm.ptr
+    %87 = arith.cmpi ult, %c1024_i64_39, %86 : i64
+    %c92_i8_41 = arith.constant 92 : i8
+    cf.cond_br %87, ^bb1(%c92_i8_41 : i8), ^bb35
   ^bb37:  // pred: ^bb31
-    %99 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_53 = arith.constant 2 : i64
+    %88 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_42 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %100 = arith.cmpi uge, %99, %c2_i64_53 : i64
-    %c80_i8_54 = arith.constant 80 : i8
-    cf.cond_br %100, ^bb38, ^bb1(%c80_i8_54 : i8)
+    %89 = arith.cmpi uge, %88, %c2_i64_42 : i64
+    %c80_i8_43 = arith.constant 80 : i8
+    cf.cond_br %89, ^bb38, ^bb1(%c80_i8_43 : i8)
   ^bb38:  // pred: ^bb37
-    %101 = arith.subi %99, %c2_i64_53 : i64
-    llvm.store %101, %arg1 : i64, !llvm.ptr
+    %90 = arith.subi %88, %c2_i64_42 : i64
+    llvm.store %90, %arg1 : i64, !llvm.ptr
     cf.br ^bb36
   ^bb39:  // pred: ^bb41
-    %102 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_55 = arith.constant 1 : i64
-    %103 = arith.subi %102, %c1_i64_55 : i64
-    %104 = llvm.getelementptr %arg2[%103] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %103, %arg3 : i64, !llvm.ptr
-    %105 = llvm.load %104 : !llvm.ptr -> i256
-    %106 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_56 = arith.constant 1 : i64
-    %107 = arith.subi %106, %c1_i64_56 : i64
-    %108 = llvm.getelementptr %arg2[%107] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %107, %arg3 : i64, !llvm.ptr
-    %109 = llvm.load %108 : !llvm.ptr -> i256
-    "dora.return"(%105, %109) : (i256, i256) -> ()
+    %91 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %92 = llvm.getelementptr %91[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %93 = llvm.load %92 : !llvm.ptr -> i256
+    llvm.store %92, %1 : !llvm.ptr, !llvm.ptr
+    %94 = llvm.load %1 : !llvm.ptr -> !llvm.ptr
+    %95 = llvm.getelementptr %94[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %96 = llvm.load %95 : !llvm.ptr -> i256
+    llvm.store %95, %1 : !llvm.ptr, !llvm.ptr
+    "dora.return"(%93, %96) : (i256, i256) -> ()
   ^bb40:  // no predecessors
     cf.br ^bb44
   ^bb41:  // pred: ^bb43
-    %c1024_i64_57 = arith.constant 1024 : i64
-    %110 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-2_i64_58 = arith.constant -2 : i64
-    %111 = arith.addi %110, %c-2_i64_58 : i64
-    %c2_i64_59 = arith.constant 2 : i64
-    %112 = arith.cmpi ult, %110, %c2_i64_59 : i64
-    %c91_i8_60 = arith.constant 91 : i8
-    cf.cond_br %112, ^bb1(%c91_i8_60 : i8), ^bb39
+    %c1024_i64_44 = arith.constant 1024 : i64
+    %97 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-2_i64_45 = arith.constant -2 : i64
+    %98 = arith.addi %97, %c-2_i64_45 : i64
+    llvm.store %98, %arg3 : i64, !llvm.ptr
+    %c2_i64_46 = arith.constant 2 : i64
+    %99 = arith.cmpi ult, %97, %c2_i64_46 : i64
+    %c91_i8_47 = arith.constant 91 : i8
+    cf.cond_br %99, ^bb1(%c91_i8_47 : i8), ^bb39
   ^bb42:  // pred: ^bb35
-    %113 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c0_i64_61 = arith.constant 0 : i64
+    %100 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c0_i64_48 = arith.constant 0 : i64
     call @dora_fn_nop() : () -> ()
-    %114 = arith.cmpi uge, %113, %c0_i64_61 : i64
-    %c80_i8_62 = arith.constant 80 : i8
-    cf.cond_br %114, ^bb43, ^bb1(%c80_i8_62 : i8)
+    %101 = arith.cmpi uge, %100, %c0_i64_48 : i64
+    %c80_i8_49 = arith.constant 80 : i8
+    cf.cond_br %101, ^bb43, ^bb1(%c80_i8_49 : i8)
   ^bb43:  // pred: ^bb42
-    %115 = arith.subi %113, %c0_i64_61 : i64
-    llvm.store %115, %arg1 : i64, !llvm.ptr
+    %102 = arith.subi %100, %c0_i64_48 : i64
+    llvm.store %102, %arg1 : i64, !llvm.ptr
     cf.br ^bb41
   ^bb44:  // pred: ^bb40
-    %c0_i64_63 = arith.constant 0 : i64
+    %c0_i64_50 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %116 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_63, %c0_i64_63, %116, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %103 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_50, %c0_i64_50, %103, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_iszero_pop.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_iszero_pop.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,73 +95,69 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
-    %16 = "evm.iszero"(%15) : (i256) -> i256
-    %17 = llvm.load %arg3 : !llvm.ptr -> i64
-    %18 = llvm.getelementptr %arg2[%17] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_2 = arith.constant 1 : i64
-    %19 = arith.addi %17, %c1_i64_2 : i64
-    llvm.store %19, %arg3 : i64, !llvm.ptr
-    llvm.store %16, %18 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
+    %15 = "evm.iszero"(%14) : (i256) -> i256
+    %16 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %15, %16 : i256, !llvm.ptr
+    %17 = llvm.getelementptr %16[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %17, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_3 = arith.constant 1024 : i64
-    %20 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c0_i64_4 = arith.constant 0 : i64
-    %21 = arith.addi %20, %c0_i64_4 : i64
-    %c1_i64_5 = arith.constant 1 : i64
-    %22 = arith.cmpi ult, %20, %c1_i64_5 : i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %18 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c0_i64_2 = arith.constant 0 : i64
+    %19 = arith.addi %18, %c0_i64_2 : i64
+    llvm.store %19, %arg3 : i64, !llvm.ptr
+    %c1_i64_3 = arith.constant 1 : i64
+    %20 = arith.cmpi ult, %18, %c1_i64_3 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %22, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %20, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %23 = llvm.load %arg1 : !llvm.ptr -> i64
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
     %c3_i64 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %24 = arith.cmpi uge, %23, %c3_i64 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %24, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %22 = arith.cmpi uge, %21, %c3_i64 : i64
+    %c80_i8_4 = arith.constant 80 : i8
+    cf.cond_br %22, ^bb10, ^bb1(%c80_i8_4 : i8)
   ^bb10:  // pred: ^bb9
-    %25 = arith.subi %23, %c3_i64 : i64
-    llvm.store %25, %arg1 : i64, !llvm.ptr
+    %23 = arith.subi %21, %c3_i64 : i64
+    llvm.store %23, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %26 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %27 = arith.subi %26, %c1_i64_7 : i64
-    %28 = llvm.getelementptr %arg2[%27] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %27, %arg3 : i64, !llvm.ptr
-    %29 = llvm.load %28 : !llvm.ptr -> i256
+    %24 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %25 = llvm.getelementptr %24[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %26 = llvm.load %25 : !llvm.ptr -> i256
+    llvm.store %25, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_8 = arith.constant 1024 : i64
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_5 = arith.constant 1024 : i64
+    %27 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %31 = arith.addi %30, %c-1_i64 : i64
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.cmpi ult, %30, %c1_i64_9 : i64
-    %c91_i8_10 = arith.constant 91 : i8
-    cf.cond_br %32, ^bb1(%c91_i8_10 : i8), ^bb11
+    %28 = arith.addi %27, %c-1_i64 : i64
+    llvm.store %28, %arg3 : i64, !llvm.ptr
+    %c1_i64_6 = arith.constant 1 : i64
+    %29 = arith.cmpi ult, %27, %c1_i64_6 : i64
+    %c91_i8_7 = arith.constant 91 : i8
+    cf.cond_br %29, ^bb1(%c91_i8_7 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %33 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_11 = arith.constant 2 : i64
+    %30 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_8 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %34 = arith.cmpi uge, %33, %c2_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %34, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %31 = arith.cmpi uge, %30, %c2_i64_8 : i64
+    %c80_i8_9 = arith.constant 80 : i8
+    cf.cond_br %31, ^bb14, ^bb1(%c80_i8_9 : i8)
   ^bb14:  // pred: ^bb13
-    %35 = arith.subi %33, %c2_i64_11 : i64
-    llvm.store %35, %arg1 : i64, !llvm.ptr
+    %32 = arith.subi %30, %c2_i64_8 : i64
+    llvm.store %32, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_10 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %36, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %33 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_10, %c0_i64_10, %33, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_pop.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push0_pop.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 5 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c0_i256 = arith.constant 0 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c0_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -93,38 +95,37 @@ module {
     llvm.store %11, %arg1 : i64, !llvm.ptr
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_1 = arith.constant 1 : i64
-    %13 = arith.subi %12, %c1_i64_1 : i64
-    %14 = llvm.getelementptr %arg2[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %13, %arg3 : i64, !llvm.ptr
-    %15 = llvm.load %14 : !llvm.ptr -> i256
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %13 = llvm.getelementptr %12[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %14 = llvm.load %13 : !llvm.ptr -> i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb11
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %16 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %15 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %17 = arith.addi %16, %c-1_i64 : i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %18 = arith.cmpi ult, %16, %c1_i64_3 : i64
+    %16 = arith.addi %15, %c-1_i64 : i64
+    llvm.store %16, %arg3 : i64, !llvm.ptr
+    %c1_i64_2 = arith.constant 1 : i64
+    %17 = arith.cmpi ult, %15, %c1_i64_2 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %18, ^bb1(%c91_i8 : i8), ^bb7
+    cf.cond_br %17, ^bb1(%c91_i8 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %19 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c2_i64_4 = arith.constant 2 : i64
+    %18 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c2_i64_3 = arith.constant 2 : i64
     call @dora_fn_nop() : () -> ()
-    %20 = arith.cmpi uge, %19, %c2_i64_4 : i64
-    %c80_i8_5 = arith.constant 80 : i8
-    cf.cond_br %20, ^bb10, ^bb1(%c80_i8_5 : i8)
+    %19 = arith.cmpi uge, %18, %c2_i64_3 : i64
+    %c80_i8_4 = arith.constant 80 : i8
+    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_4 : i8)
   ^bb10:  // pred: ^bb9
-    %21 = arith.subi %19, %c2_i64_4 : i64
-    llvm.store %21, %arg1 : i64, !llvm.ptr
+    %20 = arith.subi %18, %c2_i64_3 : i64
+    llvm.store %20, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb7
-    %c0_i64_6 = arith.constant 0 : i64
+    %c0_i64_5 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %22 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_6, %c0_i64_6, %22, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %21 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_5, %c0_i64_5, %21, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_add.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_add.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c11_i256 = arith.constant 11 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c11_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c31_i256 = arith.constant 31 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c31_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c31_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = "evm.add"(%24, %28) : (i256, i256) -> i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = "evm.add"(%22, %25) : (i256, i256) -> i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_mul_div.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_mul_div.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 11 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 11 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13, ^bb16, ^bb17, ^bb20, ^bb21
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c1_i256 = arith.constant 1 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c1_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,147 +96,135 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c2_i256 = arith.constant 2 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = "evm.mul"(%24, %28) : (i256, i256) -> i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = "evm.mul"(%22, %25) : (i256, i256) -> i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb17
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
     %c5_i64 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c5_i64 : i64
-    %c80_i8_11 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_11 : i8)
+    %33 = arith.cmpi uge, %32, %c5_i64 : i64
+    %c80_i8_7 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_7 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c5_i64 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c5_i64 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb16
-    %c2_i256_12 = arith.constant 2 : i256
-    %39 = llvm.load %arg3 : !llvm.ptr -> i64
-    %40 = llvm.getelementptr %arg2[%39] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_13 = arith.constant 1 : i64
-    %41 = arith.addi %39, %c1_i64_13 : i64
-    llvm.store %41, %arg3 : i64, !llvm.ptr
-    llvm.store %c2_i256_12, %40 : i256, !llvm.ptr
+    %c2_i256_8 = arith.constant 2 : i256
+    %35 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c2_i256_8, %35 : i256, !llvm.ptr
+    %36 = llvm.getelementptr %35[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %36, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb21
   ^bb16:  // pred: ^bb18
-    %c1024_i64_14 = arith.constant 1024 : i64
-    %42 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_15 = arith.constant 1 : i64
-    %43 = arith.addi %42, %c1_i64_15 : i64
-    %44 = arith.cmpi ult, %c1024_i64_14, %43 : i64
-    %c92_i8_16 = arith.constant 92 : i8
-    cf.cond_br %44, ^bb1(%c92_i8_16 : i8), ^bb15
+    %c1024_i64_9 = arith.constant 1024 : i64
+    %37 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_10 = arith.constant 1 : i64
+    %38 = arith.addi %37, %c1_i64_10 : i64
+    llvm.store %38, %arg3 : i64, !llvm.ptr
+    %39 = arith.cmpi ult, %c1024_i64_9, %38 : i64
+    %c92_i8_11 = arith.constant 92 : i8
+    cf.cond_br %39, ^bb1(%c92_i8_11 : i8), ^bb15
   ^bb17:  // pred: ^bb11
-    %45 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_17 = arith.constant 3 : i64
+    %40 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_12 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %46 = arith.cmpi uge, %45, %c3_i64_17 : i64
-    %c80_i8_18 = arith.constant 80 : i8
-    cf.cond_br %46, ^bb18, ^bb1(%c80_i8_18 : i8)
+    %41 = arith.cmpi uge, %40, %c3_i64_12 : i64
+    %c80_i8_13 = arith.constant 80 : i8
+    cf.cond_br %41, ^bb18, ^bb1(%c80_i8_13 : i8)
   ^bb18:  // pred: ^bb17
-    %47 = arith.subi %45, %c3_i64_17 : i64
-    llvm.store %47, %arg1 : i64, !llvm.ptr
+    %42 = arith.subi %40, %c3_i64_12 : i64
+    llvm.store %42, %arg1 : i64, !llvm.ptr
     cf.br ^bb16
   ^bb19:  // pred: ^bb20
-    %48 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_19 = arith.constant 1 : i64
-    %49 = arith.subi %48, %c1_i64_19 : i64
-    %50 = llvm.getelementptr %arg2[%49] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %49, %arg3 : i64, !llvm.ptr
-    %51 = llvm.load %50 : !llvm.ptr -> i256
-    %52 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_20 = arith.constant 1 : i64
-    %53 = arith.subi %52, %c1_i64_20 : i64
-    %54 = llvm.getelementptr %arg2[%53] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %53, %arg3 : i64, !llvm.ptr
-    %55 = llvm.load %54 : !llvm.ptr -> i256
-    %56 = "evm.div"(%51, %55) : (i256, i256) -> i256
-    %57 = llvm.load %arg3 : !llvm.ptr -> i64
-    %58 = llvm.getelementptr %arg2[%57] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_21 = arith.constant 1 : i64
-    %59 = arith.addi %57, %c1_i64_21 : i64
-    llvm.store %59, %arg3 : i64, !llvm.ptr
-    llvm.store %56, %58 : i256, !llvm.ptr
+    %43 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %44 = llvm.getelementptr %43[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %45 = llvm.load %44 : !llvm.ptr -> i256
+    llvm.store %44, %0 : !llvm.ptr, !llvm.ptr
+    %46 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %47 = llvm.getelementptr %46[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %48 = llvm.load %47 : !llvm.ptr -> i256
+    llvm.store %47, %0 : !llvm.ptr, !llvm.ptr
+    %49 = "evm.div"(%45, %48) : (i256, i256) -> i256
+    %50 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %49, %50 : i256, !llvm.ptr
+    %51 = llvm.getelementptr %50[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %51, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb23
   ^bb20:  // pred: ^bb22
-    %c1024_i64_22 = arith.constant 1024 : i64
-    %60 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c-1_i64_23 = arith.constant -1 : i64
-    %61 = arith.addi %60, %c-1_i64_23 : i64
-    %c2_i64_24 = arith.constant 2 : i64
-    %62 = arith.cmpi ult, %60, %c2_i64_24 : i64
-    %c91_i8_25 = arith.constant 91 : i8
-    cf.cond_br %62, ^bb1(%c91_i8_25 : i8), ^bb19
+    %c1024_i64_14 = arith.constant 1024 : i64
+    %52 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c-1_i64_15 = arith.constant -1 : i64
+    %53 = arith.addi %52, %c-1_i64_15 : i64
+    llvm.store %53, %arg3 : i64, !llvm.ptr
+    %c2_i64_16 = arith.constant 2 : i64
+    %54 = arith.cmpi ult, %52, %c2_i64_16 : i64
+    %c91_i8_17 = arith.constant 91 : i8
+    cf.cond_br %54, ^bb1(%c91_i8_17 : i8), ^bb19
   ^bb21:  // pred: ^bb15
-    %63 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c5_i64_26 = arith.constant 5 : i64
+    %55 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c5_i64_18 = arith.constant 5 : i64
     call @dora_fn_nop() : () -> ()
-    %64 = arith.cmpi uge, %63, %c5_i64_26 : i64
-    %c80_i8_27 = arith.constant 80 : i8
-    cf.cond_br %64, ^bb22, ^bb1(%c80_i8_27 : i8)
+    %56 = arith.cmpi uge, %55, %c5_i64_18 : i64
+    %c80_i8_19 = arith.constant 80 : i8
+    cf.cond_br %56, ^bb22, ^bb1(%c80_i8_19 : i8)
   ^bb22:  // pred: ^bb21
-    %65 = arith.subi %63, %c5_i64_26 : i64
-    llvm.store %65, %arg1 : i64, !llvm.ptr
+    %57 = arith.subi %55, %c5_i64_18 : i64
+    llvm.store %57, %arg1 : i64, !llvm.ptr
     cf.br ^bb20
   ^bb23:  // pred: ^bb19
-    %c0_i64_28 = arith.constant 0 : i64
+    %c0_i64_20 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %66 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_28, %c0_i64_28, %66, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %58 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_20, %c0_i64_20, %58, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }

--- a/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_sub.snap
+++ b/crates/dora-compiler/src/evm/snapshots/dora_compiler__evm__tests__push_push_sub.snap
@@ -53,31 +53,33 @@ module {
   func.func private @dora_fn_tload(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func private @dora_fn_tstore(!llvm.ptr, !llvm.ptr, !llvm.ptr)
   func.func public @main(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) -> i8 attributes {llvm.emit_c_interface} {
-    cf.br ^bb5
-  ^bb1(%0: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
     %c0_i64 = arith.constant 0 : i64
-    %1 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64, %c0_i64, %1, %0) : (!llvm.ptr, i64, i64, i64, i8) -> ()
-    return %0 : i8
-  ^bb2(%2: i256):  // no predecessors
+    %0 = llvm.alloca %c0_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg2, %0 : !llvm.ptr, !llvm.ptr
+    cf.br ^bb5
+  ^bb1(%1: i8):  // 7 preds: ^bb2, ^bb4, ^bb5, ^bb8, ^bb9, ^bb12, ^bb13
+    %c0_i64_0 = arith.constant 0 : i64
+    %2 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_0, %c0_i64_0, %2, %1) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    return %1 : i8
+  ^bb2(%3: i256):  // no predecessors
     %c89_i8 = arith.constant 89 : i8
-    cf.switch %2 : i256, [
+    cf.switch %3 : i256, [
       default: ^bb1(%c89_i8 : i8)
     ]
   ^bb3:  // pred: ^bb4
     %c11_i256 = arith.constant 11 : i256
-    %3 = llvm.load %arg3 : !llvm.ptr -> i64
-    %4 = llvm.getelementptr %arg2[%3] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64 = arith.constant 1 : i64
-    %5 = arith.addi %3, %c1_i64 : i64
-    llvm.store %5, %arg3 : i64, !llvm.ptr
+    %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
     llvm.store %c11_i256, %4 : i256, !llvm.ptr
+    %5 = llvm.getelementptr %4[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %5, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb9
   ^bb4:  // pred: ^bb6
     %c1024_i64 = arith.constant 1024 : i64
     %6 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_0 = arith.constant 1 : i64
-    %7 = arith.addi %6, %c1_i64_0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %7 = arith.addi %6, %c1_i64 : i64
+    llvm.store %7, %arg3 : i64, !llvm.ptr
     %8 = arith.cmpi ult, %c1024_i64, %7 : i64
     %c92_i8 = arith.constant 92 : i8
     cf.cond_br %8, ^bb1(%c92_i8 : i8), ^bb3
@@ -94,78 +96,72 @@ module {
     cf.br ^bb4
   ^bb7:  // pred: ^bb8
     %c5_i256 = arith.constant 5 : i256
-    %12 = llvm.load %arg3 : !llvm.ptr -> i64
-    %13 = llvm.getelementptr %arg2[%12] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_1 = arith.constant 1 : i64
-    %14 = arith.addi %12, %c1_i64_1 : i64
-    llvm.store %14, %arg3 : i64, !llvm.ptr
-    llvm.store %c5_i256, %13 : i256, !llvm.ptr
+    %12 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %c5_i256, %12 : i256, !llvm.ptr
+    %13 = llvm.getelementptr %12[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %13, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb13
   ^bb8:  // pred: ^bb10
-    %c1024_i64_2 = arith.constant 1024 : i64
-    %15 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_3 = arith.constant 1 : i64
-    %16 = arith.addi %15, %c1_i64_3 : i64
-    %17 = arith.cmpi ult, %c1024_i64_2, %16 : i64
-    %c92_i8_4 = arith.constant 92 : i8
-    cf.cond_br %17, ^bb1(%c92_i8_4 : i8), ^bb7
+    %c1024_i64_1 = arith.constant 1024 : i64
+    %14 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1_i64_2 = arith.constant 1 : i64
+    %15 = arith.addi %14, %c1_i64_2 : i64
+    llvm.store %15, %arg3 : i64, !llvm.ptr
+    %16 = arith.cmpi ult, %c1024_i64_1, %15 : i64
+    %c92_i8_3 = arith.constant 92 : i8
+    cf.cond_br %16, ^bb1(%c92_i8_3 : i8), ^bb7
   ^bb9:  // pred: ^bb3
-    %18 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_5 = arith.constant 3 : i64
+    %17 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_4 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %19 = arith.cmpi uge, %18, %c3_i64_5 : i64
-    %c80_i8_6 = arith.constant 80 : i8
-    cf.cond_br %19, ^bb10, ^bb1(%c80_i8_6 : i8)
+    %18 = arith.cmpi uge, %17, %c3_i64_4 : i64
+    %c80_i8_5 = arith.constant 80 : i8
+    cf.cond_br %18, ^bb10, ^bb1(%c80_i8_5 : i8)
   ^bb10:  // pred: ^bb9
-    %20 = arith.subi %18, %c3_i64_5 : i64
-    llvm.store %20, %arg1 : i64, !llvm.ptr
+    %19 = arith.subi %17, %c3_i64_4 : i64
+    llvm.store %19, %arg1 : i64, !llvm.ptr
     cf.br ^bb8
   ^bb11:  // pred: ^bb12
-    %21 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_7 = arith.constant 1 : i64
-    %22 = arith.subi %21, %c1_i64_7 : i64
-    %23 = llvm.getelementptr %arg2[%22] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %22, %arg3 : i64, !llvm.ptr
-    %24 = llvm.load %23 : !llvm.ptr -> i256
-    %25 = llvm.load %arg3 : !llvm.ptr -> i64
-    %c1_i64_8 = arith.constant 1 : i64
-    %26 = arith.subi %25, %c1_i64_8 : i64
-    %27 = llvm.getelementptr %arg2[%26] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    llvm.store %26, %arg3 : i64, !llvm.ptr
-    %28 = llvm.load %27 : !llvm.ptr -> i256
-    %29 = "evm.sub"(%24, %28) : (i256, i256) -> i256
-    %30 = llvm.load %arg3 : !llvm.ptr -> i64
-    %31 = llvm.getelementptr %arg2[%30] : (!llvm.ptr, i64) -> !llvm.ptr, i256
-    %c1_i64_9 = arith.constant 1 : i64
-    %32 = arith.addi %30, %c1_i64_9 : i64
-    llvm.store %32, %arg3 : i64, !llvm.ptr
-    llvm.store %29, %31 : i256, !llvm.ptr
+    %20 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %21 = llvm.getelementptr %20[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %22 = llvm.load %21 : !llvm.ptr -> i256
+    llvm.store %21, %0 : !llvm.ptr, !llvm.ptr
+    %23 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %24 = llvm.getelementptr %23[-1] : (!llvm.ptr) -> !llvm.ptr, i256
+    %25 = llvm.load %24 : !llvm.ptr -> i256
+    llvm.store %24, %0 : !llvm.ptr, !llvm.ptr
+    %26 = "evm.sub"(%22, %25) : (i256, i256) -> i256
+    %27 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    llvm.store %26, %27 : i256, !llvm.ptr
+    %28 = llvm.getelementptr %27[1] : (!llvm.ptr) -> !llvm.ptr, i256
+    llvm.store %28, %0 : !llvm.ptr, !llvm.ptr
     cf.br ^bb15
   ^bb12:  // pred: ^bb14
-    %c1024_i64_10 = arith.constant 1024 : i64
-    %33 = llvm.load %arg3 : !llvm.ptr -> i64
+    %c1024_i64_6 = arith.constant 1024 : i64
+    %29 = llvm.load %arg3 : !llvm.ptr -> i64
     %c-1_i64 = arith.constant -1 : i64
-    %34 = arith.addi %33, %c-1_i64 : i64
+    %30 = arith.addi %29, %c-1_i64 : i64
+    llvm.store %30, %arg3 : i64, !llvm.ptr
     %c2_i64 = arith.constant 2 : i64
-    %35 = arith.cmpi ult, %33, %c2_i64 : i64
+    %31 = arith.cmpi ult, %29, %c2_i64 : i64
     %c91_i8 = arith.constant 91 : i8
-    cf.cond_br %35, ^bb1(%c91_i8 : i8), ^bb11
+    cf.cond_br %31, ^bb1(%c91_i8 : i8), ^bb11
   ^bb13:  // pred: ^bb7
-    %36 = llvm.load %arg1 : !llvm.ptr -> i64
-    %c3_i64_11 = arith.constant 3 : i64
+    %32 = llvm.load %arg1 : !llvm.ptr -> i64
+    %c3_i64_7 = arith.constant 3 : i64
     call @dora_fn_nop() : () -> ()
-    %37 = arith.cmpi uge, %36, %c3_i64_11 : i64
-    %c80_i8_12 = arith.constant 80 : i8
-    cf.cond_br %37, ^bb14, ^bb1(%c80_i8_12 : i8)
+    %33 = arith.cmpi uge, %32, %c3_i64_7 : i64
+    %c80_i8_8 = arith.constant 80 : i8
+    cf.cond_br %33, ^bb14, ^bb1(%c80_i8_8 : i8)
   ^bb14:  // pred: ^bb13
-    %38 = arith.subi %36, %c3_i64_11 : i64
-    llvm.store %38, %arg1 : i64, !llvm.ptr
+    %34 = arith.subi %32, %c3_i64_7 : i64
+    llvm.store %34, %arg1 : i64, !llvm.ptr
     cf.br ^bb12
   ^bb15:  // pred: ^bb11
-    %c0_i64_13 = arith.constant 0 : i64
+    %c0_i64_9 = arith.constant 0 : i64
     %c1_i8 = arith.constant 1 : i8
-    %39 = llvm.load %arg1 : !llvm.ptr -> i64
-    call @dora_fn_write_result(%arg0, %c0_i64_13, %c0_i64_13, %39, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
+    %35 = llvm.load %arg1 : !llvm.ptr -> i64
+    call @dora_fn_write_result(%arg0, %c0_i64_9, %c0_i64_9, %35, %c1_i8) : (!llvm.ptr, i64, i64, i64, i8) -> ()
     return %c1_i8 : i8
   }
 }


### PR DESCRIPTION
PR #158 results in a performance rollback of stack operations, and it is proposed to optimize stack access with this PR to improve the stack performance.