### PR TITLE
perf: use runtime result stack var instead of malloc it on the heap

### DIFF
--- a/crates/dora-compiler/src/dora/instructions/contract.rs
+++ b/crates/dora-compiler/src/dora/instructions/contract.rs
@@ -124,7 +124,7 @@ impl<'c> ConversionPass<'c> {
         };
         let error = rewriter.get_field_value(
             result_ptr,
-            offset_of!(dora_runtime::context::RuntimeResult<*mut u8>, error),
+            offset_of!(dora_runtime::context::RuntimeResult<()>, error),
             rewriter.intrinsics.i8_ty,
         )?;
         // Check the runtime halt error
@@ -132,7 +132,7 @@ impl<'c> ConversionPass<'c> {
         rewrite_ctx!(context, op, rewriter, _location, NoDefer);
         let gas = rewriter.get_field_value(
             result_ptr,
-            offset_of!(dora_runtime::context::RuntimeResult<*mut u8>, gas_used),
+            offset_of!(dora_runtime::context::RuntimeResult<()>, gas_used),
             rewriter.intrinsics.i64_ty,
         )?;
         gas_or_fail!(op, rewriter, gas, gas_counter_ptr);
@@ -215,6 +215,7 @@ impl<'c> ConversionPass<'c> {
         );
 
         let uint8 = rewriter.intrinsics.i8_ty;
+        let uint64 = rewriter.intrinsics.i64_ty;
         let uint256 = rewriter.intrinsics.i256_ty;
         let ptr_type = rewriter.ptr_ty();
 
@@ -295,12 +296,12 @@ impl<'c> ConversionPass<'c> {
         ))?;
         let result = rewriter.get_field_value(
             result_ptr,
-            offset_of!(dora_runtime::context::RuntimeResult<u8>, value),
-            uint8,
+            offset_of!(dora_runtime::context::RuntimeResult<u64>, value),
+            uint64,
         )?;
         let error = rewriter.get_field_value(
             result_ptr,
-            offset_of!(dora_runtime::context::RuntimeResult<*mut u8>, error),
+            offset_of!(dora_runtime::context::RuntimeResult<u64>, error),
             rewriter.intrinsics.i8_ty,
         )?;
         // Check the runtime halt error
@@ -308,7 +309,7 @@ impl<'c> ConversionPass<'c> {
         rewrite_ctx!(context, op, rewriter, _location, NoDefer);
         let gas = rewriter.get_field_value(
             result_ptr,
-            offset_of!(dora_runtime::context::RuntimeResult<*mut u8>, gas_used),
+            offset_of!(dora_runtime::context::RuntimeResult<u64>, gas_used),
             rewriter.intrinsics.i64_ty,
         )?;
         gas_or_fail!(op, rewriter, gas, gas_counter_ptr);

--- a/crates/dora-compiler/src/dora/instructions/host.rs
+++ b/crates/dora-compiler/src/dora/instructions/host.rs
@@ -251,7 +251,7 @@ impl<'c> ConversionPass<'c> {
         ))?;
         let error = rewriter.get_field_value(
             result_ptr,
-            offset_of!(dora_runtime::context::RuntimeResult<*mut u8>, error),
+            offset_of!(dora_runtime::context::RuntimeResult<()>, error),
             rewriter.intrinsics.i8_ty,
         )?;
         // Check the runtime sstore halt error

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_call.snap
@@ -144,7 +144,7 @@ module {
     %c0_i8_10 = arith.constant 0 : i8
     %42 = call @dora_fn_call(%arg0, %40, %41, %39, %36, %29, %37, %33, %38, %c0_i8_10) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %44 = llvm.load %43 : !llvm.ptr -> i8
+    %44 = llvm.load %43 : !llvm.ptr -> i64
     %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %46 = llvm.load %45 : !llvm.ptr -> i8
     %c0_i8_11 = arith.constant 0 : i8
@@ -163,7 +163,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %51, ^bb1(%c80_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %52 = arith.extui %44 : i8 to i256
+    %52 = arith.extui %44 : i64 to i256
     %53 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %52, %53 : i256, !llvm.ptr
     %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_callcode.snap
@@ -135,7 +135,7 @@ module {
     %c3_i8 = arith.constant 3 : i8
     %38 = call @dora_fn_call(%arg0, %36, %37, %35, %32, %25, %33, %29, %34, %c3_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %39 = llvm.getelementptr %38[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %40 = llvm.load %39 : !llvm.ptr -> i8
+    %40 = llvm.load %39 : !llvm.ptr -> i64
     %41 = llvm.getelementptr %38[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %42 = llvm.load %41 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -154,7 +154,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %47, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %48 = arith.extui %40 : i8 to i256
+    %48 = arith.extui %40 : i64 to i256
     %49 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %48, %49 : i256, !llvm.ptr
     %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_delegatecall.snap
@@ -132,7 +132,7 @@ module {
     %c2_i8 = arith.constant 2 : i8
     %35 = call @dora_fn_call(%arg0, %33, %34, %32, %29, %22, %30, %26, %31, %c2_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %36 = llvm.getelementptr %35[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %37 = llvm.load %36 : !llvm.ptr -> i64
     %38 = llvm.getelementptr %35[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %39 = llvm.load %38 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -151,7 +151,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %44, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %45 = arith.extui %37 : i8 to i256
+    %45 = arith.extui %37 : i64 to i256
     %46 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %45, %46 : i256, !llvm.ptr
     %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_0.snap
@@ -340,7 +340,7 @@ module {
     %c0_i8_10 = arith.constant 0 : i8
     %42 = call @dora_fn_call(%arg0, %40, %41, %39, %36, %29, %37, %33, %38, %c0_i8_10) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %44 = llvm.load %43 : !llvm.ptr -> i8
+    %44 = llvm.load %43 : !llvm.ptr -> i64
     %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %46 = llvm.load %45 : !llvm.ptr -> i8
     %c0_i8_11 = arith.constant 0 : i8
@@ -359,7 +359,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %51, ^bb1(%c80_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %52 = arith.extui %44 : i8 to i256
+    %52 = arith.extui %44 : i64 to i256
     %53 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %52, %53 : i256, !llvm.ptr
     %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_call_1.snap
@@ -340,7 +340,7 @@ module {
     %c0_i8_10 = arith.constant 0 : i8
     %42 = call @dora_fn_call(%arg0, %40, %41, %39, %36, %29, %37, %33, %38, %c0_i8_10) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %43 = llvm.getelementptr %42[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %44 = llvm.load %43 : !llvm.ptr -> i8
+    %44 = llvm.load %43 : !llvm.ptr -> i64
     %45 = llvm.getelementptr %42[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %46 = llvm.load %45 : !llvm.ptr -> i8
     %c0_i8_11 = arith.constant 0 : i8
@@ -359,7 +359,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %51, ^bb1(%c80_i8 : i8), ^bb12
   ^bb12:  // pred: ^bb11
-    %52 = arith.extui %44 : i8 to i256
+    %52 = arith.extui %44 : i64 to i256
     %53 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %52, %53 : i256, !llvm.ptr
     %54 = llvm.getelementptr %53[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_callcode.snap
@@ -376,7 +376,7 @@ module {
     %c3_i8 = arith.constant 3 : i8
     %38 = call @dora_fn_call(%arg0, %36, %37, %35, %32, %25, %33, %29, %34, %c3_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %39 = llvm.getelementptr %38[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %40 = llvm.load %39 : !llvm.ptr -> i8
+    %40 = llvm.load %39 : !llvm.ptr -> i64
     %41 = llvm.getelementptr %38[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %42 = llvm.load %41 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -395,7 +395,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %47, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %48 = arith.extui %40 : i8 to i256
+    %48 = arith.extui %40 : i64 to i256
     %49 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %48, %49 : i256, !llvm.ptr
     %50 = llvm.getelementptr %49[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_delegatecall.snap
@@ -132,7 +132,7 @@ module {
     %c2_i8 = arith.constant 2 : i8
     %35 = call @dora_fn_call(%arg0, %33, %34, %32, %29, %22, %30, %26, %31, %c2_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %36 = llvm.getelementptr %35[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %37 = llvm.load %36 : !llvm.ptr -> i64
     %38 = llvm.getelementptr %35[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %39 = llvm.load %38 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -151,7 +151,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %44, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %45 = arith.extui %37 : i8 to i256
+    %45 = arith.extui %37 : i64 to i256
     %46 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %45, %46 : i256, !llvm.ptr
     %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatacopy.snap
@@ -132,7 +132,7 @@ module {
     %c1_i8 = arith.constant 1 : i8
     %35 = call @dora_fn_call(%arg0, %33, %34, %32, %29, %22, %30, %26, %31, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %36 = llvm.getelementptr %35[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %37 = llvm.load %36 : !llvm.ptr -> i64
     %38 = llvm.getelementptr %35[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %39 = llvm.load %38 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -151,7 +151,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %44, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %45 = arith.extui %37 : i8 to i256
+    %45 = arith.extui %37 : i64 to i256
     %46 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %45, %46 : i256, !llvm.ptr
     %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_mstore_create_returndatasize.snap
@@ -132,7 +132,7 @@ module {
     %c1_i8 = arith.constant 1 : i8
     %35 = call @dora_fn_call(%arg0, %33, %34, %32, %29, %22, %30, %26, %31, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %36 = llvm.getelementptr %35[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %37 = llvm.load %36 : !llvm.ptr -> i64
     %38 = llvm.getelementptr %35[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %39 = llvm.load %38 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -151,7 +151,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %44, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %45 = arith.extui %37 : i8 to i256
+    %45 = arith.extui %37 : i64 to i256
     %46 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %45, %46 : i256, !llvm.ptr
     %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256

--- a/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
+++ b/crates/dora-compiler/src/dora/tests/snapshots/dora_compiler__dora__tests__operations__push_staticcall.snap
@@ -132,7 +132,7 @@ module {
     %c1_i8 = arith.constant 1 : i8
     %35 = call @dora_fn_call(%arg0, %33, %34, %32, %29, %22, %30, %26, %31, %c1_i8) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i8) -> !llvm.ptr
     %36 = llvm.getelementptr %35[16] : (!llvm.ptr) -> !llvm.ptr, i8
-    %37 = llvm.load %36 : !llvm.ptr -> i8
+    %37 = llvm.load %36 : !llvm.ptr -> i64
     %38 = llvm.getelementptr %35[0] : (!llvm.ptr) -> !llvm.ptr, i8
     %39 = llvm.load %38 : !llvm.ptr -> i8
     %c0_i8 = arith.constant 0 : i8
@@ -151,7 +151,7 @@ module {
     %c80_i8 = arith.constant 80 : i8
     cf.cond_br %44, ^bb1(%c80_i8 : i8), ^bb11
   ^bb11:  // pred: ^bb10
-    %45 = arith.extui %37 : i8 to i256
+    %45 = arith.extui %37 : i64 to i256
     %46 = llvm.load %arg4 : !llvm.ptr -> !llvm.ptr
     llvm.store %45, %46 : i256, !llvm.ptr
     %47 = llvm.getelementptr %46[1] : (!llvm.ptr) -> !llvm.ptr, i256


### PR DESCRIPTION
+ perf: use runtime result stack var instead of malloc it on the heap

Benchmark (5%)
![image](https://github.com/user-attachments/assets/ddbe99bd-6d2d-4c29-a03b-49aefaa57392)

